### PR TITLE
Update C# telemetry readme

### DIFF
--- a/telemetry/csharp/README.md
+++ b/telemetry/csharp/README.md
@@ -6,6 +6,8 @@ This is the SDK client used by the Toolkit to send telemetry events to the backe
 
 The backend service is defined in the [service definition file](/telemetry/service/service-model.json). The [AWS SDK for .Net](https://github.com/aws/aws-sdk-net) service generator is used with the service definition file to produce SDK client code. The client code is then placed in a project (AwsToolkit.Telemtry.SDK) that is compatible for use with the Toolkit.
 
+The AWS Toolkit for Visual Studio consumes this telemetry client through a package [published to NuGet](https://www.nuget.org/packages/AWS.Toolkit.Telemetry.SDK/).
+
 To generate the client code, run:
 
 ```
@@ -41,7 +43,7 @@ See [Roadmap](#Roadmap) for future plans in this space.
 
 There are two types of telemetry definitions that serve as inputs to the code generator:
 
--   **Common Telemetry definitions** - Central definitions applied to all AWS Toolkit products. The AWS Toolkit for Visual Studio consumes these telemetry types through a central package (package not generated yet, see Roadmap). These definitions reside in [commonDefinitions.json](/telemetry/definitions/commonDefinitions.json).
+-   **Common Telemetry definitions** - Central definitions applied to all AWS Toolkit products. The AWS Toolkit for Visual Studio consumes these telemetry types through a central package that is [published to NuGet](https://www.nuget.org/packages/AWS.Toolkit.Telemetry.Events/). These definitions reside in [commonDefinitions.json](/telemetry/definitions/commonDefinitions.json).
 -   **Supplemental Telemetry definitions** - definitions that are specific to one toolkit (or not necessarily applicable to all Toolkits), or definitions that are part of a to-be-released feature which that cannot be made public yet. These definitions reside in the toolkit repo, and the generator is used to produce code that is directly integrated into the toolkit. The generated code references datatypes from the common telemetry definitions, and is expected to have access to the package mentioned above.
 
 As an example, the common telemetry definitions contains a type called `result`, which some events use in their metadata to indicate whether an operation succeeded or failed. A toolkit could have a supplemental telemetry definition which also makes use of the same `result` type. Running the generator against the supplemental definitions would not produce code for the `result` type, because it exists in the code that was produced for the common definitions.
@@ -70,14 +72,16 @@ See [Options file](AwsToolkit.Telemetry.Events.Generator/Options.cs) for details
 
 ### Integrating Generated code into the AWS Toolkit for Visual Studio
 
-This project is currently not intended to be integrated into the toolkit until packages are published. See [Roadmap](#Roadmap). The steps below are provided as a workaround.
+Common telemetry definitions can be integrated by using the NuGet package [AWS.Toolkit.Telemetry.Events](https://www.nuget.org/packages/AWS.Toolkit.Telemetry.Events/).
+
+Supplemental telemetry definitions can be integrated as follows:
 
 1. Sync this repo
-1. Build and run AwsToolkit.Telemetry
-1. Take the generated file (GeneratedCode.cs), and place it in the toolkit, as `toolkitcore/AWSToolkit.Util/Telemetry/Telemetry.generated.cs`
-1. Copy over all `Amazon.AwsToolkit.Telemetry.Events.Core` files from this repo as well.
+1. Compile the telemetry generator
+1. Run the generator, using the Toolkit's supplemental telemetry definition file(s) as command line arguments (`toolkitcore\AWSToolkit.Util\Telemetry\vs-telemetry-definitions.json`)
+1. Take the generated file(s) (GeneratedCode.cs), and place them in the toolkit (`toolkitcore\AWSToolkit.Util\Telemetry\ToolkitTelemetryEvents.generated.cs`)
 
 ## Roadmap
 
--   Standalone NuGet Packages
-    -   Produce and publish a package containing the telemetry events code generator
+-   Standalone NuGet Package containing the Telemetry Event generator
+    -   Produce and publish a package containing the telemetry events code generator, so that supplemental telemetry files can be produced without having to compile from this repo


### PR DESCRIPTION

## Description

This change updates the readme to properly reflect that there are telemetry packages available for use in the Toolkit.


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

