### PR TITLE
Cleanup generator a bit, add overload for MetricMetadata functions

### DIFF
--- a/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
+++ b/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
@@ -55,6 +55,6 @@ class GeneratorTest {
             it.bufferedReader().readText()
         }
 
-        assertThat(outputFile).hasContent(expected)
+        assertThat(outputFile.toFile().readText()).isEqualTo(expected)
     }
 }

--- a/telemetry/jetbrains/src/test/resources/testGeneratorOutput
+++ b/telemetry/jetbrains/src/test/resources/testGeneratorOutput
@@ -14,6 +14,7 @@ import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import software.amazon.awssdk.services.toolkittelemetry.model.Unit
+import software.aws.toolkits.jetbrains.services.telemetry.MetricEventMetadata
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 
 /**
@@ -39,8 +40,8 @@ object LambdaTelemetry {
      */
     fun create(
         project: Project? = null,
-        lambdaruntime: LambdaRuntime,
-        arbitrarystring: String,
+        lambdaRuntime: LambdaRuntime,
+        arbitraryString: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -50,8 +51,30 @@ object LambdaTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                metadata("lambdaruntime", lambdaruntime.toString())
-                metadata("arbitrarystring", arbitrarystring.toString())
+                metadata("lambdaruntime", lambdaRuntime.toString())
+                metadata("arbitrarystring", arbitraryString.toString())
+            }
+        }
+    }
+
+    /**
+     * called when creating lambdas remotely
+     */
+    fun create(
+        metadata: MetricEventMetadata,
+        lambdaRuntime: LambdaRuntime,
+        arbitraryString: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_create") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("lambdaruntime", lambdaRuntime.toString())
+                metadata("arbitrarystring", arbitraryString.toString())
             }
         }
     }
@@ -79,11 +102,33 @@ object LambdaTelemetry {
     }
 
     /**
+     * called when deleting lambdas remotely
+     */
+    fun delete(
+        metadata: MetricEventMetadata,
+        duration: Double,
+        booltype: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_delete") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("duration", duration.toString())
+                metadata("booltype", booltype.toString())
+            }
+        }
+    }
+
+    /**
      * called when invoking lambdas remotely
      */
     fun remoteinvoke(
         project: Project? = null,
-        lambdaruntime: LambdaRuntime? = null,
+        lambdaRuntime: LambdaRuntime? = null,
         inttype: Int,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
@@ -94,8 +139,32 @@ object LambdaTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                if(lambdaruntime != null) {
-                    metadata("lambdaruntime", lambdaruntime.toString())
+                if(lambdaRuntime != null) {
+                    metadata("lambdaruntime", lambdaRuntime.toString())
+                }
+                metadata("inttype", inttype.toString())
+            }
+        }
+    }
+
+    /**
+     * called when invoking lambdas remotely
+     */
+    fun remoteinvoke(
+        metadata: MetricEventMetadata,
+        lambdaRuntime: LambdaRuntime? = null,
+        inttype: Int,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_remoteinvoke") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                if(lambdaRuntime != null) {
+                    metadata("lambdaruntime", lambdaRuntime.toString())
                 }
                 metadata("inttype", inttype.toString())
             }
@@ -121,6 +190,24 @@ object NoTelemetry {
             }
         }
     }
+
+    /**
+     * called when invoking lambdas remotely
+     */
+    fun metadata(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("no_metadata") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
 }
 
 object PassiveTelemetry {
@@ -133,6 +220,24 @@ object PassiveTelemetry {
         createTime: Instant = Instant.now()
     ) {
         TelemetryService.getInstance().record(project) {
+            datum("passive_passive") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(true)
+            }
+        }
+    }
+
+    /**
+     * a passive metric
+     */
+    fun passive(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
             datum("passive_passive") {
                 createTime(createTime)
                 unit(Unit.NONE)

--- a/telemetry/jetbrains/src/test/resources/testResultOutput
+++ b/telemetry/jetbrains/src/test/resources/testResultOutput
@@ -13,6 +13,7 @@ import kotlin.Double
 import kotlin.String
 import kotlin.Suppress
 import software.amazon.awssdk.services.toolkittelemetry.model.Unit
+import software.aws.toolkits.jetbrains.services.telemetry.MetricEventMetadata
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 
 /**
@@ -65,11 +66,43 @@ object MetadataTelemetry {
      * It has a result
      */
     fun hasResult(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("metadata_hasResult") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
+    /**
+     * It has a result
+     */
+    fun hasResult(
         project: Project? = null,
         success: Boolean,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
         hasResult(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
+    /**
+     * It has a result
+     */
+    fun hasResult(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        hasResult(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 }


### PR DESCRIPTION
* Clean up null safety when reading defintions files
* Use camelcase for arguments
* Add overload that thats a MetricMetadata

```diff
diff --git jetbrains-core/build/generated-src/software/aws/toolkits/telemetry/TelemetryDefinitions.kt.old jetbrains-core/build/generated-src/software/aws/toolkits/telemetry/TelemetryDefinitions.kt
index f871e09a8..6f1fae525 100644
--- jetbrains-core/build/generated-src/software/aws/toolkits/telemetry/TelemetryDefinitions.kt.old
+++ jetbrains-core/build/generated-src/software/aws/toolkits/telemetry/TelemetryDefinitions.kt
@@ -237,6 +237,26 @@ object ApigatewayTelemetry {
         }
     }
 
+    /**
+     * Copying an API Gateway remote URL
+     */
+    fun copyUrl(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("apigateway_copyUrl") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Copying an API Gateway remote URL
      */
@@ -249,13 +269,25 @@ object ApigatewayTelemetry {
         copyUrl(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Copying an API Gateway remote URL
+     */
+    fun copyUrl(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        copyUrl(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Invoking one simulated API Gateway call using the SAM cli
      */
     fun invokeLocal(
         project: Project? = null,
         runtime: Runtime? = null,
-        httpmethod: String? = null,
+        httpMethod: String? = null,
         result: Result,
         debug: Boolean,
         value: Double = 1.0,
@@ -270,8 +302,38 @@ object ApigatewayTelemetry {
                 if(runtime != null) {
                     metadata("runtime", runtime.toString())
                 }
-                if(httpmethod != null) {
-                    metadata("httpmethod", httpmethod.toString())
+                if(httpMethod != null) {
+                    metadata("httpmethod", httpMethod.toString())
+                }
+                metadata("result", result.toString())
+                metadata("debug", debug.toString())
+            }
+        }
+    }
+
+    /**
+     * Invoking one simulated API Gateway call using the SAM cli
+     */
+    fun invokeLocal(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        httpMethod: String? = null,
+        result: Result,
+        debug: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("apigateway_invokeLocal") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                if(runtime != null) {
+                    metadata("runtime", runtime.toString())
+                }
+                if(httpMethod != null) {
+                    metadata("httpmethod", httpMethod.toString())
                 }
                 metadata("result", result.toString())
                 metadata("debug", debug.toString())
@@ -285,13 +347,29 @@ object ApigatewayTelemetry {
     fun invokeLocal(
         project: Project? = null,
         runtime: Runtime? = null,
-        httpmethod: String? = null,
+        httpMethod: String? = null,
         success: Boolean,
         debug: Boolean,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        invokeLocal(project, runtime, httpmethod, if(success) Result.Succeeded else Result.Failed,
+        invokeLocal(project, runtime, httpMethod, if(success) Result.Succeeded else Result.Failed,
+                debug, value, createTime)
+    }
+
+    /**
+     * Invoking one simulated API Gateway call using the SAM cli
+     */
+    fun invokeLocal(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        httpMethod: String? = null,
+        success: Boolean,
+        debug: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        invokeLocal(metadata, runtime, httpMethod, if(success) Result.Succeeded else Result.Failed,
                 debug, value, createTime)
     }
 
@@ -301,7 +379,7 @@ object ApigatewayTelemetry {
     fun invokeRemote(
         project: Project? = null,
         result: Result,
-        httpmethod: String? = null,
+        httpMethod: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -312,8 +390,32 @@ object ApigatewayTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                if(httpmethod != null) {
-                    metadata("httpmethod", httpmethod.toString())
+                if(httpMethod != null) {
+                    metadata("httpmethod", httpMethod.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Calling a remote API Gateway
+     */
+    fun invokeRemote(
+        metadata: MetricEventMetadata,
+        result: Result,
+        httpMethod: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("apigateway_invokeRemote") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(httpMethod != null) {
+                    metadata("httpmethod", httpMethod.toString())
                 }
             }
         }
@@ -325,11 +427,25 @@ object ApigatewayTelemetry {
     fun invokeRemote(
         project: Project? = null,
         success: Boolean,
-        httpmethod: String? = null,
+        httpMethod: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        invokeRemote(project, if(success) Result.Succeeded else Result.Failed, httpmethod, value,
+        invokeRemote(project, if(success) Result.Succeeded else Result.Failed, httpMethod, value,
+                createTime)
+    }
+
+    /**
+     * Calling a remote API Gateway
+     */
+    fun invokeRemote(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        httpMethod: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        invokeRemote(metadata, if(success) Result.Succeeded else Result.Failed, httpMethod, value,
                 createTime)
     }
 
@@ -354,6 +470,27 @@ object ApigatewayTelemetry {
         }
     }
 
+    /**
+     * Called when starting a local API Gateway server simulator with SAM. Only called when starting
+     * it for long running testing, not for single invokes
+     */
+    fun startLocalServer(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("apigateway_startLocalServer") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when starting a local API Gateway server simulator with SAM. Only called when starting
      * it for long running testing, not for single invokes
@@ -367,6 +504,20 @@ object ApigatewayTelemetry {
         startLocalServer(project, if(success) Result.Succeeded else Result.Failed, value,
                 createTime)
     }
+
+    /**
+     * Called when starting a local API Gateway server simulator with SAM. Only called when starting
+     * it for long running testing, not for single invokes
+     */
+    fun startLocalServer(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        startLocalServer(metadata, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
 }
 
 object AwsTelemetry {
@@ -375,7 +526,7 @@ object AwsTelemetry {
      */
     fun copyArn(
         project: Project? = null,
-        servicetype: ServiceType,
+        serviceType: ServiceType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -385,7 +536,27 @@ object AwsTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                metadata("servicetype", servicetype.toString())
+                metadata("servicetype", serviceType.toString())
+            }
+        }
+    }
+
+    /**
+     * Copy the ARN of an AWS resource
+     */
+    fun copyArn(
+        metadata: MetricEventMetadata,
+        serviceType: ServiceType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_copyArn") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("servicetype", serviceType.toString())
             }
         }
     }
@@ -408,12 +579,30 @@ object AwsTelemetry {
         }
     }
 
+    /**
+     * Create a new credentials file
+     */
+    fun createCredentials(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_createCredentials") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Delete an AWS resource
      */
     fun deleteResource(
         project: Project? = null,
-        servicetype: ServiceType,
+        serviceType: ServiceType,
         result: Result,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
@@ -424,7 +613,29 @@ object AwsTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                metadata("servicetype", servicetype.toString())
+                metadata("servicetype", serviceType.toString())
+                metadata("result", result.toString())
+            }
+        }
+    }
+
+    /**
+     * Delete an AWS resource
+     */
+    fun deleteResource(
+        metadata: MetricEventMetadata,
+        serviceType: ServiceType,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_deleteResource") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("servicetype", serviceType.toString())
                 metadata("result", result.toString())
             }
         }
@@ -435,15 +646,29 @@ object AwsTelemetry {
      */
     fun deleteResource(
         project: Project? = null,
-        servicetype: ServiceType,
+        serviceType: ServiceType,
         success: Boolean,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        deleteResource(project, servicetype, if(success) Result.Succeeded else Result.Failed, value,
+        deleteResource(project, serviceType, if(success) Result.Succeeded else Result.Failed, value,
                 createTime)
     }
 
+    /**
+     * Delete an AWS resource
+     */
+    fun deleteResource(
+        metadata: MetricEventMetadata,
+        serviceType: ServiceType,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        deleteResource(metadata, serviceType, if(success) Result.Succeeded else Result.Failed,
+                value, createTime)
+    }
+
     /**
      * Open docs for the extension
      */
@@ -462,6 +687,24 @@ object AwsTelemetry {
         }
     }
 
+    /**
+     * Open docs for the extension
+     */
+    fun help(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_help") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Open the quickstart guide
      */
@@ -480,13 +723,31 @@ object AwsTelemetry {
         }
     }
 
+    /**
+     * Open the quickstart guide
+     */
+    fun helpQuickstart(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_helpQuickstart") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Inject selected AWS credentials into a third-party run (e.g. RunConfiguration)
      */
     fun injectCredentials(
         project: Project? = null,
         result: Result,
-        runtimestring: String? = null,
+        runtimeString: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -497,8 +758,32 @@ object AwsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                if(runtimestring != null) {
-                    metadata("runtimestring", runtimestring.toString())
+                if(runtimeString != null) {
+                    metadata("runtimestring", runtimeString.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Inject selected AWS credentials into a third-party run (e.g. RunConfiguration)
+     */
+    fun injectCredentials(
+        metadata: MetricEventMetadata,
+        result: Result,
+        runtimeString: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_injectCredentials") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(runtimeString != null) {
+                    metadata("runtimestring", runtimeString.toString())
                 }
             }
         }
@@ -510,11 +795,25 @@ object AwsTelemetry {
     fun injectCredentials(
         project: Project? = null,
         success: Boolean,
-        runtimestring: String? = null,
+        runtimeString: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        injectCredentials(project, if(success) Result.Succeeded else Result.Failed, runtimestring,
+        injectCredentials(project, if(success) Result.Succeeded else Result.Failed, runtimeString,
+                value, createTime)
+    }
+
+    /**
+     * Inject selected AWS credentials into a third-party run (e.g. RunConfiguration)
+     */
+    fun injectCredentials(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        runtimeString: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        injectCredentials(metadata, if(success) Result.Succeeded else Result.Failed, runtimeString,
                 value, createTime)
     }
 
@@ -538,6 +837,26 @@ object AwsTelemetry {
         }
     }
 
+    /**
+     * Open the credentials file
+     */
+    fun openCredentials(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_openCredentials") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Open the credentials file
      */
@@ -550,6 +869,19 @@ object AwsTelemetry {
         openCredentials(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Open the credentials file
+     */
+    fun openCredentials(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        openCredentials(metadata, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Refresh the AWS explorer window
      */
@@ -568,6 +900,24 @@ object AwsTelemetry {
         }
     }
 
+    /**
+     * Refresh the AWS explorer window
+     */
+    fun refreshExplorer(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_refreshExplorer") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Report an issue with the plugin
      */
@@ -586,12 +936,30 @@ object AwsTelemetry {
         }
     }
 
+    /**
+     * Report an issue with the plugin
+     */
+    fun reportPluginIssue(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_reportPluginIssue") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Select a credentials profile
      */
     fun setCredentials(
         project: Project? = null,
-        credentialtype: CredentialType? = null,
+        credentialType: CredentialType? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -601,8 +969,30 @@ object AwsTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                if(credentialtype != null) {
-                    metadata("credentialtype", credentialtype.toString())
+                if(credentialType != null) {
+                    metadata("credentialtype", credentialType.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Select a credentials profile
+     */
+    fun setCredentials(
+        metadata: MetricEventMetadata,
+        credentialType: CredentialType? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_setCredentials") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                if(credentialType != null) {
+                    metadata("credentialtype", credentialType.toString())
                 }
             }
         }
@@ -613,7 +1003,7 @@ object AwsTelemetry {
      */
     fun setPartition(
         project: Project? = null,
-        partitionid: String,
+        partitionId: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -623,7 +1013,27 @@ object AwsTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                metadata("partitionid", partitionid.toString())
+                metadata("partitionid", partitionId.toString())
+            }
+        }
+    }
+
+    /**
+     * A partition change occurred
+     */
+    fun setPartition(
+        metadata: MetricEventMetadata,
+        partitionId: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_setPartition") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("partitionid", partitionId.toString())
             }
         }
     }
@@ -633,7 +1043,7 @@ object AwsTelemetry {
      */
     fun setRegion(
         project: Project? = null,
-        regionid: String,
+        regionId: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -643,7 +1053,27 @@ object AwsTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                metadata("regionid", regionid.toString())
+                metadata("regionid", regionId.toString())
+            }
+        }
+    }
+
+    /**
+     * A region change occurred
+     */
+    fun setRegion(
+        metadata: MetricEventMetadata,
+        regionId: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_setRegion") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("regionid", regionId.toString())
             }
         }
     }
@@ -666,6 +1096,24 @@ object AwsTelemetry {
         }
     }
 
+    /**
+     * Open the repo for the extension
+     */
+    fun showExtensionSource(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_showExtensionSource") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Validate credentials when selecting new credentials
      */
@@ -686,6 +1134,26 @@ object AwsTelemetry {
         }
     }
 
+    /**
+     * Validate credentials when selecting new credentials
+     */
+    fun validateCredentials(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("aws_validateCredentials") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(true)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Validate credentials when selecting new credentials
      */
@@ -698,6 +1166,19 @@ object AwsTelemetry {
         validateCredentials(project, if(success) Result.Succeeded else Result.Failed, value,
                 createTime)
     }
+
+    /**
+     * Validate credentials when selecting new credentials
+     */
+    fun validateCredentials(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        validateCredentials(metadata, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
 }
 
 object BeanstalkTelemetry {
@@ -707,12 +1188,12 @@ object BeanstalkTelemetry {
     fun deploy(
         project: Project? = null,
         result: Result,
-        regionid: String,
-        initialdeploy: Boolean,
+        regionId: String,
+        initialDeploy: Boolean,
         name: String? = null,
         framework: String? = null,
-        xrayenabled: Boolean? = null,
-        enhancedhealthenabled: Boolean? = null,
+        xrayEnabled: Boolean? = null,
+        enhancedHealthEnabled: Boolean? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -723,19 +1204,59 @@ object BeanstalkTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("regionid", regionid.toString())
-                metadata("initialdeploy", initialdeploy.toString())
+                metadata("regionid", regionId.toString())
+                metadata("initialdeploy", initialDeploy.toString())
                 if(name != null) {
                     metadata("name", name.toString())
                 }
                 if(framework != null) {
                     metadata("framework", framework.toString())
                 }
-                if(xrayenabled != null) {
-                    metadata("xrayenabled", xrayenabled.toString())
+                if(xrayEnabled != null) {
+                    metadata("xrayenabled", xrayEnabled.toString())
                 }
-                if(enhancedhealthenabled != null) {
-                    metadata("enhancedhealthenabled", enhancedhealthenabled.toString())
+                if(enhancedHealthEnabled != null) {
+                    metadata("enhancedhealthenabled", enhancedHealthEnabled.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Called when deploying an application to Elastic Beanstalk
+     */
+    fun deploy(
+        metadata: MetricEventMetadata,
+        result: Result,
+        regionId: String,
+        initialDeploy: Boolean,
+        name: String? = null,
+        framework: String? = null,
+        xrayEnabled: Boolean? = null,
+        enhancedHealthEnabled: Boolean? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("beanstalk_deploy") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("regionid", regionId.toString())
+                metadata("initialdeploy", initialDeploy.toString())
+                if(name != null) {
+                    metadata("name", name.toString())
+                }
+                if(framework != null) {
+                    metadata("framework", framework.toString())
+                }
+                if(xrayEnabled != null) {
+                    metadata("xrayenabled", xrayEnabled.toString())
+                }
+                if(enhancedHealthEnabled != null) {
+                    metadata("enhancedhealthenabled", enhancedHealthEnabled.toString())
                 }
             }
         }
@@ -747,17 +1268,36 @@ object BeanstalkTelemetry {
     fun deploy(
         project: Project? = null,
         success: Boolean,
-        regionid: String,
-        initialdeploy: Boolean,
+        regionId: String,
+        initialDeploy: Boolean,
         name: String? = null,
         framework: String? = null,
-        xrayenabled: Boolean? = null,
-        enhancedhealthenabled: Boolean? = null,
+        xrayEnabled: Boolean? = null,
+        enhancedHealthEnabled: Boolean? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        deploy(project, if(success) Result.Succeeded else Result.Failed, regionid, initialdeploy,
-                name, framework, xrayenabled, enhancedhealthenabled, value, createTime)
+        deploy(project, if(success) Result.Succeeded else Result.Failed, regionId, initialDeploy,
+                name, framework, xrayEnabled, enhancedHealthEnabled, value, createTime)
+    }
+
+    /**
+     * Called when deploying an application to Elastic Beanstalk
+     */
+    fun deploy(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        regionId: String,
+        initialDeploy: Boolean,
+        name: String? = null,
+        framework: String? = null,
+        xrayEnabled: Boolean? = null,
+        enhancedHealthEnabled: Boolean? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        deploy(metadata, if(success) Result.Succeeded else Result.Failed, regionId, initialDeploy,
+                name, framework, xrayEnabled, enhancedHealthEnabled, value, createTime)
     }
 }
 
@@ -768,8 +1308,8 @@ object ClouddebugTelemetry {
     fun attachDebugger(
         project: Project? = null,
         result: Result,
-        workflowtoken: String,
-        clouddebugplatform: CloudDebugPlatform,
+        workflowToken: String,
+        cloudDebugPlatform: CloudDebugPlatform,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -780,8 +1320,32 @@ object ClouddebugTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("workflowtoken", workflowtoken.toString())
-                metadata("clouddebugplatform", clouddebugplatform.toString())
+                metadata("workflowtoken", workflowToken.toString())
+                metadata("clouddebugplatform", cloudDebugPlatform.toString())
+            }
+        }
+    }
+
+    /**
+     * Confirm the resource that will be debugged is not a production resource
+     */
+    fun attachDebugger(
+        metadata: MetricEventMetadata,
+        result: Result,
+        workflowToken: String,
+        cloudDebugPlatform: CloudDebugPlatform,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_attachDebugger") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("workflowtoken", workflowToken.toString())
+                metadata("clouddebugplatform", cloudDebugPlatform.toString())
             }
         }
     }
@@ -792,13 +1356,28 @@ object ClouddebugTelemetry {
     fun attachDebugger(
         project: Project? = null,
         success: Boolean,
-        workflowtoken: String,
-        clouddebugplatform: CloudDebugPlatform,
+        workflowToken: String,
+        cloudDebugPlatform: CloudDebugPlatform,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        attachDebugger(project, if(success) Result.Succeeded else Result.Failed, workflowtoken,
-                clouddebugplatform, value, createTime)
+        attachDebugger(project, if(success) Result.Succeeded else Result.Failed, workflowToken,
+                cloudDebugPlatform, value, createTime)
+    }
+
+    /**
+     * Confirm the resource that will be debugged is not a production resource
+     */
+    fun attachDebugger(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        workflowToken: String,
+        cloudDebugPlatform: CloudDebugPlatform,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        attachDebugger(metadata, if(success) Result.Succeeded else Result.Failed, workflowToken,
+                cloudDebugPlatform, value, createTime)
     }
 
     /**
@@ -821,6 +1400,26 @@ object ClouddebugTelemetry {
         }
     }
 
+    /**
+     * Confirm the resource that will be debugged is not a production resource
+     */
+    fun confirmNotProduction(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_confirmNotProduction") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Confirm the resource that will be debugged is not a production resource
      */
@@ -834,13 +1433,26 @@ object ClouddebugTelemetry {
                 createTime)
     }
 
+    /**
+     * Confirm the resource that will be debugged is not a production resource
+     */
+    fun confirmNotProduction(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        confirmNotProduction(metadata, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Copy a directory to a remote machine for debugging
      */
     fun copy(
         project: Project? = null,
         result: Result,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -851,7 +1463,29 @@ object ClouddebugTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("workflowtoken", workflowtoken.toString())
+                metadata("workflowtoken", workflowToken.toString())
+            }
+        }
+    }
+
+    /**
+     * Copy a directory to a remote machine for debugging
+     */
+    fun copy(
+        metadata: MetricEventMetadata,
+        result: Result,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_copy") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("workflowtoken", workflowToken.toString())
             }
         }
     }
@@ -862,11 +1496,25 @@ object ClouddebugTelemetry {
     fun copy(
         project: Project? = null,
         success: Boolean,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        copy(project, if(success) Result.Succeeded else Result.Failed, workflowtoken, value,
+        copy(project, if(success) Result.Succeeded else Result.Failed, workflowToken, value,
+                createTime)
+    }
+
+    /**
+     * Copy a directory to a remote machine for debugging
+     */
+    fun copy(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        copy(metadata, if(success) Result.Succeeded else Result.Failed, workflowToken, value,
                 createTime)
     }
 
@@ -894,6 +1542,30 @@ object ClouddebugTelemetry {
         }
     }
 
+    /**
+     * Revert a resource that was set up for debugging to its original state
+     */
+    fun deinstrument(
+        metadata: MetricEventMetadata,
+        result: Result,
+        version: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_deinstrument") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(version != null) {
+                    metadata("version", version.toString())
+                }
+            }
+        }
+    }
+
     /**
      * Revert a resource that was set up for debugging to its original state
      */
@@ -908,6 +1580,20 @@ object ClouddebugTelemetry {
                 createTime)
     }
 
+    /**
+     * Revert a resource that was set up for debugging to its original state
+     */
+    fun deinstrument(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        version: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        deinstrument(metadata, if(success) Result.Succeeded else Result.Failed, version, value,
+                createTime)
+    }
+
     /**
      * Install the cloud debug CLI
      */
@@ -915,7 +1601,7 @@ object ClouddebugTelemetry {
         project: Project? = null,
         result: Result,
         version: String? = null,
-        oldversion: String? = null,
+        oldVersion: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -929,8 +1615,36 @@ object ClouddebugTelemetry {
                 if(version != null) {
                     metadata("version", version.toString())
                 }
-                if(oldversion != null) {
-                    metadata("oldversion", oldversion.toString())
+                if(oldVersion != null) {
+                    metadata("oldversion", oldVersion.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Install the cloud debug CLI
+     */
+    fun install(
+        metadata: MetricEventMetadata,
+        result: Result,
+        version: String? = null,
+        oldVersion: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_install") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(version != null) {
+                    metadata("version", version.toString())
+                }
+                if(oldVersion != null) {
+                    metadata("oldversion", oldVersion.toString())
                 }
             }
         }
@@ -943,11 +1657,26 @@ object ClouddebugTelemetry {
         project: Project? = null,
         success: Boolean,
         version: String? = null,
-        oldversion: String? = null,
+        oldVersion: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        install(project, if(success) Result.Succeeded else Result.Failed, version, oldversion,
+        install(project, if(success) Result.Succeeded else Result.Failed, version, oldVersion,
+                value, createTime)
+    }
+
+    /**
+     * Install the cloud debug CLI
+     */
+    fun install(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        version: String? = null,
+        oldVersion: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        install(metadata, if(success) Result.Succeeded else Result.Failed, version, oldVersion,
                 value, createTime)
     }
 
@@ -958,7 +1687,7 @@ object ClouddebugTelemetry {
         project: Project? = null,
         result: Result,
         version: String? = null,
-        workflowtoken: String? = null,
+        workflowToken: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -972,8 +1701,36 @@ object ClouddebugTelemetry {
                 if(version != null) {
                     metadata("version", version.toString())
                 }
-                if(workflowtoken != null) {
-                    metadata("workflowtoken", workflowtoken.toString())
+                if(workflowToken != null) {
+                    metadata("workflowtoken", workflowToken.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Set up a service for debugging
+     */
+    fun instrument(
+        metadata: MetricEventMetadata,
+        result: Result,
+        version: String? = null,
+        workflowToken: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_instrument") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(version != null) {
+                    metadata("version", version.toString())
+                }
+                if(workflowToken != null) {
+                    metadata("workflowtoken", workflowToken.toString())
                 }
             }
         }
@@ -986,21 +1743,36 @@ object ClouddebugTelemetry {
         project: Project? = null,
         success: Boolean,
         version: String? = null,
-        workflowtoken: String? = null,
+        workflowToken: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        instrument(project, if(success) Result.Succeeded else Result.Failed, version, workflowtoken,
+        instrument(project, if(success) Result.Succeeded else Result.Failed, version, workflowToken,
                 value, createTime)
     }
 
+    /**
+     * Set up a service for debugging
+     */
+    fun instrument(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        version: String? = null,
+        workflowToken: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        instrument(metadata, if(success) Result.Succeeded else Result.Failed, version,
+                workflowToken, value, createTime)
+    }
+
     /**
      * Forward a local port to a remote machine for debugging
      */
     fun portForward(
         project: Project? = null,
         result: Result,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -1011,7 +1783,29 @@ object ClouddebugTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("workflowtoken", workflowtoken.toString())
+                metadata("workflowtoken", workflowToken.toString())
+            }
+        }
+    }
+
+    /**
+     * Forward a local port to a remote machine for debugging
+     */
+    fun portForward(
+        metadata: MetricEventMetadata,
+        result: Result,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_portForward") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("workflowtoken", workflowToken.toString())
             }
         }
     }
@@ -1022,11 +1816,25 @@ object ClouddebugTelemetry {
     fun portForward(
         project: Project? = null,
         success: Boolean,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        portForward(project, if(success) Result.Succeeded else Result.Failed, workflowtoken, value,
+        portForward(project, if(success) Result.Succeeded else Result.Failed, workflowToken, value,
+                createTime)
+    }
+
+    /**
+     * Forward a local port to a remote machine for debugging
+     */
+    fun portForward(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        portForward(metadata, if(success) Result.Succeeded else Result.Failed, workflowToken, value,
                 createTime)
     }
 
@@ -1036,7 +1844,7 @@ object ClouddebugTelemetry {
     fun retrieveRole(
         project: Project? = null,
         result: Result,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -1047,7 +1855,29 @@ object ClouddebugTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("workflowtoken", workflowtoken.toString())
+                metadata("workflowtoken", workflowToken.toString())
+            }
+        }
+    }
+
+    /**
+     * Install the cloud debug CLI
+     */
+    fun retrieveRole(
+        metadata: MetricEventMetadata,
+        result: Result,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_retrieveRole") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("workflowtoken", workflowToken.toString())
             }
         }
     }
@@ -1058,14 +1888,28 @@ object ClouddebugTelemetry {
     fun retrieveRole(
         project: Project? = null,
         success: Boolean,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        retrieveRole(project, if(success) Result.Succeeded else Result.Failed, workflowtoken, value,
+        retrieveRole(project, if(success) Result.Succeeded else Result.Failed, workflowToken, value,
                 createTime)
     }
 
+    /**
+     * Install the cloud debug CLI
+     */
+    fun retrieveRole(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        retrieveRole(metadata, if(success) Result.Succeeded else Result.Failed, workflowToken,
+                value, createTime)
+    }
+
     /**
      * Open the shell on a remote resource
      */
@@ -1090,6 +1934,30 @@ object ClouddebugTelemetry {
         }
     }
 
+    /**
+     * Open the shell on a remote resource
+     */
+    fun shell(
+        metadata: MetricEventMetadata,
+        result: Result,
+        version: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_shell") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(version != null) {
+                    metadata("version", version.toString())
+                }
+            }
+        }
+    }
+
     /**
      * Open the shell on a remote resource
      */
@@ -1103,13 +1971,26 @@ object ClouddebugTelemetry {
         shell(project, if(success) Result.Succeeded else Result.Failed, version, value, createTime)
     }
 
+    /**
+     * Open the shell on a remote resource
+     */
+    fun shell(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        version: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        shell(metadata, if(success) Result.Succeeded else Result.Failed, version, value, createTime)
+    }
+
     /**
      * Start an application on a remote machine for debugging
      */
     fun startApplication(
         project: Project? = null,
         result: Result,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -1120,7 +2001,29 @@ object ClouddebugTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("workflowtoken", workflowtoken.toString())
+                metadata("workflowtoken", workflowToken.toString())
+            }
+        }
+    }
+
+    /**
+     * Start an application on a remote machine for debugging
+     */
+    fun startApplication(
+        metadata: MetricEventMetadata,
+        result: Result,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_startApplication") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("workflowtoken", workflowToken.toString())
             }
         }
     }
@@ -1131,11 +2034,25 @@ object ClouddebugTelemetry {
     fun startApplication(
         project: Project? = null,
         success: Boolean,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        startApplication(project, if(success) Result.Succeeded else Result.Failed, workflowtoken,
+        startApplication(project, if(success) Result.Succeeded else Result.Failed, workflowToken,
+                value, createTime)
+    }
+
+    /**
+     * Start an application on a remote machine for debugging
+     */
+    fun startApplication(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        startApplication(metadata, if(success) Result.Succeeded else Result.Failed, workflowToken,
                 value, createTime)
     }
 
@@ -1145,7 +2062,7 @@ object ClouddebugTelemetry {
     fun startRemoteDebug(
         project: Project? = null,
         result: Result,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -1156,7 +2073,29 @@ object ClouddebugTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("workflowtoken", workflowtoken.toString())
+                metadata("workflowtoken", workflowToken.toString())
+            }
+        }
+    }
+
+    /**
+     * Start the remote debug session
+     */
+    fun startRemoteDebug(
+        metadata: MetricEventMetadata,
+        result: Result,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_startRemoteDebug") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("workflowtoken", workflowToken.toString())
             }
         }
     }
@@ -1167,11 +2106,25 @@ object ClouddebugTelemetry {
     fun startRemoteDebug(
         project: Project? = null,
         success: Boolean,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        startRemoteDebug(project, if(success) Result.Succeeded else Result.Failed, workflowtoken,
+        startRemoteDebug(project, if(success) Result.Succeeded else Result.Failed, workflowToken,
+                value, createTime)
+    }
+
+    /**
+     * Start the remote debug session
+     */
+    fun startRemoteDebug(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        startRemoteDebug(metadata, if(success) Result.Succeeded else Result.Failed, workflowToken,
                 value, createTime)
     }
 
@@ -1181,7 +2134,7 @@ object ClouddebugTelemetry {
     fun stopApplication(
         project: Project? = null,
         result: Result,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -1192,7 +2145,29 @@ object ClouddebugTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("workflowtoken", workflowtoken.toString())
+                metadata("workflowtoken", workflowToken.toString())
+            }
+        }
+    }
+
+    /**
+     * Stop an application on a remote machine after debugging is completed
+     */
+    fun stopApplication(
+        metadata: MetricEventMetadata,
+        result: Result,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("clouddebug_stopApplication") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("workflowtoken", workflowToken.toString())
             }
         }
     }
@@ -1203,11 +2178,25 @@ object ClouddebugTelemetry {
     fun stopApplication(
         project: Project? = null,
         success: Boolean,
-        workflowtoken: String,
+        workflowToken: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        stopApplication(project, if(success) Result.Succeeded else Result.Failed, workflowtoken,
+        stopApplication(project, if(success) Result.Succeeded else Result.Failed, workflowToken,
+                value, createTime)
+    }
+
+    /**
+     * Stop an application on a remote machine after debugging is completed
+     */
+    fun stopApplication(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        workflowToken: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        stopApplication(metadata, if(success) Result.Succeeded else Result.Failed, workflowToken,
                 value, createTime)
     }
 }
@@ -1233,6 +2222,26 @@ object CloudformationTelemetry {
         }
     }
 
+    /**
+     * Called when deleting a cloudformation stack
+     */
+    fun delete(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudformation_delete") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when deleting a cloudformation stack
      */
@@ -1245,6 +2254,18 @@ object CloudformationTelemetry {
         delete(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Called when deleting a cloudformation stack
+     */
+    fun delete(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        delete(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Open a CloudFormation stack in the stack viewer
      */
@@ -1262,6 +2283,24 @@ object CloudformationTelemetry {
             }
         }
     }
+
+    /**
+     * Open a CloudFormation stack in the stack viewer
+     */
+    fun open(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudformation_open") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
 }
 
 object CloudwatchlogsTelemetry {
@@ -1285,6 +2324,26 @@ object CloudwatchlogsTelemetry {
         }
     }
 
+    /**
+     * Download a stream to a file on disk. Value indicates the final size of the formatted stream.
+     */
+    fun downloadStreamToFile(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_downloadStreamToFile") {
+                createTime(createTime)
+                unit(Unit.BYTES)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Download a stream to a file on disk. Value indicates the final size of the formatted stream.
      */
@@ -1298,6 +2357,19 @@ object CloudwatchlogsTelemetry {
                 createTime)
     }
 
+    /**
+     * Download a stream to a file on disk. Value indicates the final size of the formatted stream.
+     */
+    fun downloadStreamToFile(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        downloadStreamToFile(metadata, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Open the CloudWatch Logs group window. ServiceType indicates that it was opened from a
      * different service (like directly from an ECS container)
@@ -1305,7 +2377,7 @@ object CloudwatchlogsTelemetry {
     fun openGroup(
         project: Project? = null,
         result: Result,
-        servicetype: ServiceType? = null,
+        serviceType: ServiceType? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -1316,8 +2388,33 @@ object CloudwatchlogsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                if(servicetype != null) {
-                    metadata("servicetype", servicetype.toString())
+                if(serviceType != null) {
+                    metadata("servicetype", serviceType.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Open the CloudWatch Logs group window. ServiceType indicates that it was opened from a
+     * different service (like directly from an ECS container)
+     */
+    fun openGroup(
+        metadata: MetricEventMetadata,
+        result: Result,
+        serviceType: ServiceType? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_openGroup") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(serviceType != null) {
+                    metadata("servicetype", serviceType.toString())
                 }
             }
         }
@@ -1330,11 +2427,26 @@ object CloudwatchlogsTelemetry {
     fun openGroup(
         project: Project? = null,
         success: Boolean,
-        servicetype: ServiceType? = null,
+        serviceType: ServiceType? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        openGroup(project, if(success) Result.Succeeded else Result.Failed, servicetype, value,
+        openGroup(project, if(success) Result.Succeeded else Result.Failed, serviceType, value,
+                createTime)
+    }
+
+    /**
+     * Open the CloudWatch Logs group window. ServiceType indicates that it was opened from a
+     * different service (like directly from an ECS container)
+     */
+    fun openGroup(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        serviceType: ServiceType? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        openGroup(metadata, if(success) Result.Succeeded else Result.Failed, serviceType, value,
                 createTime)
     }
 
@@ -1345,7 +2457,7 @@ object CloudwatchlogsTelemetry {
     fun openStream(
         project: Project? = null,
         result: Result,
-        servicetype: ServiceType? = null,
+        serviceType: ServiceType? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -1356,8 +2468,33 @@ object CloudwatchlogsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                if(servicetype != null) {
-                    metadata("servicetype", servicetype.toString())
+                if(serviceType != null) {
+                    metadata("servicetype", serviceType.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Open a CloudWatch Logs stream in the window. ServiceType indicates that it was opened from a
+     * different service (like directly from an ECS container)
+     */
+    fun openStream(
+        metadata: MetricEventMetadata,
+        result: Result,
+        serviceType: ServiceType? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_openStream") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(serviceType != null) {
+                    metadata("servicetype", serviceType.toString())
                 }
             }
         }
@@ -1370,11 +2507,26 @@ object CloudwatchlogsTelemetry {
     fun openStream(
         project: Project? = null,
         success: Boolean,
-        servicetype: ServiceType? = null,
+        serviceType: ServiceType? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        openStream(project, if(success) Result.Succeeded else Result.Failed, servicetype, value,
+        openStream(project, if(success) Result.Succeeded else Result.Failed, serviceType, value,
+                createTime)
+    }
+
+    /**
+     * Open a CloudWatch Logs stream in the window. ServiceType indicates that it was opened from a
+     * different service (like directly from an ECS container)
+     */
+    fun openStream(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        serviceType: ServiceType? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        openStream(metadata, if(success) Result.Succeeded else Result.Failed, serviceType, value,
                 createTime)
     }
 
@@ -1398,6 +2550,26 @@ object CloudwatchlogsTelemetry {
         }
     }
 
+    /**
+     * Download a stream to memory then open in an editor.
+     */
+    fun openStreamInEditor(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_openStreamInEditor") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Download a stream to memory then open in an editor.
      */
@@ -1411,6 +2583,19 @@ object CloudwatchlogsTelemetry {
                 createTime)
     }
 
+    /**
+     * Download a stream to memory then open in an editor.
+     */
+    fun openStreamInEditor(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        openStreamInEditor(metadata, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Refresh group is pressed
      */
@@ -1429,6 +2614,24 @@ object CloudwatchlogsTelemetry {
         }
     }
 
+    /**
+     * Refresh group is pressed
+     */
+    fun refreshGroup(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_refreshGroup") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Refresh stream is pressed
      */
@@ -1447,6 +2650,24 @@ object CloudwatchlogsTelemetry {
         }
     }
 
+    /**
+     * Refresh stream is pressed
+     */
+    fun refreshStream(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_refreshStream") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Called when a group is searched
      */
@@ -1467,6 +2688,26 @@ object CloudwatchlogsTelemetry {
         }
     }
 
+    /**
+     * Called when a group is searched
+     */
+    fun searchGroup(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_searchGroup") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when a group is searched
      */
@@ -1479,6 +2720,18 @@ object CloudwatchlogsTelemetry {
         searchGroup(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Called when a group is searched
+     */
+    fun searchGroup(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        searchGroup(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Called when a stream is searched
      */
@@ -1499,6 +2752,26 @@ object CloudwatchlogsTelemetry {
         }
     }
 
+    /**
+     * Called when a stream is searched
+     */
+    fun searchStream(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_searchStream") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when a stream is searched
      */
@@ -1511,6 +2784,18 @@ object CloudwatchlogsTelemetry {
         searchStream(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Called when a stream is searched
+     */
+    fun searchStream(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        searchStream(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Show event around a time period in ms specified by Value
      */
@@ -1531,6 +2816,26 @@ object CloudwatchlogsTelemetry {
         }
     }
 
+    /**
+     * Show event around a time period in ms specified by Value
+     */
+    fun showEventsAround(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_showEventsAround") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Show event around a time period in ms specified by Value
      */
@@ -1544,6 +2849,19 @@ object CloudwatchlogsTelemetry {
                 createTime)
     }
 
+    /**
+     * Show event around a time period in ms specified by Value
+     */
+    fun showEventsAround(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        showEventsAround(metadata, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Tail stream off/on
      */
@@ -1564,6 +2882,26 @@ object CloudwatchlogsTelemetry {
         }
     }
 
+    /**
+     * Tail stream off/on
+     */
+    fun tailStream(
+        metadata: MetricEventMetadata,
+        enabled: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_tailStream") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("enabled", enabled.toString())
+            }
+        }
+    }
+
     /**
      * Copy the currently open (possibly filtered) messages to an editor
      */
@@ -1584,6 +2922,26 @@ object CloudwatchlogsTelemetry {
         }
     }
 
+    /**
+     * Copy the currently open (possibly filtered) messages to an editor
+     */
+    fun viewCurrentMessagesInEditor(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_viewCurrentMessagesInEditor") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Copy the currently open (possibly filtered) messages to an editor
      */
@@ -1597,6 +2955,19 @@ object CloudwatchlogsTelemetry {
                 createTime)
     }
 
+    /**
+     * Copy the currently open (possibly filtered) messages to an editor
+     */
+    fun viewCurrentMessagesInEditor(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        viewCurrentMessagesInEditor(metadata, if(success) Result.Succeeded else Result.Failed,
+                value, createTime)
+    }
+
     /**
      * Word wrap events off/on
      */
@@ -1616,6 +2987,26 @@ object CloudwatchlogsTelemetry {
             }
         }
     }
+
+    /**
+     * Word wrap events off/on
+     */
+    fun wrapEvents(
+        metadata: MetricEventMetadata,
+        enabled: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("cloudwatchlogs_wrapEvents") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("enabled", enabled.toString())
+            }
+        }
+    }
 }
 
 object FeedbackTelemetry {
@@ -1639,6 +3030,26 @@ object FeedbackTelemetry {
         }
     }
 
+    /**
+     * Called while submitting in-IDE feedback
+     */
+    fun result(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("feedback_result") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called while submitting in-IDE feedback
      */
@@ -1650,6 +3061,18 @@ object FeedbackTelemetry {
     ) {
         result(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
+
+    /**
+     * Called while submitting in-IDE feedback
+     */
+    fun result(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        result(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
 }
 
 object LambdaTelemetry {
@@ -1673,6 +3096,26 @@ object LambdaTelemetry {
         }
     }
 
+    /**
+     * Called when opening the local configuration of a Lambda to edit
+     */
+    fun configure(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_configure") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when opening the local configuration of a Lambda to edit
      */
@@ -1685,6 +3128,18 @@ object LambdaTelemetry {
         configure(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Called when opening the local configuration of a Lambda to edit
+     */
+    fun configure(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        configure(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Called when creating lambdas remotely
      */
@@ -1705,6 +3160,26 @@ object LambdaTelemetry {
         }
     }
 
+    /**
+     * Called when creating lambdas remotely
+     */
+    fun create(
+        metadata: MetricEventMetadata,
+        runtime: Runtime,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_create") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("runtime", runtime.toString())
+            }
+        }
+    }
+
     /**
      * called when deleting lambdas remotely
      */
@@ -1727,6 +3202,28 @@ object LambdaTelemetry {
         }
     }
 
+    /**
+     * called when deleting lambdas remotely
+     */
+    fun delete(
+        metadata: MetricEventMetadata,
+        duration: Double,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_delete") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("duration", duration.toString())
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * called when deleting lambdas remotely
      */
@@ -1741,6 +3238,20 @@ object LambdaTelemetry {
                 createTime)
     }
 
+    /**
+     * called when deleting lambdas remotely
+     */
+    fun delete(
+        metadata: MetricEventMetadata,
+        duration: Double,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        delete(metadata, duration, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Called when creating lambdas remotely
      */
@@ -1765,6 +3276,30 @@ object LambdaTelemetry {
         }
     }
 
+    /**
+     * Called when creating lambdas remotely
+     */
+    fun editFunction(
+        metadata: MetricEventMetadata,
+        update: Boolean? = null,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_editFunction") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                if(update != null) {
+                    metadata("update", update.toString())
+                }
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when creating lambdas remotely
      */
@@ -1779,6 +3314,20 @@ object LambdaTelemetry {
                 createTime)
     }
 
+    /**
+     * Called when creating lambdas remotely
+     */
+    fun editFunction(
+        metadata: MetricEventMetadata,
+        update: Boolean? = null,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        editFunction(metadata, update, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Jump to a lambda handler from elsewhere
      */
@@ -1799,6 +3348,26 @@ object LambdaTelemetry {
         }
     }
 
+    /**
+     * Jump to a lambda handler from elsewhere
+     */
+    fun goToHandler(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_goToHandler") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Jump to a lambda handler from elsewhere
      */
@@ -1811,6 +3380,18 @@ object LambdaTelemetry {
         goToHandler(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Jump to a lambda handler from elsewhere
+     */
+    fun goToHandler(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        goToHandler(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Called when importing a remote Lambda function
      */
@@ -1835,6 +3416,30 @@ object LambdaTelemetry {
         }
     }
 
+    /**
+     * Called when importing a remote Lambda function
+     */
+    fun import(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_import") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                if(runtime != null) {
+                    metadata("runtime", runtime.toString())
+                }
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when importing a remote Lambda function
      */
@@ -1848,6 +3453,20 @@ object LambdaTelemetry {
         import(project, runtime, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Called when importing a remote Lambda function
+     */
+    fun import(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        import(metadata, runtime, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Called when invoking lambdas locally (with SAM in most toolkits)
      */
@@ -1874,6 +3493,32 @@ object LambdaTelemetry {
         }
     }
 
+    /**
+     * Called when invoking lambdas locally (with SAM in most toolkits)
+     */
+    fun invokeLocal(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        result: Result,
+        debug: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_invokeLocal") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                if(runtime != null) {
+                    metadata("runtime", runtime.toString())
+                }
+                metadata("result", result.toString())
+                metadata("debug", debug.toString())
+            }
+        }
+    }
+
     /**
      * Called when invoking lambdas locally (with SAM in most toolkits)
      */
@@ -1889,6 +3534,21 @@ object LambdaTelemetry {
                 createTime)
     }
 
+    /**
+     * Called when invoking lambdas locally (with SAM in most toolkits)
+     */
+    fun invokeLocal(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        success: Boolean,
+        debug: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        invokeLocal(metadata, runtime, if(success) Result.Succeeded else Result.Failed, debug,
+                value, createTime)
+    }
+
     /**
      * Called when invoking lambdas remotely
      */
@@ -1913,6 +3573,30 @@ object LambdaTelemetry {
         }
     }
 
+    /**
+     * Called when invoking lambdas remotely
+     */
+    fun invokeRemote(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_invokeRemote") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                if(runtime != null) {
+                    metadata("runtime", runtime.toString())
+                }
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when invoking lambdas remotely
      */
@@ -1927,6 +3611,20 @@ object LambdaTelemetry {
                 createTime)
     }
 
+    /**
+     * Called when invoking lambdas remotely
+     */
+    fun invokeRemote(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        invokeRemote(metadata, runtime, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Called when updating a Lambda function's code outside the context of a SAM template
      */
@@ -1951,6 +3649,30 @@ object LambdaTelemetry {
         }
     }
 
+    /**
+     * Called when updating a Lambda function's code outside the context of a SAM template
+     */
+    fun updateFunctionCode(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("lambda_updateFunctionCode") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                if(runtime != null) {
+                    metadata("runtime", runtime.toString())
+                }
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when updating a Lambda function's code outside the context of a SAM template
      */
@@ -1964,6 +3686,20 @@ object LambdaTelemetry {
         updateFunctionCode(project, runtime, if(success) Result.Succeeded else Result.Failed, value,
                 createTime)
     }
+
+    /**
+     * Called when updating a Lambda function's code outside the context of a SAM template
+     */
+    fun updateFunctionCode(
+        metadata: MetricEventMetadata,
+        runtime: Runtime? = null,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        updateFunctionCode(metadata, runtime, if(success) Result.Succeeded else Result.Failed,
+                value, createTime)
+    }
 }
 
 object RdsTelemetry {
@@ -1975,8 +3711,8 @@ object RdsTelemetry {
     fun createConnectionConfiguration(
         project: Project? = null,
         result: Result,
-        databasecredentials: DatabaseCredentials,
-        databaseengine: String? = null,
+        databaseCredentials: DatabaseCredentials,
+        databaseEngine: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -1987,9 +3723,37 @@ object RdsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("databasecredentials", databasecredentials.toString())
-                if(databaseengine != null) {
-                    metadata("databaseengine", databaseengine.toString())
+                metadata("databasecredentials", databaseCredentials.toString())
+                if(databaseEngine != null) {
+                    metadata("databaseengine", databaseEngine.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Called when creating a new database connection configuration to for a RDS database. In
+     * Datagrip we do not get this infromation if it is created directly, so this is only counts
+     * actions.
+     */
+    fun createConnectionConfiguration(
+        metadata: MetricEventMetadata,
+        result: Result,
+        databaseCredentials: DatabaseCredentials,
+        databaseEngine: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("rds_createConnectionConfiguration") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("databasecredentials", databaseCredentials.toString())
+                if(databaseEngine != null) {
+                    metadata("databaseengine", databaseEngine.toString())
                 }
             }
         }
@@ -2003,13 +3767,30 @@ object RdsTelemetry {
     fun createConnectionConfiguration(
         project: Project? = null,
         success: Boolean,
-        databasecredentials: DatabaseCredentials,
-        databaseengine: String? = null,
+        databaseCredentials: DatabaseCredentials,
+        databaseEngine: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
         createConnectionConfiguration(project, if(success) Result.Succeeded else Result.Failed,
-                databasecredentials, databaseengine, value, createTime)
+                databaseCredentials, databaseEngine, value, createTime)
+    }
+
+    /**
+     * Called when creating a new database connection configuration to for a RDS database. In
+     * Datagrip we do not get this infromation if it is created directly, so this is only counts
+     * actions.
+     */
+    fun createConnectionConfiguration(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        databaseCredentials: DatabaseCredentials,
+        databaseEngine: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        createConnectionConfiguration(metadata, if(success) Result.Succeeded else Result.Failed,
+                databaseCredentials, databaseEngine, value, createTime)
     }
 
     /**
@@ -2019,8 +3800,8 @@ object RdsTelemetry {
     fun getCredentials(
         project: Project? = null,
         result: Result,
-        databasecredentials: DatabaseCredentials,
-        databaseengine: String,
+        databaseCredentials: DatabaseCredentials,
+        databaseEngine: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2031,8 +3812,33 @@ object RdsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("databasecredentials", databasecredentials.toString())
-                metadata("databaseengine", databaseengine.toString())
+                metadata("databasecredentials", databaseCredentials.toString())
+                metadata("databaseengine", databaseEngine.toString())
+            }
+        }
+    }
+
+    /**
+     * Called when getting IAM/SecretsManager credentials for a RDS database. Value represents how
+     * long it takes in ms.
+     */
+    fun getCredentials(
+        metadata: MetricEventMetadata,
+        result: Result,
+        databaseCredentials: DatabaseCredentials,
+        databaseEngine: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("rds_getCredentials") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("databasecredentials", databaseCredentials.toString())
+                metadata("databaseengine", databaseEngine.toString())
             }
         }
     }
@@ -2044,13 +3850,29 @@ object RdsTelemetry {
     fun getCredentials(
         project: Project? = null,
         success: Boolean,
-        databasecredentials: DatabaseCredentials,
-        databaseengine: String,
+        databaseCredentials: DatabaseCredentials,
+        databaseEngine: String,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
         getCredentials(project, if(success) Result.Succeeded else Result.Failed,
-                databasecredentials, databaseengine, value, createTime)
+                databaseCredentials, databaseEngine, value, createTime)
+    }
+
+    /**
+     * Called when getting IAM/SecretsManager credentials for a RDS database. Value represents how
+     * long it takes in ms.
+     */
+    fun getCredentials(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        databaseCredentials: DatabaseCredentials,
+        databaseEngine: String,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        getCredentials(metadata, if(success) Result.Succeeded else Result.Failed,
+                databaseCredentials, databaseEngine, value, createTime)
     }
 }
 
@@ -2062,7 +3884,7 @@ object RedshiftTelemetry {
     fun createConnectionConfiguration(
         project: Project? = null,
         result: Result,
-        databasecredentials: DatabaseCredentials,
+        databaseCredentials: DatabaseCredentials,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2073,7 +3895,30 @@ object RedshiftTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("databasecredentials", databasecredentials.toString())
+                metadata("databasecredentials", databaseCredentials.toString())
+            }
+        }
+    }
+
+    /**
+     * Called when creating a new database connection configuration to for a Redshift database. In
+     * Datagrip we do not get this infromation if it is created directly, so this only counts actions.
+     */
+    fun createConnectionConfiguration(
+        metadata: MetricEventMetadata,
+        result: Result,
+        databaseCredentials: DatabaseCredentials,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("redshift_createConnectionConfiguration") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("databasecredentials", databaseCredentials.toString())
             }
         }
     }
@@ -2085,12 +3930,27 @@ object RedshiftTelemetry {
     fun createConnectionConfiguration(
         project: Project? = null,
         success: Boolean,
-        databasecredentials: DatabaseCredentials,
+        databaseCredentials: DatabaseCredentials,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
         createConnectionConfiguration(project, if(success) Result.Succeeded else Result.Failed,
-                databasecredentials, value, createTime)
+                databaseCredentials, value, createTime)
+    }
+
+    /**
+     * Called when creating a new database connection configuration to for a Redshift database. In
+     * Datagrip we do not get this infromation if it is created directly, so this only counts actions.
+     */
+    fun createConnectionConfiguration(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        databaseCredentials: DatabaseCredentials,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        createConnectionConfiguration(metadata, if(success) Result.Succeeded else Result.Failed,
+                databaseCredentials, value, createTime)
     }
 
     /**
@@ -2100,7 +3960,7 @@ object RedshiftTelemetry {
     fun getCredentials(
         project: Project? = null,
         result: Result,
-        databasecredentials: DatabaseCredentials,
+        databaseCredentials: DatabaseCredentials,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2111,7 +3971,30 @@ object RedshiftTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("databasecredentials", databasecredentials.toString())
+                metadata("databasecredentials", databaseCredentials.toString())
+            }
+        }
+    }
+
+    /**
+     * Called when getting IAM/SecretsManager credentials for a Redshift database. Value represents
+     * how long it takes in ms.
+     */
+    fun getCredentials(
+        metadata: MetricEventMetadata,
+        result: Result,
+        databaseCredentials: DatabaseCredentials,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("redshift_getCredentials") {
+                createTime(createTime)
+                unit(Unit.MILLISECONDS)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("databasecredentials", databaseCredentials.toString())
             }
         }
     }
@@ -2123,12 +4006,27 @@ object RedshiftTelemetry {
     fun getCredentials(
         project: Project? = null,
         success: Boolean,
-        databasecredentials: DatabaseCredentials,
+        databaseCredentials: DatabaseCredentials,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
         getCredentials(project, if(success) Result.Succeeded else Result.Failed,
-                databasecredentials, value, createTime)
+                databaseCredentials, value, createTime)
+    }
+
+    /**
+     * Called when getting IAM/SecretsManager credentials for a Redshift database. Value represents
+     * how long it takes in ms.
+     */
+    fun getCredentials(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        databaseCredentials: DatabaseCredentials,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        getCredentials(metadata, if(success) Result.Succeeded else Result.Failed,
+                databaseCredentials, value, createTime)
     }
 }
 
@@ -2151,6 +4049,24 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Copy the bucket name to the clipboard
+     */
+    fun copyBucketName(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_copyBucketName") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Copy the path of a S3 object to the clipboard
      */
@@ -2169,6 +4085,24 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Copy the path of a S3 object to the clipboard
+     */
+    fun copyPath(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_copyPath") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
     /**
      * Copy the URL of a S3 object to the clipboard
      */
@@ -2191,6 +4125,28 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Copy the URL of a S3 object to the clipboard
+     */
+    fun copyUrl(
+        metadata: MetricEventMetadata,
+        result: Result,
+        presigned: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_copyUrl") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("presigned", presigned.toString())
+            }
+        }
+    }
+
     /**
      * Copy the URL of a S3 object to the clipboard
      */
@@ -2205,6 +4161,20 @@ object S3Telemetry {
                 createTime)
     }
 
+    /**
+     * Copy the URL of a S3 object to the clipboard
+     */
+    fun copyUrl(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        presigned: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        copyUrl(metadata, if(success) Result.Succeeded else Result.Failed, presigned, value,
+                createTime)
+    }
+
     /**
      * Create a S3 bucket
      */
@@ -2225,6 +4195,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Create a S3 bucket
+     */
+    fun createBucket(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_createBucket") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Create a S3 bucket
      */
@@ -2237,6 +4227,18 @@ object S3Telemetry {
         createBucket(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Create a S3 bucket
+     */
+    fun createBucket(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        createBucket(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Create an S3 folder
      */
@@ -2257,6 +4259,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Create an S3 folder
+     */
+    fun createFolder(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_createFolder") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Create an S3 folder
      */
@@ -2269,6 +4291,18 @@ object S3Telemetry {
         createFolder(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Create an S3 folder
+     */
+    fun createFolder(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        createFolder(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Delete a S3 bucket
      */
@@ -2289,6 +4323,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Delete a S3 bucket
+     */
+    fun deleteBucket(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_deleteBucket") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Delete a S3 bucket
      */
@@ -2301,6 +4355,18 @@ object S3Telemetry {
         deleteBucket(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Delete a S3 bucket
+     */
+    fun deleteBucket(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        deleteBucket(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Delete a single S3 object
      */
@@ -2321,6 +4387,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Delete a single S3 object
+     */
+    fun deleteObject(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_deleteObject") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Delete a single S3 object
      */
@@ -2333,6 +4419,18 @@ object S3Telemetry {
         deleteObject(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Delete a single S3 object
+     */
+    fun deleteObject(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        deleteObject(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Download a single S3 object
      */
@@ -2353,6 +4451,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Download a single S3 object
+     */
+    fun downloadObject(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_downloadObject") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Download a single S3 object
      */
@@ -2365,6 +4483,18 @@ object S3Telemetry {
         downloadObject(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Download a single S3 object
+     */
+    fun downloadObject(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        downloadObject(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Download multiple S3 objects
      */
@@ -2385,6 +4515,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Download multiple S3 objects
+     */
+    fun downloadObjects(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_downloadObjects") {
+                createTime(createTime)
+                unit(Unit.COUNT)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Download multiple S3 objects
      */
@@ -2397,6 +4547,19 @@ object S3Telemetry {
         downloadObjects(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Download multiple S3 objects
+     */
+    fun downloadObjects(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        downloadObjects(metadata, if(success) Result.Succeeded else Result.Failed, value,
+                createTime)
+    }
+
     /**
      * Open a view of a S3 bucket
      */
@@ -2417,6 +4580,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Open a view of a S3 bucket
+     */
+    fun openEditor(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_openEditor") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Open a view of a S3 bucket
      */
@@ -2429,6 +4612,18 @@ object S3Telemetry {
         openEditor(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Open a view of a S3 bucket
+     */
+    fun openEditor(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        openEditor(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Rename a single S3 object
      */
@@ -2449,6 +4644,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Rename a single S3 object
+     */
+    fun renameObject(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_renameObject") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Rename a single S3 object
      */
@@ -2461,6 +4676,18 @@ object S3Telemetry {
         renameObject(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Rename a single S3 object
+     */
+    fun renameObject(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        renameObject(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Upload a single S3 object
      */
@@ -2481,6 +4708,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Upload a single S3 object
+     */
+    fun uploadObject(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_uploadObject") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Upload a single S3 object
      */
@@ -2493,6 +4740,18 @@ object S3Telemetry {
         uploadObject(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Upload a single S3 object
+     */
+    fun uploadObject(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        uploadObject(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Upload multiple S3 objects
      */
@@ -2513,6 +4772,26 @@ object S3Telemetry {
         }
     }
 
+    /**
+     * Upload multiple S3 objects
+     */
+    fun uploadObjects(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("s3_uploadObjects") {
+                createTime(createTime)
+                unit(Unit.COUNT)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Upload multiple S3 objects
      */
@@ -2524,6 +4803,18 @@ object S3Telemetry {
     ) {
         uploadObjects(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
+
+    /**
+     * Upload multiple S3 objects
+     */
+    fun uploadObjects(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        uploadObjects(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
 }
 
 object SamTelemetry {
@@ -2551,6 +4842,30 @@ object SamTelemetry {
         }
     }
 
+    /**
+     * Called when deploying a sam application
+     */
+    fun deploy(
+        metadata: MetricEventMetadata,
+        result: Result,
+        version: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sam_deploy") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(version != null) {
+                    metadata("version", version.toString())
+                }
+            }
+        }
+    }
+
     /**
      * Called when deploying a sam application
      */
@@ -2564,6 +4879,20 @@ object SamTelemetry {
         deploy(project, if(success) Result.Succeeded else Result.Failed, version, value, createTime)
     }
 
+    /**
+     * Called when deploying a sam application
+     */
+    fun deploy(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        version: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        deploy(metadata, if(success) Result.Succeeded else Result.Failed, version, value,
+                createTime)
+    }
+
     /**
      * Called when initing a sam application
      */
@@ -2572,10 +4901,10 @@ object SamTelemetry {
         result: Result,
         name: String? = null,
         runtime: Runtime? = null,
-        templatename: String? = null,
+        templateName: String? = null,
         version: String? = null,
         reason: String? = null,
-        eventbridgeschema: String? = null,
+        eventBridgeSchema: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2592,8 +4921,8 @@ object SamTelemetry {
                 if(runtime != null) {
                     metadata("runtime", runtime.toString())
                 }
-                if(templatename != null) {
-                    metadata("templatename", templatename.toString())
+                if(templateName != null) {
+                    metadata("templatename", templateName.toString())
                 }
                 if(version != null) {
                     metadata("version", version.toString())
@@ -2601,8 +4930,52 @@ object SamTelemetry {
                 if(reason != null) {
                     metadata("reason", reason.toString())
                 }
-                if(eventbridgeschema != null) {
-                    metadata("eventbridgeschema", eventbridgeschema.toString())
+                if(eventBridgeSchema != null) {
+                    metadata("eventbridgeschema", eventBridgeSchema.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Called when initing a sam application
+     */
+    fun init(
+        metadata: MetricEventMetadata,
+        result: Result,
+        name: String? = null,
+        runtime: Runtime? = null,
+        templateName: String? = null,
+        version: String? = null,
+        reason: String? = null,
+        eventBridgeSchema: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sam_init") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(name != null) {
+                    metadata("name", name.toString())
+                }
+                if(runtime != null) {
+                    metadata("runtime", runtime.toString())
+                }
+                if(templateName != null) {
+                    metadata("templatename", templateName.toString())
+                }
+                if(version != null) {
+                    metadata("version", version.toString())
+                }
+                if(reason != null) {
+                    metadata("reason", reason.toString())
+                }
+                if(eventBridgeSchema != null) {
+                    metadata("eventbridgeschema", eventBridgeSchema.toString())
                 }
             }
         }
@@ -2616,15 +4989,34 @@ object SamTelemetry {
         success: Boolean,
         name: String? = null,
         runtime: Runtime? = null,
-        templatename: String? = null,
+        templateName: String? = null,
         version: String? = null,
         reason: String? = null,
-        eventbridgeschema: String? = null,
+        eventBridgeSchema: String? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        init(project, if(success) Result.Succeeded else Result.Failed, name, runtime, templatename,
-                version, reason, eventbridgeschema, value, createTime)
+        init(project, if(success) Result.Succeeded else Result.Failed, name, runtime, templateName,
+                version, reason, eventBridgeSchema, value, createTime)
+    }
+
+    /**
+     * Called when initing a sam application
+     */
+    fun init(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        name: String? = null,
+        runtime: Runtime? = null,
+        templateName: String? = null,
+        version: String? = null,
+        reason: String? = null,
+        eventBridgeSchema: String? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        init(metadata, if(success) Result.Succeeded else Result.Failed, name, runtime, templateName,
+                version, reason, eventBridgeSchema, value, createTime)
     }
 }
 
@@ -2635,7 +5027,7 @@ object SchemasTelemetry {
     fun download(
         project: Project? = null,
         result: Result,
-        schemalanguage: SchemaLanguage? = null,
+        schemaLanguage: SchemaLanguage? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2646,8 +5038,32 @@ object SchemasTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                if(schemalanguage != null) {
-                    metadata("schemalanguage", schemalanguage.toString())
+                if(schemaLanguage != null) {
+                    metadata("schemalanguage", schemaLanguage.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Called when downloading an EventBridge schema
+     */
+    fun download(
+        metadata: MetricEventMetadata,
+        result: Result,
+        schemaLanguage: SchemaLanguage? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("schemas_download") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(schemaLanguage != null) {
+                    metadata("schemalanguage", schemaLanguage.toString())
                 }
             }
         }
@@ -2659,11 +5075,25 @@ object SchemasTelemetry {
     fun download(
         project: Project? = null,
         success: Boolean,
-        schemalanguage: SchemaLanguage? = null,
+        schemaLanguage: SchemaLanguage? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        download(project, if(success) Result.Succeeded else Result.Failed, schemalanguage, value,
+        download(project, if(success) Result.Succeeded else Result.Failed, schemaLanguage, value,
+                createTime)
+    }
+
+    /**
+     * Called when downloading an EventBridge schema
+     */
+    fun download(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        schemaLanguage: SchemaLanguage? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        download(metadata, if(success) Result.Succeeded else Result.Failed, schemaLanguage, value,
                 createTime)
     }
 
@@ -2687,6 +5117,26 @@ object SchemasTelemetry {
         }
     }
 
+    /**
+     * Called when searching an EventBridge schema registry
+     */
+    fun search(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("schemas_search") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when searching an EventBridge schema registry
      */
@@ -2699,6 +5149,18 @@ object SchemasTelemetry {
         search(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
 
+    /**
+     * Called when searching an EventBridge schema registry
+     */
+    fun search(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        search(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
+
     /**
      * Called when selecting an EventBridge schema to view
      */
@@ -2719,6 +5181,26 @@ object SchemasTelemetry {
         }
     }
 
+    /**
+     * Called when selecting an EventBridge schema to view
+     */
+    fun view(
+        metadata: MetricEventMetadata,
+        result: Result,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("schemas_view") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
     /**
      * Called when selecting an EventBridge schema to view
      */
@@ -2730,6 +5212,18 @@ object SchemasTelemetry {
     ) {
         view(project, if(success) Result.Succeeded else Result.Failed, value, createTime)
     }
+
+    /**
+     * Called when selecting an EventBridge schema to view
+     */
+    fun view(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        view(metadata, if(success) Result.Succeeded else Result.Failed, value, createTime)
+    }
 }
 
 object SessionTelemetry {
@@ -2751,6 +5245,24 @@ object SessionTelemetry {
         }
     }
 
+    /**
+     * Called when stopping the IDE on a best effort basis
+     */
+    fun end(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("session_end") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(true)
+            }
+        }
+    }
+
     /**
      * Called when starting the plugin
      */
@@ -2768,6 +5280,24 @@ object SessionTelemetry {
             }
         }
     }
+
+    /**
+     * Called when starting the plugin
+     */
+    fun start(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("session_start") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(true)
+            }
+        }
+    }
 }
 
 object SqsTelemetry {
@@ -2777,7 +5307,7 @@ object SqsTelemetry {
     fun configureLambdaTrigger(
         project: Project? = null,
         result: Result,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2788,7 +5318,29 @@ object SqsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("sqsqueuetype", sqsqueuetype.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
+            }
+        }
+    }
+
+    /**
+     * Configure the queue as a trigger for a Lambda
+     */
+    fun configureLambdaTrigger(
+        metadata: MetricEventMetadata,
+        result: Result,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sqs_configureLambdaTrigger") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
             }
         }
     }
@@ -2799,12 +5351,26 @@ object SqsTelemetry {
     fun configureLambdaTrigger(
         project: Project? = null,
         success: Boolean,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
         configureLambdaTrigger(project, if(success) Result.Succeeded else Result.Failed,
-                sqsqueuetype, value, createTime)
+                sqsQueueType, value, createTime)
+    }
+
+    /**
+     * Configure the queue as a trigger for a Lambda
+     */
+    fun configureLambdaTrigger(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        configureLambdaTrigger(metadata, if(success) Result.Succeeded else Result.Failed,
+                sqsQueueType, value, createTime)
     }
 
     /**
@@ -2813,7 +5379,7 @@ object SqsTelemetry {
     fun createQueue(
         project: Project? = null,
         result: Result,
-        sqsqueuetype: SqsQueueType? = null,
+        sqsQueueType: SqsQueueType? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2824,8 +5390,32 @@ object SqsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                if(sqsqueuetype != null) {
-                    metadata("sqsqueuetype", sqsqueuetype.toString())
+                if(sqsQueueType != null) {
+                    metadata("sqsqueuetype", sqsQueueType.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Create a new SQS queue
+     */
+    fun createQueue(
+        metadata: MetricEventMetadata,
+        result: Result,
+        sqsQueueType: SqsQueueType? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sqs_createQueue") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                if(sqsQueueType != null) {
+                    metadata("sqsqueuetype", sqsQueueType.toString())
                 }
             }
         }
@@ -2837,11 +5427,25 @@ object SqsTelemetry {
     fun createQueue(
         project: Project? = null,
         success: Boolean,
-        sqsqueuetype: SqsQueueType? = null,
+        sqsQueueType: SqsQueueType? = null,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        createQueue(project, if(success) Result.Succeeded else Result.Failed, sqsqueuetype, value,
+        createQueue(project, if(success) Result.Succeeded else Result.Failed, sqsQueueType, value,
+                createTime)
+    }
+
+    /**
+     * Create a new SQS queue
+     */
+    fun createQueue(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        sqsQueueType: SqsQueueType? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        createQueue(metadata, if(success) Result.Succeeded else Result.Failed, sqsQueueType, value,
                 createTime)
     }
 
@@ -2852,7 +5456,7 @@ object SqsTelemetry {
     fun deleteMessages(
         project: Project? = null,
         result: Result,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2863,7 +5467,30 @@ object SqsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("sqsqueuetype", sqsqueuetype.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
+            }
+        }
+    }
+
+    /**
+     * Delete one or more messages from an SQS queue. Value indicates the number of messages that we
+     * tried to delete.
+     */
+    fun deleteMessages(
+        metadata: MetricEventMetadata,
+        result: Result,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sqs_deleteMessages") {
+                createTime(createTime)
+                unit(Unit.COUNT)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
             }
         }
     }
@@ -2875,11 +5502,26 @@ object SqsTelemetry {
     fun deleteMessages(
         project: Project? = null,
         success: Boolean,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        deleteMessages(project, if(success) Result.Succeeded else Result.Failed, sqsqueuetype,
+        deleteMessages(project, if(success) Result.Succeeded else Result.Failed, sqsQueueType,
+                value, createTime)
+    }
+
+    /**
+     * Delete one or more messages from an SQS queue. Value indicates the number of messages that we
+     * tried to delete.
+     */
+    fun deleteMessages(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        deleteMessages(metadata, if(success) Result.Succeeded else Result.Failed, sqsQueueType,
                 value, createTime)
     }
 
@@ -2889,7 +5531,7 @@ object SqsTelemetry {
     fun editQueueAttributes(
         project: Project? = null,
         result: Result,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2900,7 +5542,29 @@ object SqsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("sqsqueuetype", sqsqueuetype.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
+            }
+        }
+    }
+
+    /**
+     * Edit the Queue attributes
+     */
+    fun editQueueAttributes(
+        metadata: MetricEventMetadata,
+        result: Result,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sqs_editQueueAttributes") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
             }
         }
     }
@@ -2911,11 +5575,25 @@ object SqsTelemetry {
     fun editQueueAttributes(
         project: Project? = null,
         success: Boolean,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        editQueueAttributes(project, if(success) Result.Succeeded else Result.Failed, sqsqueuetype,
+        editQueueAttributes(project, if(success) Result.Succeeded else Result.Failed, sqsQueueType,
+                value, createTime)
+    }
+
+    /**
+     * Edit the Queue attributes
+     */
+    fun editQueueAttributes(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        editQueueAttributes(metadata, if(success) Result.Succeeded else Result.Failed, sqsQueueType,
                 value, createTime)
     }
 
@@ -2924,7 +5602,7 @@ object SqsTelemetry {
      */
     fun openQueue(
         project: Project? = null,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2934,7 +5612,27 @@ object SqsTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                metadata("sqsqueuetype", sqsqueuetype.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
+            }
+        }
+    }
+
+    /**
+     * Open an SQS queue. Initially opens to either the send message pane or poll messags pane.
+     */
+    fun openQueue(
+        metadata: MetricEventMetadata,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sqs_openQueue") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("sqsqueuetype", sqsQueueType.toString())
             }
         }
     }
@@ -2945,7 +5643,7 @@ object SqsTelemetry {
     fun purgeQueue(
         project: Project? = null,
         result: Result,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2956,7 +5654,29 @@ object SqsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("sqsqueuetype", sqsqueuetype.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
+            }
+        }
+    }
+
+    /**
+     * Purge all messages from the queue
+     */
+    fun purgeQueue(
+        metadata: MetricEventMetadata,
+        result: Result,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sqs_purgeQueue") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
             }
         }
     }
@@ -2967,11 +5687,25 @@ object SqsTelemetry {
     fun purgeQueue(
         project: Project? = null,
         success: Boolean,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        purgeQueue(project, if(success) Result.Succeeded else Result.Failed, sqsqueuetype, value,
+        purgeQueue(project, if(success) Result.Succeeded else Result.Failed, sqsQueueType, value,
+                createTime)
+    }
+
+    /**
+     * Purge all messages from the queue
+     */
+    fun purgeQueue(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        purgeQueue(metadata, if(success) Result.Succeeded else Result.Failed, sqsQueueType, value,
                 createTime)
     }
 
@@ -2981,7 +5715,7 @@ object SqsTelemetry {
     fun sendMessage(
         project: Project? = null,
         result: Result,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -2992,7 +5726,29 @@ object SqsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("sqsqueuetype", sqsqueuetype.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
+            }
+        }
+    }
+
+    /**
+     * Send a message to an SQS queue
+     */
+    fun sendMessage(
+        metadata: MetricEventMetadata,
+        result: Result,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sqs_sendMessage") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
             }
         }
     }
@@ -3003,11 +5759,25 @@ object SqsTelemetry {
     fun sendMessage(
         project: Project? = null,
         success: Boolean,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        sendMessage(project, if(success) Result.Succeeded else Result.Failed, sqsqueuetype, value,
+        sendMessage(project, if(success) Result.Succeeded else Result.Failed, sqsQueueType, value,
+                createTime)
+    }
+
+    /**
+     * Send a message to an SQS queue
+     */
+    fun sendMessage(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        sendMessage(metadata, if(success) Result.Succeeded else Result.Failed, sqsQueueType, value,
                 createTime)
     }
 
@@ -3017,7 +5787,7 @@ object SqsTelemetry {
     fun subscribeSns(
         project: Project? = null,
         result: Result,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
@@ -3028,7 +5798,29 @@ object SqsTelemetry {
                 value(value)
                 passive(false)
                 metadata("result", result.toString())
-                metadata("sqsqueuetype", sqsqueuetype.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
+            }
+        }
+    }
+
+    /**
+     * Subscribe the queue to messages from an sns topic
+     */
+    fun subscribeSns(
+        metadata: MetricEventMetadata,
+        result: Result,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("sqs_subscribeSns") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+                metadata("result", result.toString())
+                metadata("sqsqueuetype", sqsQueueType.toString())
             }
         }
     }
@@ -3039,11 +5831,25 @@ object SqsTelemetry {
     fun subscribeSns(
         project: Project? = null,
         success: Boolean,
-        sqsqueuetype: SqsQueueType,
+        sqsQueueType: SqsQueueType,
         value: Double = 1.0,
         createTime: Instant = Instant.now()
     ) {
-        subscribeSns(project, if(success) Result.Succeeded else Result.Failed, sqsqueuetype, value,
+        subscribeSns(project, if(success) Result.Succeeded else Result.Failed, sqsQueueType, value,
+                createTime)
+    }
+
+    /**
+     * Subscribe the queue to messages from an sns topic
+     */
+    fun subscribeSns(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        sqsQueueType: SqsQueueType,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        subscribeSns(metadata, if(success) Result.Succeeded else Result.Failed, sqsQueueType, value,
                 createTime)
     }
 }
@@ -3068,4 +5874,24 @@ object ToolkitTelemetry {
             }
         }
     }
+
+    /**
+     * The Toolkit has completed initialization
+     */
+    fun init(
+        metadata: MetricEventMetadata,
+        duration: Double,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("toolkit_init") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(true)
+                metadata("duration", duration.toString())
+            }
+        }
+    }
 }
```

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

