### PR TITLE
Add new telemetry definition to understand when credentials are loaded

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -122,6 +122,11 @@
             "description": "True if turned on, false if turned off"
         },
         {
+            "name": "credentialSourceId",
+            "type": "string",
+            "description": "The ID of the source of credentials (e.g. profile)"
+        },
+        {
             "name": "credentialType",
             "type": "string",
             "description": "The type of credential that was selected",
@@ -245,6 +250,13 @@
             "name": "aws_openCredentials",
             "description": "Open the credentials file",
             "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "aws_loadCredentials",
+            "description": "Load credentials from a credential source",
+            "unit": "Count",
+            "metadata": [{ "type": "credentialSourceId" }],
+            "passive": true
         },
         {
             "name": "aws_createCredentials",


### PR DESCRIPTION
Adding a new telemetry definition around credential loading. In order to optimize certain workflows it's useful to understand how often credentials are loaded and how many credentials are present.