### PR TITLE
Fix JS metrics generation to not include empty metrics

### DIFF
--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -111,7 +111,7 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
         str += `export function record${name}(args${metadata.every(item => !item.required) ? '?' : ''}: ${name}) {
     let metadata: any[] = []
     ${metadata.map(
-        (item: MetadataType) => `if(args.${item.name}) {metadata.push({Key: '${item.name}', Value: args.${item.name}?.toString() ?? ''})}`
+        (item: MetadataType) => `if(args.${item.name}) {metadata.push({Key: '${item.name}', Value: args.${item.name}?.toString()})}`
     ).join('\n')}
     ext.telemetry.record({
             createTime: args?.createTime ?? new Date(),

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -111,7 +111,7 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
         str += `export function record${name}(args${metadata.every(item => !item.required) ? '?' : ''}: ${name}) {
     let metadata: any[] = []
     ${metadata.map(
-        (item: MetadataType) => `if(args.${item.name}) {metadata.push({Key: '${item.name}', Value: args.${item.name}?.toString()})}`
+        (item: MetadataType) => `if(args.${item.name}) {metadata.push({Key: '${item.name}', Value: args.${item.name}.toString()})}`
     ).join('\n')}
     ext.telemetry.record({
             createTime: args?.createTime ?? new Date(),

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -109,15 +109,17 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
       */\n`
 
         str += `export function record${name}(args${metadata.every(item => !item.required) ? '?' : ''}: ${name}) {
+    let metadata: any[] = []
+    ${metadata.map(
+        (item: MetadataType) => `if(args.${item.name}) {metadata.push({Key: '${item.name}', Value: args.${item.name}?.toString() ?? ''})}`
+    ).join('\n')}
     ext.telemetry.record({
             createTime: args?.createTime ?? new Date(),
             data: [{
                 MetricName: '${metric.name}',
                 Value: args?.value ?? 1,
                 Unit: '${metric.unit ?? 'None'}',
-                Metadata: [${metadata.map(
-                    (item: MetadataType) => `{Key: '${item.name}', Value: args.${item.name}?.toString() ?? ''}`
-                )}]
+                Metadata: metadata
             }]
         })
 }`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Before
```

export function recordCloudwatchlogsOpenGroup(args: CloudwatchlogsOpenGroup) {
    ext.telemetry.record({
        createTime: args?.createTime ?? new Date(),
        data: [
            {
                MetricName: 'cloudwatchlogs_openGroup',
                Value: args?.value ?? 1,
                Unit: 'None',
                Metadata: [
                    { Key: 'result', Value: args.result?.toString() ?? '' },
                    { Key: 'serviceType', Value: args.serviceType?.toString() ?? '' },
                ],
            },
        ],
    })
}
```
After
```
export function recordCloudwatchlogsOpenGroup(args: CloudwatchlogsOpenGroup) {
    let metadata: any[] = []
    if (args.result) {
        metadata.push({ Key: 'result', Value: args.result.toString() })
    }
    if (args.serviceType) {
        metadata.push({ Key: 'serviceType', Value: args.serviceType.toString() })
    }
    ext.telemetry.record({
        createTime: args?.createTime ?? new Date(),
        data: [
            {
                MetricName: 'cloudwatchlogs_openGroup',
                Value: args?.value ?? 1,
                Unit: 'None',
                Metadata: metadata
            }
        ]
    })
}
```
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

