### PR TITLE
Fix typescript telemetry generation, missing trailing comma

### DIFF
--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -119,7 +119,7 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
                 MetricName: '${metric.name}',
                 Value: args?.value ?? 1,
                 Unit: '${metric.unit ?? 'None'}',
-                Passive: ${metric.passive}
+                Passive: ${metric.passive},
                 Metadata: metadata
             }]
         })


### PR DESCRIPTION

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

