### PR TITLE
Add credential source to 'validateCredentials'

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -361,7 +361,11 @@
         {
             "name": "aws_validateCredentials",
             "description": "Validate credentials when selecting new credentials",
-            "metadata": [{ "type": "result" }, { "type": "credentialType", "required": false }],
+            "metadata": [
+                { "type": "result" }, 
+                { "type": "credentialType", "required": false }, 
+                { "type": "credentialSourceId", "required": false }
+            ],
             "passive": true
         },
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds optional metadata to `validateCredentials` to check from where the credentials came from. 

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

