### PR TITLE
Add dotnet core 3.1 to runtimes list

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -45,6 +45,7 @@
             "name": "runtime",
             "type": "string",
             "allowedValues": [
+                "dotnetcore3.1",
                 "dotnetcore2.1",
                 "nodejs12.x",
                 "nodejs10.x",


### PR DESCRIPTION

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

