### PR TITLE
Allow overriding existing telemetry types with the extra input files

### DIFF
--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -67,6 +67,11 @@ and change `name`, `description`, and the values in `allowedValues`
 
 Then rerun the generator. This example will generate a new type that can be imported or used in telemetry calls.
 
+### Overriding existing telemetry
+In VSCode and JetBrains, extra telemetry files will take precedence over existing definitions. For example, if you have a metric for `lambda_update`, adding another `lambda_update` in the repo's extra telemetry files will override all of the values of it.
+
+Types work similarly, and will also be overwritten by extra telemetry files.
+
 ### Editing in IDE
 
 The telemetry format comes with a json schema document [here](telemetrySchema.json) that can be loaded

--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
@@ -37,7 +37,7 @@ fun generateTelemetryFromFiles(
     defaultDefinitions: List<String> = ResourceLoader.DEFINITIONS_FILES,
     outputFolder: File
 ) {
-    val telemetry = TelemetryParser.parseFiles(inputFiles, defaultDefinitions)
+    val telemetry = TelemetryParser.parseFiles(defaultDefinitions, inputFiles)
     // make sure the output directory exists before writing to it
     outputFolder.mkdirs()
     FileSpec.builder(PACKAGE_NAME, "TelemetryDefinitions")

--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryParser.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryParser.kt
@@ -86,6 +86,12 @@ data class MetadataSchema(
 object TelemetryParser {
     private val MAPPER = jacksonObjectMapper()
 
+    /**
+     * Read in default definitions and extra definitions files, and deserialize into an object
+     *
+     * Definitions from `paths` will override definitions from defaultResourceFiles if their names
+     * are the same. This allows testing updates to existing definitions from within each IDE project.
+     */
     fun parseFiles(
         defaultResourcesFiles: List<String>,
         paths: List<File> = listOf()
@@ -101,8 +107,6 @@ object TelemetryParser {
                 it.metrics.plus(it2.metrics)
             )
         }.let {
-            // Allow read in files to overwrite default definitions. First one wins, so the extra
-            // files are read before the default resources
             TelemetryDefinition(
                 it.types.distinctBy{ t -> t.name},
                 it.metrics.distinctBy { m -> m.name }

--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryParser.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryParser.kt
@@ -87,8 +87,8 @@ object TelemetryParser {
     private val MAPPER = jacksonObjectMapper()
 
     fun parseFiles(
-        paths: List<File> = listOf(),
-        defaultResourcesFiles: List<String>
+        defaultResourcesFiles: List<String>,
+        paths: List<File> = listOf()
     ): TelemetrySchema {
         val files = paths.map { it.readText() } + defaultResourcesFiles
         val rawSchema = JSONObject(JSONTokener(ResourceLoader.SCHEMA_FILE))
@@ -99,6 +99,13 @@ object TelemetryParser {
             TelemetryDefinition(
                 it.types.plus(it2.types),
                 it.metrics.plus(it2.metrics)
+            )
+        }.let {
+            // Allow read in files to overwrite default definitions. First one wins, so the extra
+            // files are read before the default resources
+            TelemetryDefinition(
+                it.types.distinctBy{ t -> t.name},
+                it.metrics.distinctBy { m -> m.name }
             )
         }
 

--- a/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
+++ b/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -25,12 +26,17 @@ class GeneratorTest {
 
     @Test
     fun generatesWithNormalInput() {
-        testGenerator("/testGeneratorInput.json", "/testGeneratorOutput")
+        testGenerator(defaultDefinitionsFile = "/testGeneratorInput.json", expectedOutputFile = "/testGeneratorOutput")
     }
 
     @Test
     fun resultGeneratesTwoFunctions() {
-        testGenerator("/testResultInput.json", "/testResultOutput")
+        testGenerator(defaultDefinitionsFile = "/testResultInput.json", expectedOutputFile = "/testResultOutput")
+    }
+
+    @Test
+    fun generateOverrides() {
+        testGenerator(defaultDefinitionsFile = "/testResultInput.json", definitionsOverrides = listOf("/testOverrideInput.json"), expectedOutputFile = "/testOverrideOutput")
     }
 
     @Test
@@ -41,10 +47,10 @@ class GeneratorTest {
     }
 
     // inputPath and outputPath must be in test resources
-    private fun testGenerator(inputPath: String, expectedOutputFile: String) {
+    private fun testGenerator(defaultDefinitionsFile: String, definitionsOverrides: List<String> = listOf(), expectedOutputFile: String) {
         generateTelemetryFromFiles(
-            inputFiles = listOf(),
-            defaultDefinitions = listOf(this.javaClass.getResourceAsStream(inputPath).use { it.bufferedReader().readText() }),
+            defaultDefinitions = listOf(this.javaClass.getResourceAsStream(defaultDefinitionsFile).use { it.bufferedReader().readText() }),
+            inputFiles = definitionsOverrides.map { File(javaClass.getResource(it).toURI()) },
             outputFolder = folder.root
         )
 

--- a/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/ParserTest.kt
+++ b/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/ParserTest.kt
@@ -11,7 +11,6 @@ class ParserTest {
     fun typeMissingDescription() {
         assertThatThrownBy {
             TelemetryParser.parseFiles(
-                listOf(),
                 listOf(
                     """
             {
@@ -32,7 +31,7 @@ class ParserTest {
     @Test
     fun missingMetricsField() {
         assertThatThrownBy {
-            TelemetryParser.parseFiles(listOf(), listOf("""{"types": []}"""))
+            TelemetryParser.parseFiles(listOf("""{"types": []}"""))
         }.hasMessageContaining("required key [metrics] not found")
     }
 
@@ -40,7 +39,6 @@ class ParserTest {
     fun invalidDataTypes() {
         assertThatThrownBy {
             TelemetryParser.parseFiles(
-                listOf(),
                 listOf(
                     """
             {
@@ -63,7 +61,6 @@ class ParserTest {
     @Test
     fun successfulParse() {
         TelemetryParser.parseFiles(
-            listOf(),
             listOf(
                 """
             {

--- a/telemetry/jetbrains/src/test/resources/testOverrideInput.json
+++ b/telemetry/jetbrains/src/test/resources/testOverrideInput.json
@@ -1,0 +1,15 @@
+{
+  "types": [
+    {
+      "name": "result",
+      "allowedValues": ["Succeeded"],
+      "description": "The result of the operation"
+    }
+  ],
+  "metrics": [
+    {
+      "name": "metadata_hasResult",
+      "description": "It does not actually have a result, yep"
+    }
+  ]
+}

--- a/telemetry/jetbrains/src/test/resources/testOverrideOutput
+++ b/telemetry/jetbrains/src/test/resources/testOverrideOutput
@@ -1,0 +1,70 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// THIS FILE IS GENERATED! DO NOT EDIT BY HAND!
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
+
+package software.aws.toolkits.telemetry
+
+import com.intellij.openapi.project.Project
+import java.time.Instant
+import kotlin.Double
+import kotlin.String
+import kotlin.Suppress
+import software.amazon.awssdk.services.toolkittelemetry.model.Unit
+import software.aws.toolkits.jetbrains.services.telemetry.MetricEventMetadata
+import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
+
+/**
+ * The result of the operation
+ */
+enum class Result(
+    private val value: String
+) {
+    Succeeded("Succeeded"),
+
+    Unknown("unknown");
+
+    override fun toString(): String = value
+
+    companion object {
+        fun from(type: String): Result = values().firstOrNull { it.value == type } ?: Unknown
+    }
+}
+
+object MetadataTelemetry {
+    /**
+     * It does not actually have a result, yep
+     */
+    fun hasResult(
+        project: Project? = null,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(project) {
+            datum("metadata_hasResult") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+
+    /**
+     * It does not actually have a result, yep
+     */
+    fun hasResult(
+        metadata: MetricEventMetadata,
+        value: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("metadata_hasResult") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(false)
+            }
+        }
+    }
+}

--- a/telemetry/vscode/package-lock.json
+++ b/telemetry/vscode/package-lock.json
@@ -18,6 +18,12 @@
         "@types/node": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.162",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
+      "integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.11.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
@@ -170,6 +176,11 @@
         "universalify": "^1.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -239,9 +250,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
     },
     "universalify": {

--- a/telemetry/vscode/package.json
+++ b/telemetry/vscode/package.json
@@ -20,12 +20,14 @@
     "devDependencies": {
         "@types/fs-extra": "^9.0.1",
         "@types/yargs": "^15.0.7",
+        "@types/lodash": "^4.14.162",
         "ts-node": "^9.0.0",
-        "typescript": "^4.0.3"
+        "typescript": "^4.0.5"
     },
     "dependencies": {
         "ajv": "^6.12.5",
         "fs-extra": "^9.0.1",
+        "lodash": "^4.17.20",
         "prettier": "^2.1.2",
         "yargs": "^16.0.3"
     }


### PR DESCRIPTION
Allow overriding existing telemetry types with the extra input files

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

