### PR TITLE
Pin year of generated source

### DIFF
--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -142,7 +142,7 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
 export async function generate(args: CommandLineArguments) {
     let output = `
     /*!
-     * Copyright ${new Date().getUTCFullYear()} Amazon.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
      * SPDX-License-Identifier: Apache-2.0
      */
 

--- a/telemetry/vscode/test/resources/generatorOutput
+++ b/telemetry/vscode/test/resources/generatorOutput
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/telemetry/vscode/test/resources/generatorOverrideOutput
+++ b/telemetry/vscode/test/resources/generatorOverrideOutput
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
- The year was based on the current year so it failed tests when it became 2021
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

