### PR TITLE
Fix more telemetry generation and publishing issues

### DIFF
--- a/telemetry/jetbrains/gradle.properties
+++ b/telemetry/jetbrains/gradle.properties
@@ -1,2 +1,5 @@
 kotlin.code.style=official
 version = "1.0-SNAPSHOT"
+# See this issue: https://github.com/gradle/gradle/issues/11308 . This prevents
+# generating maven-metadata.xml.sha256/512 which is making Sonatype not release
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
@@ -10,6 +10,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import java.io.File
 
@@ -39,10 +40,11 @@ object TelemetryGenerator {
         val enum = TypeSpec.enumBuilder(item.name.toTypeFormat())
             .primaryConstructor(
                 FunSpec.constructorBuilder()
-                    .addParameter("name", String::class)
+                    .addParameter("value", String::class)
                     .build()
             )
-            .addFunction(FunSpec.builder("toString").addModifiers(KModifier.OVERRIDE).returns(String::class).addStatement("return name").build())
+            .addProperty(PropertySpec.builder("value", String::class).initializer("value").build())
+            .addFunction(FunSpec.builder("toString").addModifiers(KModifier.OVERRIDE).returns(String::class).addStatement("return value").build())
             .addKdoc(item.description)
 
         item.allowedValues!!.forEach { enumValue ->
@@ -58,7 +60,7 @@ object TelemetryGenerator {
                 FunSpec.builder("from")
                     .returns(ClassName("", item.name.toTypeFormat()))
                     .addParameter("type", Any::class)
-                    .addStatement("return values().first { it.name == type.toString() }")
+                    .addStatement("return values().first { it.value == type.toString() }")
                     .build()
             )
             .build()

--- a/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
+++ b/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
@@ -11,7 +11,7 @@ import org.junit.rules.TemporaryFolder
 import java.nio.file.Files
 import java.nio.file.Paths
 
-class GeneratorTest() {
+class GeneratorTest {
     @JvmField
     @Rule
     val folder = TemporaryFolder()

--- a/telemetry/jetbrains/src/test/resources/testGeneratorOutput
+++ b/telemetry/jetbrains/src/test/resources/testGeneratorOutput
@@ -16,16 +16,16 @@ import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
  * The lambda runtime
  */
 enum class LambdaRuntime(
-    name: String
+    val value: String
 ) {
     DOTNETCORE21("dotnetcore2.1"),
 
     NODEJS12X("nodejs12.x");
 
-    override fun toString(): String = name
+    override fun toString(): String = value
 
     companion object {
-        fun from(type: Any): LambdaRuntime = values().first { it.name == type.toString() }
+        fun from(type: Any): LambdaRuntime = values().first { it.value == type.toString() }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Add `systemProp.org.gradle.internal.publish.checksums.insecure`, see this issue: https://github.com/gradle/gradle/issues/11308 
- `name` -> `value` in generated enums + make it a val. `name` is already part of `enum` oops

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

