### PR TITLE
Stop lowercasing metadata in JetBrains telemetry

### DIFF
--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
@@ -272,7 +272,7 @@ private fun FunSpec.Builder.generateMetadataStatement(data: MetadataSchema): Fun
         data.type.name.toArgumentFormat()
     }
 
-    addStatement("metadata(%S, %L)", data.type.name.toArgumentFormat().toLowerCase(), setStatement)
+    addStatement("metadata(%S, %L)", data.type.name.toArgumentFormat(), setStatement)
     if (data.required == false) {
         endControlFlow()
     }

--- a/telemetry/jetbrains/src/test/resources/testGeneratorOutput
+++ b/telemetry/jetbrains/src/test/resources/testGeneratorOutput
@@ -52,8 +52,8 @@ object LambdaTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                metadata("lambdaruntime", lambdaRuntime.toString())
-                metadata("arbitrarystring", arbitraryString)
+                metadata("lambdaRuntime", lambdaRuntime.toString())
+                metadata("arbitraryString", arbitraryString)
             }
         }
     }
@@ -74,8 +74,8 @@ object LambdaTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(false)
-                metadata("lambdaruntime", lambdaRuntime.toString())
-                metadata("arbitrarystring", arbitraryString)
+                metadata("lambdaRuntime", lambdaRuntime.toString())
+                metadata("arbitraryString", arbitraryString)
             }
         }
     }
@@ -141,7 +141,7 @@ object LambdaTelemetry {
                 value(value)
                 passive(false)
                 if(lambdaRuntime != null) {
-                    metadata("lambdaruntime", lambdaRuntime.toString())
+                    metadata("lambdaRuntime", lambdaRuntime.toString())
                 }
                 metadata("inttype", inttype.toString())
             }
@@ -165,7 +165,7 @@ object LambdaTelemetry {
                 value(value)
                 passive(false)
                 if(lambdaRuntime != null) {
-                    metadata("lambdaruntime", lambdaRuntime.toString())
+                    metadata("lambdaRuntime", lambdaRuntime.toString())
                 }
                 metadata("inttype", inttype.toString())
             }


### PR DESCRIPTION
- This was originally added for consistency, but the other two generators do not do this, and it is not necessary to do.
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

