### PR TITLE
Fix name of edit queue parameters

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -779,8 +779,8 @@
             "metadata": [{ "type": "result" }, { "type": "sqsQueueType" }]
         },
         {
-            "name": "sqs_editQueueAttributes",
-            "description": "Edit the Queue attributes",
+            "name": "sqs_editQueueParameters",
+            "description": "Edit the Queue parameters",
             "metadata": [{ "type": "result" }, { "type": "sqsQueueType" }]
         },
         {


### PR DESCRIPTION
"Queue Attributes" is not a concept in SQS, they are actually "Queue Parameters". Since the feature is not out, fix the name now

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

