### PR TITLE
Add 'reason' to 'apprunner_createService'

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -280,7 +280,8 @@
             "description": "Create an App Runner service",
             "metadata": [
                 { "type": "result" },
-                { "type": "appRunnerServiceSource" }
+                { "type": "appRunnerServiceSource" },
+                { "type": "reason", "required": false }
             ]
         },
         {


### PR DESCRIPTION
Adds the `reason` field so we can dig deeper into issues. Currently does not mean much for JB since the failures would be from bad API calls 99.9% of the time, but for VS Code this field will allow us to differentiate between failures due to API calls vs. failures due to mis-configuration.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

