### PR TITLE
SQS telemetry addendums

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -552,12 +552,7 @@
         {
             "name": "sqs_createQueue",
             "description": "Create a new SQS queue",
-            "metadata": [{ "type": "result" }, { "type": "sqsQueueType" }]
-        },
-        {
-            "name": "sqs_deleteQueue",
-            "description": "Delete a SQS queue",
-            "metadata": [{ "type": "result" }, { "type": "sqsQueueType" }]
+            "metadata": [{ "type": "result" }, { "type": "sqsQueueType", "required": false }]
         },
         {
             "name": "sqs_sendMessage",


### PR DESCRIPTION
- Remove deleteQueue which overlaps the already existing delete resource
- Make sqs_createQueue sqsQueueType optional because we won't know in a cancel

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

