### PR TITLE
Make runtime optional for invokeRemote

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -240,7 +240,7 @@
         {
             "name": "lambda_invokeRemote",
             "description": "Called when invoking lambdas remotely",
-            "metadata": [{ "type": "runtime" }, { "type": "result" }]
+            "metadata": [{ "type": "runtime", "required": false }, { "type": "result" }]
         },
         {
             "name": "lambda_invokeLocal",


### PR DESCRIPTION

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

