### PR TITLE
Add generic version metadata to lambda_invokeLocal definition

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -592,6 +592,7 @@
             "description": "Called when invoking lambdas locally (with SAM in most toolkits)",
             "metadata": [
                 { "type": "runtime", "required": false },
+                { "type": "version", "required": false },
                 { "type": "lambdaPackageType" },
                 { "type": "result" },
                 { "type": "debug" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

Added an optional "version" parameter to the `lambda_invokeLocal` metadata. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Most toolkits use SAM CLI to invoke local lambda functions. Recording the SAM version used would be a helpful metric.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
