### PR TITLE
Fix metrics with no metadata

### DIFF
--- a/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
+++ b/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
@@ -33,7 +33,7 @@ class GeneratorTest() {
         val outputFile = Paths.get(folder.root.absolutePath, "software", "aws", "toolkits", "telemetry", "TelemetryDefinitions.kt")
         assertThat(Files.exists(outputFile)).isTrue
 
-        assertThat(outputFile.toFile().readText()).isEqualToIgnoringWhitespace(this.javaClass.getResourceAsStream("/testGeneratorOutput.kt").use {
+        assertThat(outputFile.toFile().readText()).isEqualToIgnoringWhitespace(this.javaClass.getResourceAsStream("/testGeneratorOutput").use {
             it.bufferedReader().readText()
         })
     }

--- a/telemetry/jetbrains/src/test/resources/testGeneratorInput.json
+++ b/telemetry/jetbrains/src/test/resources/testGeneratorInput.json
@@ -47,6 +47,11 @@
       "description": "called when invoking lambdas remotely",
       "unit": "None",
       "metadata": [{ "type": "lambdaRuntime", "required": false }, { "type": "inttype" }]
+    },
+    {
+      "name": "no_metadata",
+      "description": "called when invoking lambdas remotely",
+      "unit": "None"
     }
   ]
 }

--- a/telemetry/jetbrains/src/test/resources/testGeneratorOutput
+++ b/telemetry/jetbrains/src/test/resources/testGeneratorOutput
@@ -80,3 +80,16 @@ object LambdaTelemetry {
             }}
     }
 }
+
+object NoTelemetry {
+    /**
+     * called when invoking lambdas remotely
+     */
+    fun recordMetadata(project: Project?, value: Double = 1.0) {
+        TelemetryService.getInstance().record(project) {
+            datum("no_metadata") {
+                unit(Unit.NONE)
+                value(value)
+            }}
+    }
+}

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -77,7 +77,7 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
     })
 
     metrics.forEach((metric: Metric) => {
-        const metadata: MetricMetadataType[] = metric.metadata.map((item: MetricMetadata) => {
+        const metadata: MetricMetadataType[] = metric.metadata?.map((item: MetricMetadata) => {
             const foundMetadata: MetadataType | undefined = metadataTypes?.find(
                 (candidate: MetadataType) => candidate.name === item.type
             )
@@ -90,7 +90,7 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
                 ...foundMetadata,
                 required: item.required ?? true
             }
-        })
+        }) ?? []
 
         const name = metricToTypeName(metric)
         str += `interface ${name} {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- VSCode generator - fix generation with no `metadata`
- JetBrains - Update JetBrains generation tests to test for the same scenario

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

