### PR TITLE
Credentials and Region standardization

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -142,11 +142,6 @@
             ]
         },
         {
-            "name": "regionId",
-            "type": "string",
-            "description": "The ID of the region that was selected"
-        },
-        {
             "name": "partitionId",
             "type": "string",
             "description": "The ID of the partition that was selected"
@@ -270,7 +265,7 @@
         {
             "name": "aws_setRegion",
             "description": "A region change occurred",
-            "metadata": [{ "type": "regionId" }]
+            "metadata": []
         },
         {
             "name": "aws_setPartition",
@@ -331,7 +326,6 @@
             "description": "Called when deploying an application to Elastic Beanstalk",
             "metadata": [
                 { "type": "result" },
-                { "type": "regionId" },
                 { "type": "initialDeploy" },
                 { "type": "name", "required": false },
                 { "type": "framework", "required": false },
@@ -427,7 +421,7 @@
         {
             "name": "cloudformation_deploy",
             "description": "Called when deploying a CloudFormation template",
-            "metadata": [{ "type": "result" }, { "type": "regionId" }, { "type": "initialDeploy" }]
+            "metadata": [{ "type": "result" }, { "type": "initialDeploy" }]
         },
         {
             "name": "cloudformation_open",
@@ -517,22 +511,22 @@
         {
             "name": "ecr_deployImage",
             "description": "Called when deploying an image to ECR",
-            "metadata": [{ "type": "result" }, { "type": "regionId" }, { "type": "ecrDeploySource", "required": false }]
+            "metadata": [{ "type": "result" }, { "type": "ecrDeploySource", "required": false }]
         },
         {
             "name": "ecs_deployScheduledTask",
             "description": "Called when deploying a scheduled task to an ECS cluster",
-            "metadata": [{ "type": "result" }, { "type": "regionId" }, { "type": "ecsLaunchType" }]
+            "metadata": [{ "type": "result" }, { "type": "ecsLaunchType" }]
         },
         {
             "name": "ecs_deployService",
             "description": "Called when deploying a service to an ECS cluster",
-            "metadata": [{ "type": "result" }, { "type": "regionId" }, { "type": "ecsLaunchType" }]
+            "metadata": [{ "type": "result" }, { "type": "ecsLaunchType" }]
         },
         {
             "name": "ecs_deployTask",
             "description": "Called when deploying a task to an ECS cluster",
-            "metadata": [{ "type": "result" }, { "type": "regionId" }, { "type": "ecsLaunchType" }]
+            "metadata": [{ "type": "result" }, { "type": "ecsLaunchType" }]
         },
         {
             "name": "ecs_openRepository",
@@ -617,7 +611,6 @@
             "metadata": [
                 { "type": "lambdaPackageType" },
                 { "type": "result" },
-                { "type": "regionId" },
                 { "type": "initialDeploy" },
                 { "type": "runtime", "required": false },
                 { "type": "platform", "required": false }

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -122,7 +122,8 @@
         {
             "name": "credentialSourceId",
             "type": "string",
-            "description": "The ID of the source of credentials (e.g. profile)"
+            "description": "Where credentials are stored or retrieved from",
+            "allowedValues": ["sharedCredentials", "sdkStore", "ec2", "envVars", "other"]
         },
         {
             "name": "credentialType",
@@ -135,7 +136,6 @@
                 "assumeRoleProfile",
                 "assumeMfaRoleProfile",
                 "ssoProfile",
-                "envVars",
                 "ecsMetatdata",
                 "ec2Metadata",
                 "other"
@@ -517,11 +517,7 @@
         {
             "name": "ecr_deployImage",
             "description": "Called when deploying an image to ECR",
-            "metadata": [
-                { "type": "result" },
-                { "type": "regionId" },
-                { "type": "ecrDeploySource", "required": false }
-            ]
+            "metadata": [{ "type": "result" }, { "type": "regionId" }, { "type": "ecrDeploySource", "required": false }]
         },
         {
             "name": "ecs_deployScheduledTask",


### PR DESCRIPTION

## Description

Some changes have been made to standardize credentials and region metrics:
* credentialSourceId: changed to an enumeration, indicating where credentials were sourced from (for example shared credentials, the .NET sdk credentials store, or ec2). Previously this was a freeform string that was used inconsistently.
* credentialType: removed `envVars`, this was an eager definition entry that has been moved to credentialSourceId
* regionId: this field has been removed. The awsRegion property available to all metrics should be used in its place.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

