### PR TITLE
Remove no longer needed telemetryevent from vscode telemetry

### DIFF
--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -114,14 +114,12 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
         (item: MetadataType) => `if(args?.${item.name}) {metadata.push({Key: '${item.name}', Value: args.${item.name}.toString()})}`
     ).join('\n')}
     ext.telemetry.record({
-            data: [{
-                MetricName: '${metric.name}',
-                Value: args?.value ?? 1,
-                EpochTimestamp: (args?.createTime ?? new Date()).getTime(),
-                Unit: '${metric.unit ?? 'None'}',
-                Passive: ${metric.passive},
-                Metadata: metadata
-            }]
+            MetricName: '${metric.name}',
+            Value: args?.value ?? 1,
+            EpochTimestamp: (args?.createTime ?? new Date()).getTime(),
+            Unit: '${metric.unit ?? 'None'}',
+            Passive: ${metric.passive},
+            Metadata: metadata
         })
 }`
     })


### PR DESCRIPTION
Tested by generating telemetry and running tests in VSC
##  License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

