### PR TITLE
Telemetry generation fixes for VSCode

### DIFF
--- a/telemetry/telemetryDefinitions.json
+++ b/telemetry/telemetryDefinitions.json
@@ -1,7 +1,7 @@
 {
     "types": [
         {
-            "name": "lambdaRuntime",
+            "name": "runtime",
             "type": "string",
             "allowedValues": [
                 "dotnetcore2.1",
@@ -41,13 +41,13 @@
             "name": "lambda_create",
             "description": "called when creating lambdas remotely",
             "unit": "None",
-            "metadata": [{ "type": "lambdaRuntime" }]
+            "metadata": [{ "type": "runtime" }]
         },
         {
             "name": "lambda_remoteinvoke",
             "description": "called when invoking lambdas remotely",
             "unit": "None",
-            "metadata": [{ "type": "lambdaRuntime", "required": false }, { "type": "result" }]
+            "metadata": [{ "type": "runtime", "required": false }, { "type": "result" }]
         }
     ]
 }

--- a/telemetry/vscode/README.md
+++ b/telemetry/vscode/README.md
@@ -6,7 +6,7 @@ This package contains scripts and files to generate telemetry calls for the [AWS
 
 To generate telemetry for VSCode, install this package in your package.json, then run:
 
-`node node_modules/aws-toolkit-telemetry/lib/generateTelemetry.js --output=<path/to/file>.ts`
+`node node_modules/@aws-toolkits/telemetry/lib/generateTelemetry.js --output=<path/to/file>.ts`
 
 The script has two arguments:
 

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -73,7 +73,7 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
             values = (m.allowedValues as string[])!.map((item: string) => `'${item}'`).join(' | ')
         }
 
-        str += `type ${m.name} = ${values}\n`
+        str += `export type ${m.name} = ${values}\n`
     })
 
     metrics.forEach((metric: Metric) => {


### PR DESCRIPTION
- Export telemetry types in vscode
- revert lambdaRuntime to runtime to match existing data

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

