### PR TITLE
Revert "Added generic version metadata to lambda_invokeLocal"

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -592,7 +592,6 @@
             "description": "Called when invoking lambdas locally (with SAM in most toolkits)",
             "metadata": [
                 { "type": "runtime", "required": false },
-                { "type": "version", "required": false },
                 { "type": "lambdaPackageType" },
                 { "type": "result" },
                 { "type": "debug" }


### PR DESCRIPTION
This reverts commit 98479d077954c22e46fde9c72c23d03e8b5c6a46.
Commit was accidentally pushed directly to master branch instead of making a PR.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

