### PR TITLE
Updating Telemetry SDK NuGet package to use AWSSDK.Core 3.5.1.31 to match an upcoming change to the VS Toolkit

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.csproj
@@ -21,7 +21,7 @@
 		<AssemblyOriginatorKeyFile>..\toolkit-telemetry.snk</AssemblyOriginatorKeyFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AWSSDK.Core" Version="3.3.105.1" />
+		<PackageReference Include="AWSSDK.Core" Version="3.5.1.31" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="System" />

--- a/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.nuspec
+++ b/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.nuspec
@@ -14,7 +14,7 @@
     <tags>AWS AWSToolkit</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.6">
-        <dependency id="AWSSDK.Core" version="3.3.105.1" />
+        <dependency id="AWSSDK.Core" version="3.5.1.31" />
       </group>
     </dependencies>
   </metadata>

--- a/telemetry/csharp/TelemetryClient.proj
+++ b/telemetry/csharp/TelemetryClient.proj
@@ -4,7 +4,7 @@
 		<BuildRoot Condition="'$(BuildRoot)' == ''">$(MSBuildThisFileDirectory)</BuildRoot>
 
         <BuildTemp>$(BuildRoot)buildtemp\</BuildTemp>
-        <DotNetSdkTag>3.3.704.0</DotNetSdkTag>
+        <DotNetSdkTag>3.5.43.0</DotNetSdkTag>
         <DotNetSdkClone>$(BuildTemp)dotnetsdk\</DotNetSdkClone>
         <SdkGeneratorRoot>$(DotNetSdkClone)generator\</SdkGeneratorRoot>
         <SdkGenerator>$(SdkGeneratorRoot)ServiceClientGenerator\bin\Release\ServiceClientGenerator.exe</SdkGenerator>
@@ -77,6 +77,7 @@
         <ItemGroup>
             <SourceCodeExcludes Include="$(GeneratedRoot)_bcl35\**\*.*" />
             <SourceCodeExcludes Include="$(GeneratedRoot)_mobile\**\*.*" />
+            <SourceCodeExcludes Include="$(GeneratedRoot)_netstandard\**\*.*" />
 
             <SourceCode 
                 Include="$(GeneratedRoot)**\*.*" 


### PR DESCRIPTION

## Description

The VS Toolkit will update its AWS SDK references soon (based on AWSSDK.Core 3.5.1.31), this change updates the Telemetry SDK to use the same version.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

