### PR TITLE
Add SAML as a Credential Type

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -135,6 +135,7 @@
                 "credentialProcessProfile",
                 "assumeRoleProfile",
                 "assumeMfaRoleProfile",
+                "assumeSamlRoleProfile",
                 "ssoProfile",
                 "ecsMetatdata",
                 "ec2Metadata",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change adds SAML Profiles as a Credential Type.
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

