### PR TITLE
Document awsAccount and awsRegion as metrics properties; add them to C# generator

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
@@ -53,6 +53,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -93,6 +95,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -133,6 +137,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("duration", payload.Duration);
 
@@ -183,6 +189,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("duration", payload.Duration);
 
@@ -233,6 +241,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.Duration.HasValue)
                 {
@@ -295,6 +305,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
@@ -53,6 +53,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -93,6 +95,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -133,6 +137,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("duration", payload.Duration);
 
@@ -183,6 +189,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("duration", payload.Duration);
 
@@ -233,6 +241,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.Duration.HasValue)
                 {
@@ -295,6 +305,8 @@ namespace Test
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
@@ -368,6 +368,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator
             valueCond.FalseStatements.Add(new CodeAssignStatement(datumValue, new CodePrimitiveExpression(1)));
             tryStatements.Add(valueCond);
 
+            // Generate: datum.AddMetadata("awsAccount", payload.AwsAccount);
+            var payloadAwsAccount = new CodeFieldReferenceExpression(payload, "AwsAccount");
+            tryStatements.Add(new CodeExpressionStatement(new CodeMethodInvokeExpression(datumAddData,
+                new CodePrimitiveExpression("awsAccount"), payloadAwsAccount)));
+
+            // Generate: datum.AddMetadata("awsRegion", payload.AwsRegion);
+            var payloadAwsRegion = new CodeFieldReferenceExpression(payload, "AwsRegion");
+            tryStatements.Add(new CodeExpressionStatement(new CodeMethodInvokeExpression(datumAddData,
+                new CodePrimitiveExpression("awsRegion"), payloadAwsRegion)));
+
+
             // Set MetricDatum Metadata values
             metric.metadata?.ToList().ForEach(metadata =>
             {

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
@@ -52,6 +52,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -94,6 +96,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.Runtime.HasValue)
                 {
@@ -145,6 +149,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -189,6 +195,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -231,6 +239,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
@@ -273,6 +283,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
@@ -317,6 +329,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.CredentialType.HasValue)
                 {
@@ -362,6 +376,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("regionId", payload.RegionId);
 
@@ -404,6 +420,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("partitionId", payload.PartitionId);
 
@@ -446,6 +464,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -488,6 +508,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("credentialSourceId", payload.CredentialSourceId);
 
@@ -530,6 +552,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -570,6 +594,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -614,6 +640,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -661,6 +689,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -692,7 +722,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 var datum = new MetricDatum();
                 datum.MetricName = "aws_helpQuickstart";
                 datum.Unit = Unit.None;
-                datum.Passive = false;
+                datum.Passive = true;
                 if (payload.Value.HasValue)
                 {
                     datum.Value = payload.Value.Value;
@@ -701,6 +731,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -743,6 +775,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -783,6 +817,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -823,6 +859,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -863,6 +901,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -923,6 +963,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -965,6 +1007,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1007,6 +1051,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1049,6 +1095,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1091,6 +1139,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1133,6 +1183,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1180,6 +1232,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1227,6 +1281,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1269,6 +1325,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1311,6 +1369,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1353,6 +1413,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("enabled", payload.Enabled);
 
@@ -1395,6 +1457,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("enabled", payload.Enabled);
 
@@ -1437,6 +1501,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1477,6 +1543,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1517,6 +1585,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1559,6 +1629,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1601,6 +1673,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1643,6 +1717,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1689,6 +1765,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1731,6 +1809,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1773,6 +1853,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1815,6 +1897,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1857,6 +1941,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1899,6 +1985,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1941,6 +2029,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -1983,6 +2073,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2025,6 +2117,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2067,6 +2161,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2107,6 +2203,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2147,6 +2245,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2189,6 +2289,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2231,6 +2333,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2273,6 +2377,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2317,6 +2423,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2363,6 +2471,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2409,6 +2519,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2455,6 +2567,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2497,6 +2611,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2539,6 +2655,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2581,6 +2699,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2623,6 +2743,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2665,6 +2787,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("duration", payload.Duration);
 
@@ -2709,6 +2833,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2751,6 +2877,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
@@ -2793,6 +2921,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -2835,6 +2965,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.Update.HasValue)
                 {
@@ -2884,6 +3016,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.Runtime.HasValue)
                 {
@@ -2931,11 +3065,15 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.Runtime.HasValue)
                 {
                     datum.AddMetadata("runtime", payload.Runtime.Value);
                 }
+
+                datum.AddMetadata("version", payload.Version);
 
                 datum.AddMetadata("lambdaPackageType", payload.LambdaPackageType);
 
@@ -2982,6 +3120,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.Runtime.HasValue)
                 {
@@ -3029,6 +3169,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.Runtime.HasValue)
                 {
@@ -3076,6 +3218,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("lambdaPackageType", payload.LambdaPackageType);
 
@@ -3131,6 +3275,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3173,6 +3319,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3219,6 +3367,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3261,6 +3411,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3303,6 +3455,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3345,6 +3499,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3391,6 +3547,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3435,6 +3593,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3479,6 +3639,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3523,10 +3685,10 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
-
-                datum.AddMetadata("name", payload.Name);
 
                 if (payload.Runtime.HasValue)
                 {
@@ -3585,6 +3747,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3627,6 +3791,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3674,6 +3840,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3716,6 +3884,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3756,6 +3926,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3796,6 +3968,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3836,6 +4010,52 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
+
+                metrics.Data.Add(datum);
+                telemetryLogger.Record(metrics);
+            }
+            catch (System.Exception e)
+            {
+                telemetryLogger.Logger.Error("Error recording telemetry event", e);
+                System.Diagnostics.Debug.Assert(false, "Error Recording Telemetry");
+            }
+        }
+        
+        /// Records Telemetry Event:
+        /// Copy the S3 URI of a S3 object to the clipboard (e.g. s3://<bucketName>/abc.txt)
+        public static void RecordS3CopyUri(this ITelemetryLogger telemetryLogger, S3CopyUri payload)
+        {
+            try
+            {
+                var metrics = new Metrics();
+                if (payload.CreatedOn.HasValue)
+                {
+                    metrics.CreatedOn = payload.CreatedOn.Value;
+                }
+                else
+                {
+                    metrics.CreatedOn = System.DateTime.Now;
+                }
+                metrics.Data = new List<MetricDatum>();
+
+                var datum = new MetricDatum();
+                datum.MetricName = "s3_copyUri";
+                datum.Unit = Unit.None;
+                datum.Passive = false;
+                if (payload.Value.HasValue)
+                {
+                    datum.Value = payload.Value.Value;
+                }
+                else
+                {
+                    datum.Value = 1;
+                }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
+
+                datum.AddMetadata("result", payload.Result);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3876,6 +4096,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3920,6 +4142,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -3962,6 +4186,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4004,6 +4230,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4046,6 +4274,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4088,6 +4318,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4130,6 +4362,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4172,6 +4406,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4214,6 +4450,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4256,6 +4494,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4298,6 +4538,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4340,6 +4582,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4382,6 +4626,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4424,6 +4670,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("duration", payload.Duration);
 
@@ -4466,6 +4714,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
@@ -4508,6 +4758,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4555,6 +4807,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4599,6 +4853,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4643,6 +4899,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4687,6 +4945,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4731,6 +4991,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4775,6 +5037,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4819,6 +5083,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4861,6 +5127,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4903,6 +5171,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4945,6 +5215,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -4987,6 +5259,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -5029,6 +5303,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -5071,6 +5347,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -5113,6 +5391,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("insightsDialogOpenSource", payload.InsightsDialogOpenSource);
 
@@ -5155,6 +5435,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -5201,6 +5483,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -5243,6 +5527,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
 
@@ -5285,8 +5571,58 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("result", payload.Result);
+
+                metrics.Data.Add(datum);
+                telemetryLogger.Record(metrics);
+            }
+            catch (System.Exception e)
+            {
+                telemetryLogger.Logger.Error("Error recording telemetry event", e);
+                System.Diagnostics.Debug.Assert(false, "Error Recording Telemetry");
+            }
+        }
+        
+        /// Records Telemetry Event:
+        /// The toolkit tried to retrieve blob data from a url
+        public static void RecordToolkitGetExternalResource(this ITelemetryLogger telemetryLogger, ToolkitGetExternalResource payload)
+        {
+            try
+            {
+                var metrics = new Metrics();
+                if (payload.CreatedOn.HasValue)
+                {
+                    metrics.CreatedOn = payload.CreatedOn.Value;
+                }
+                else
+                {
+                    metrics.CreatedOn = System.DateTime.Now;
+                }
+                metrics.Data = new List<MetricDatum>();
+
+                var datum = new MetricDatum();
+                datum.MetricName = "toolkit_getExternalResource";
+                datum.Unit = Unit.None;
+                datum.Passive = true;
+                if (payload.Value.HasValue)
+                {
+                    datum.Value = payload.Value.Value;
+                }
+                else
+                {
+                    datum.Value = 1;
+                }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
+
+                datum.AddMetadata("url", payload.Url);
+
+                datum.AddMetadata("result", payload.Result);
+
+                datum.AddMetadata("reason", payload.Reason);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6310,6 +6646,9 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
         /// Optional - The lambda runtime
         public Runtime? Runtime;
         
+        /// Optional - A generic version metadata
+        public string Version;
+        
         /// The Lambda Package type of the function
         public LambdaPackageType LambdaPackageType;
         
@@ -6465,9 +6804,6 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
         /// The result of the operation
         public Result Result;
         
-        /// Optional - A generic name metadata
-        public string Name;
-        
         /// Optional - The lambda runtime
         public Runtime? Runtime;
         
@@ -6532,6 +6868,14 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
     /// Copy the path of a S3 object to the clipboard
     public sealed class S3CopyPath : BaseTelemetryEvent
     {
+    }
+    
+    /// Copy the S3 URI of a S3 object to the clipboard (e.g. s3://<bucketName>/abc.txt)
+    public sealed class S3CopyUri : BaseTelemetryEvent
+    {
+        
+        /// The result of the operation
+        public Result Result;
     }
     
     /// Copy the URL of a S3 object to the clipboard
@@ -6834,5 +7178,19 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
         
         /// The result of the operation
         public Result Result;
+    }
+    
+    /// The toolkit tried to retrieve blob data from a url
+    public sealed class ToolkitGetExternalResource : BaseTelemetryEvent
+    {
+        
+        /// The url associated with a metric
+        public string Url;
+        
+        /// The result of the operation
+        public Result Result;
+        
+        /// Optional - The reason for a metric or exception depending on context
+        public string Reason;
     }
 }

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
@@ -53,6 +53,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 if (payload.Runtime.HasValue)
                 {
@@ -105,6 +107,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 datum.AddMetadata("bees", payload.Bees);
 
@@ -147,6 +151,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
                 {
                     datum.Value = 1;
                 }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/GeneratedCodeTests.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/GeneratedCodeTests.cs
@@ -30,6 +30,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests
         {
             var lambdaInvokeRemote = new LambdaInvokeRemote()
             {
+                AwsAccount = "abcdacbdacbd",
+                AwsRegion = "us-region-1",
                 Result = Result.Succeeded,
                 Runtime = Runtime.Dotnetcore31,
             };
@@ -47,6 +49,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests
             Assert.Equal("lambda_invokeRemote", datum.MetricName);
             Assert.Equal(Unit.None, datum.Unit);
             Assert.False(datum.Passive);
+            Assert.Equal(lambdaInvokeRemote.AwsAccount, datum.Metadata["awsAccount"]);
+            Assert.Equal(lambdaInvokeRemote.AwsRegion, datum.Metadata["awsRegion"]);
             Assert.Equal(lambdaInvokeRemote.Runtime.Value.ToString(), datum.Metadata["runtime"]);
             Assert.Equal(lambdaInvokeRemote.Result.ToString(), datum.Metadata["result"]);
         }

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/BaseTelemetryEvent.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/BaseTelemetryEvent.cs
@@ -9,5 +9,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
     {
         public DateTime? CreatedOn;
         public double? Value;
+        public string AwsAccount;
+        public string AwsRegion;
     }
 }

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/MetadataValue.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/MetadataValue.cs
@@ -1,0 +1,21 @@
+﻿namespace Amazon.AwsToolkit.Telemetry.Events.Core
+{
+    public class MetadataValue
+    {
+        /// <summary>
+        /// Metadata property is not relevant to a metric
+        /// </summary>
+        public const string NotApplicable = "n/a";
+
+        /// <summary>
+        /// The value for a metric property has not been set
+        /// (For example, there are no active credentials, so we don't know the Account ID)
+        /// </summary>
+        public const string NotSet = "not-set";
+
+        /// <summary>
+        /// The value for a metric property could not be obtained due to error
+        /// </summary>
+        public const string Invalid = "invalid";
+    }
+}

--- a/telemetry/telemetryformat.md
+++ b/telemetry/telemetryformat.md
@@ -55,6 +55,10 @@ _Additionally_ two additional global arguments that can be appended to any gener
 createTime?: Date
 // Value based on unit and call type
 value?: number
+// The AWS Region associated with a metric
+string? awsAccount
+// The AWS Region associated with a metric
+string? awsRegion
 ```
 
 If not specified `createTime` defaults to UTC now, `value` defaults to `1.0`.
@@ -102,6 +106,10 @@ interface LambdaRemoteinvoke {
     createTime?: Date
     // Value based on unit and call type,
     value?: number
+    // The AWS Region associated with a metric
+    awsAccount?: string
+    // The AWS Region associated with a metric
+    awsRegion?: string
 }
 
 /**
@@ -118,6 +126,8 @@ export function recordLambdaRemoteinvoke(args: LambdaRemoteinvoke) {
                 Value: args?.value ?? 1,
                 Unit: 'None',
                 Metadata: [
+                    { Key: 'awsAccount', Value: args.awsAccount ?? '' },
+                    { Key: 'awsRegion', Value: args.awsRegion ?? '' },
                     { Key: 'runtime', Value: args.runtime?.toString() ?? '' },
                     { Key: 'result', Value: args.result?.toString() ?? '' }
                 ]

--- a/telemetry/telemetryformat.md
+++ b/telemetry/telemetryformat.md
@@ -55,9 +55,14 @@ _Additionally_ two additional global arguments that can be appended to any gener
 createTime?: Date
 // Value based on unit and call type
 value?: number
-// The AWS Region associated with a metric
+// The AWS account ID associated with a metric
+// If a metric is not associated with credentials: "n/a"
+// If a metric is associated with credentials, but credentials are not selected: "not-set"
+// If a metric is associated with credentials, but an account ID cannot be obtained: "invalid"
 string? awsAccount
 // The AWS Region associated with a metric
+// If a metric is not associated with a region: "n/a"
+// If a metric is associated with a region, but no region is known: "not-set"
 string? awsRegion
 ```
 
@@ -106,7 +111,7 @@ interface LambdaRemoteinvoke {
     createTime?: Date
     // Value based on unit and call type,
     value?: number
-    // The AWS Region associated with a metric
+    // The AWS account ID associated with a metric
     awsAccount?: string
     // The AWS Region associated with a metric
     awsRegion?: string

--- a/telemetry/telemetryformat.md
+++ b/telemetry/telemetryformat.md
@@ -9,7 +9,7 @@ The format is JSON object with two fields:
 ### Types
 
 _types_ is an array that holds telemetry metadata types. This is the information posted to the telemetry service like
-`isDebug` or `runtime`.  Entries can be referenced from other files. The field is optional.
+`isDebug` or `runtime`. Entries can be referenced from other files. The field is optional.
 
 ```
 "types": [
@@ -26,9 +26,9 @@ _types_ is an array that holds telemetry metadata types. This is the information
 
 ### Metrics
 
-*metrics* is an array that contains the actual metrics posted to the service. `name` defines the metric name what is
-posted to the service, `metadata` contains data from `types` that define characteristics of the telemetry beyond 
- `createTime` and a `value`. `name` must be in the format`namespace_camelCaseName` (e.g. `s3_uploadObject`). The field is optional.
+_metrics_ is an array that contains the actual metrics posted to the service. `name` defines the metric name what is
+posted to the service, `metadata` contains data from `types` that define characteristics of the telemetry beyond
+`createTime` and a `value`. `name` must be in the format`namespace_camelCaseName` (e.g. `s3_uploadObject`). The field is optional.
 
 ```
 "metrics": [
@@ -62,6 +62,7 @@ If not specified `createTime` defaults to UTC now, `value` defaults to `1.0`.
 ### Example
 
 #### Input
+
 ```json
 {
     "types": [
@@ -73,15 +74,11 @@ If not specified `createTime` defaults to UTC now, `value` defaults to `1.0`.
         {
             "name": "runtime",
             "type": "string",
-            "allowedValues": [
-                "dotnetcore2.1",
-                "...",
-                "python2.7"
-            ],
+            "allowedValues": ["dotnetcore2.1", "...", "python2.7"],
             "description": "The Lambda runtime"
         },
-    "..."
-],
+        "..."
+    ],
     "metrics": [
         {
             "name": "lambda_invokeRemote",
@@ -92,6 +89,7 @@ If not specified `createTime` defaults to UTC now, `value` defaults to `1.0`.
     ]
 }
 ```
+
 #### Output
 
 ```typescript


### PR DESCRIPTION

## Description

This change documents `awsAccount` and `awsRegion` as properties available to all metrics.

This change also updates the C# telemetry generator so that these properties are available to the VS Toolkit. I also added some constant values ("n/a", "not-set", "invalid") to have some consistency with the JetBrains implementation.

Updates to `telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs` are autogenerated and used in tests. That file is illustrative of what the generated telemetry code looks like, but also accounts for changes made to the telemetry definitions since the last time someone worked in the C# generator code.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

