### PR TITLE
Add record overloads for JetBrains that take ConnectionSettings

### DIFF
--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
@@ -24,6 +24,7 @@ const val JETBRAINS_TELEMETRY_PACKAGE_NAME = "software.aws.toolkits.jetbrains.se
 val METRIC_METADATA = ClassName(JETBRAINS_TELEMETRY_PACKAGE_NAME, "MetricEventMetadata")
 val TELEMETRY_SERVICE = ClassName(JETBRAINS_TELEMETRY_PACKAGE_NAME, "TelemetryService")
 val PROJECT = ClassName("com.intellij.openapi.project", "Project").copy(nullable = true)
+val CONNECTION_SETTINGS = ClassName("software.aws.toolkits.jetbrains.core.credentials", "ConnectionSettings").copy(nullable = true)
 
 const val RESULT = "result"
 const val SUCCESS = "success"
@@ -140,6 +141,7 @@ private fun TypeSpec.Builder.generateRecordFunctions(metric: MetricSchema) {
     val functionName = metric.name.split("_")[1]
 
     addFunction(buildProjectFunction(functionName, metric))
+    addFunction(buildConnectionSettingsFunction(functionName, metric))
     addFunction(buildMetricMetadataFunction(functionName, metric))
 
     // Result is special cased to generate a function that accepts true/false instead of a Result
@@ -148,11 +150,18 @@ private fun TypeSpec.Builder.generateRecordFunctions(metric: MetricSchema) {
     }
 
     addFunction(buildProjectOverloadFunction(functionName, metric))
+    addFunction(buildConnectionSettingsOverloadFunction(functionName, metric))
     addFunction(buildMetricMetadataOverloadFunction(functionName, metric))
 }
 
 fun buildProjectFunction(functionName: String, metric: MetricSchema): FunSpec {
-    val metadataProvider = ParameterSpec.builder("project", PROJECT).defaultValue("null").build()
+    val metadataProvider = ParameterSpec.builder("project", PROJECT).build()
+
+    return buildRecordFunction(metadataProvider, functionName, metric)
+}
+
+fun buildConnectionSettingsFunction(functionName: String, metric: MetricSchema): FunSpec {
+    val metadataProvider = ParameterSpec.builder("connectionSettings", CONNECTION_SETTINGS).defaultValue("null").build()
 
     return buildRecordFunction(metadataProvider, functionName, metric)
 }
@@ -221,6 +230,11 @@ private fun FunSpec.Builder.generateFunctionBody(metadataParameter: ParameterSpe
 fun buildProjectOverloadFunction(functionName: String, metric: MetricSchema): FunSpec {
     val metadataProvider = ParameterSpec.builder("project", PROJECT).defaultValue("null").build()
 
+    return buildResultOverloadFunction(metadataProvider, functionName, metric)
+}
+
+fun buildConnectionSettingsOverloadFunction(functionName: String, metric: MetricSchema): FunSpec {
+    val metadataProvider = ParameterSpec.builder("connectionSettings", CONNECTION_SETTINGS).defaultValue("null").build()
     return buildResultOverloadFunction(metadataProvider, functionName, metric)
 }
 

--- a/telemetry/jetbrains/src/test/resources/testGeneratorOutput
+++ b/telemetry/jetbrains/src/test/resources/testGeneratorOutput
@@ -13,6 +13,7 @@ import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
+import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
 import software.aws.toolkits.jetbrains.services.telemetry.MetricEventMetadata
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 
@@ -40,7 +41,7 @@ public object LambdaTelemetry {
      * called when creating lambdas remotely
      */
     public fun create(
-        project: Project? = null,
+        project: Project?,
         lambdaRuntime: LambdaRuntime,
         arbitraryString: String,
         passive: Boolean = false,
@@ -48,6 +49,29 @@ public object LambdaTelemetry {
         createTime: Instant = Instant.now()
     ): Unit {
         TelemetryService.getInstance().record(project) {
+            datum("lambda_create") {
+                createTime(createTime)
+                unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
+                value(value)
+                passive(passive)
+                metadata("lambdaRuntime", lambdaRuntime.toString())
+                metadata("arbitraryString", arbitraryString)
+            }
+        }
+    }
+
+    /**
+     * called when creating lambdas remotely
+     */
+    public fun create(
+        connectionSettings: ConnectionSettings? = null,
+        lambdaRuntime: LambdaRuntime,
+        arbitraryString: String,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ): Unit {
+        TelemetryService.getInstance().record(connectionSettings) {
             datum("lambda_create") {
                 createTime(createTime)
                 unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
@@ -86,7 +110,7 @@ public object LambdaTelemetry {
      * called when deleting lambdas remotely
      */
     public fun delete(
-        project: Project? = null,
+        project: Project?,
         duration: Double,
         booltype: Boolean,
         passive: Boolean = false,
@@ -94,6 +118,29 @@ public object LambdaTelemetry {
         createTime: Instant = Instant.now()
     ): Unit {
         TelemetryService.getInstance().record(project) {
+            datum("lambda_delete") {
+                createTime(createTime)
+                unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
+                value(value)
+                passive(passive)
+                metadata("duration", duration.toString())
+                metadata("booltype", booltype.toString())
+            }
+        }
+    }
+
+    /**
+     * called when deleting lambdas remotely
+     */
+    public fun delete(
+        connectionSettings: ConnectionSettings? = null,
+        duration: Double,
+        booltype: Boolean,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ): Unit {
+        TelemetryService.getInstance().record(connectionSettings) {
             datum("lambda_delete") {
                 createTime(createTime)
                 unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
@@ -132,7 +179,7 @@ public object LambdaTelemetry {
      * called when invoking lambdas remotely
      */
     public fun remoteinvoke(
-        project: Project? = null,
+        project: Project?,
         lambdaRuntime: LambdaRuntime? = null,
         inttype: Int,
         passive: Boolean = false,
@@ -140,6 +187,31 @@ public object LambdaTelemetry {
         createTime: Instant = Instant.now()
     ): Unit {
         TelemetryService.getInstance().record(project) {
+            datum("lambda_remoteinvoke") {
+                createTime(createTime)
+                unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
+                value(value)
+                passive(passive)
+                if(lambdaRuntime != null) {
+                    metadata("lambdaRuntime", lambdaRuntime.toString())
+                }
+                metadata("inttype", inttype.toString())
+            }
+        }
+    }
+
+    /**
+     * called when invoking lambdas remotely
+     */
+    public fun remoteinvoke(
+        connectionSettings: ConnectionSettings? = null,
+        lambdaRuntime: LambdaRuntime? = null,
+        inttype: Int,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ): Unit {
+        TelemetryService.getInstance().record(connectionSettings) {
             datum("lambda_remoteinvoke") {
                 createTime(createTime)
                 unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
@@ -184,12 +256,31 @@ public object NoTelemetry {
      * called when invoking lambdas remotely
      */
     public fun metadata(
-        project: Project? = null,
+        project: Project?,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now()
     ): Unit {
         TelemetryService.getInstance().record(project) {
+            datum("no_metadata") {
+                createTime(createTime)
+                unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
+                value(value)
+                passive(passive)
+            }
+        }
+    }
+
+    /**
+     * called when invoking lambdas remotely
+     */
+    public fun metadata(
+        connectionSettings: ConnectionSettings? = null,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ): Unit {
+        TelemetryService.getInstance().record(connectionSettings) {
             datum("no_metadata") {
                 createTime(createTime)
                 unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
@@ -224,12 +315,31 @@ public object PassiveTelemetry {
      * a passive metric
      */
     public fun passive(
-        project: Project? = null,
+        project: Project?,
         passive: Boolean = true,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now()
     ): Unit {
         TelemetryService.getInstance().record(project) {
+            datum("passive_passive") {
+                createTime(createTime)
+                unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
+                value(value)
+                passive(passive)
+            }
+        }
+    }
+
+    /**
+     * a passive metric
+     */
+    public fun passive(
+        connectionSettings: ConnectionSettings? = null,
+        passive: Boolean = true,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ): Unit {
+        TelemetryService.getInstance().record(connectionSettings) {
             datum("passive_passive") {
                 createTime(createTime)
                 unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)

--- a/telemetry/jetbrains/src/test/resources/testOverrideOutput
+++ b/telemetry/jetbrains/src/test/resources/testOverrideOutput
@@ -12,6 +12,7 @@ import kotlin.Double
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
+import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
 import software.aws.toolkits.jetbrains.services.telemetry.MetricEventMetadata
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 
@@ -37,12 +38,31 @@ public object MetadataTelemetry {
      * It does not actually have a result, yep
      */
     public fun hasResult(
-        project: Project? = null,
+        project: Project?,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now()
     ): Unit {
         TelemetryService.getInstance().record(project) {
+            datum("metadata_hasResult") {
+                createTime(createTime)
+                unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
+                value(value)
+                passive(passive)
+            }
+        }
+    }
+
+    /**
+     * It does not actually have a result, yep
+     */
+    public fun hasResult(
+        connectionSettings: ConnectionSettings? = null,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ): Unit {
+        TelemetryService.getInstance().record(connectionSettings) {
             datum("metadata_hasResult") {
                 createTime(createTime)
                 unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)

--- a/telemetry/jetbrains/src/test/resources/testResultOutput
+++ b/telemetry/jetbrains/src/test/resources/testResultOutput
@@ -12,6 +12,7 @@ import kotlin.Double
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
+import software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings
 import software.aws.toolkits.jetbrains.services.telemetry.MetricEventMetadata
 import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
 
@@ -42,13 +43,34 @@ public object MetadataTelemetry {
      * It has a result
      */
     public fun hasResult(
-        project: Project? = null,
+        project: Project?,
         result: Result,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now()
     ): Unit {
         TelemetryService.getInstance().record(project) {
+            datum("metadata_hasResult") {
+                createTime(createTime)
+                unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
+                value(value)
+                passive(passive)
+                metadata("result", result.toString())
+            }
+        }
+    }
+
+    /**
+     * It has a result
+     */
+    public fun hasResult(
+        connectionSettings: ConnectionSettings? = null,
+        result: Result,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ): Unit {
+        TelemetryService.getInstance().record(connectionSettings) {
             datum("metadata_hasResult") {
                 createTime(createTime)
                 unit(software.amazon.awssdk.services.toolkittelemetry.model.Unit.NONE)
@@ -92,6 +114,20 @@ public object MetadataTelemetry {
     ): Unit {
         hasResult(project, if(success) Result.Succeeded else Result.Failed, passive, value,
                 createTime)
+    }
+
+    /**
+     * It has a result
+     */
+    public fun hasResult(
+        connectionSettings: ConnectionSettings? = null,
+        success: Boolean,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now()
+    ): Unit {
+        hasResult(connectionSettings, if(success) Result.Succeeded else Result.Failed, passive,
+                value, createTime)
     }
 
     /**


### PR DESCRIPTION
Often we want to record metrics when we don't have an instance of `com.intellij.openapi.project.Project`; the `Project` is predominately used to determine the "current account / region" - this same information can be obtained from the `software.aws.toolkits.jetbrains.core.credentials.ConnectionSettings` themselves.