### PR TITLE
Revert "Bump AWSSDK.Core from 3.5.1.31 to 3.7.0.18 in /telemetry/csharp"

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.csproj
@@ -21,7 +21,7 @@
 		<AssemblyOriginatorKeyFile>..\toolkit-telemetry.snk</AssemblyOriginatorKeyFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AWSSDK.Core" Version="3.7.0.18" />
+		<PackageReference Include="AWSSDK.Core" Version="3.5.1.31" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="System" />


### PR DESCRIPTION
Reverts aws/aws-toolkit-common#135