### PR TITLE
Modify s3_deleteObject and remove s3_deleteObjects

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -887,7 +887,7 @@
         },
         {
             "name": "s3_deleteObject",
-            "description": "Delete a single S3 object",
+            "description": "Delete S3 object(s)",
             "metadata": [
                 { "type": "result" },
                 { "type": "successCount", "required": false},
@@ -901,7 +901,7 @@
         },
         {
             "name": "s3_downloadObject",
-            "description": "Download a single S3 object",
+            "description": "Download S3 object(s)",
             "metadata": [
                 { "type": "result" },
                 { "type": "successCount", "required": false},
@@ -917,7 +917,7 @@
         },
         {
             "name": "s3_uploadObject",
-            "description": "Upload a single S3 object",
+            "description": "Upload S3 object(s)",
             "metadata": [
                 { "type": "result" },
                 { "type": "successCount", "required": false},

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -904,6 +904,8 @@
             "description": "Download a single S3 object",
             "metadata": [
                 { "type": "result" },
+                { "type": "successCount", "required": false},
+                { "type": "failedCount", "required": false},
                 { "type": "component", "required": false}
             ]
         },
@@ -918,6 +920,8 @@
             "description": "Upload a single S3 object",
             "metadata": [
                 { "type": "result" },
+                { "type": "successCount", "required": false},
+                { "type": "failedCount", "required": false},
                 { "type": "component", "required": false}
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -280,12 +280,12 @@
         },
         {
             "name": "successCount",
-            "type": "double",
+            "type": "int",
             "description": "The number of successful operations"
         },
         {
             "name": "failedCount",
-            "type": "double",
+            "type": "int",
             "description": "The number of failed operations"
         }
     ],

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -277,6 +277,16 @@
             "type": "string",
             "description": "The tool being installed",
             "allowedValues": ["session-manager-plugin", "dotnet-lambda-deploy", "dotnet-deploy-cli"]
+        },
+        {
+            "name": "successCount",
+            "type": "double",
+            "description": "The number of successful operations"
+        },
+        {
+            "name": "failedCount",
+            "type": "double",
+            "description": "The number of failed operations"
         }
     ],
     "metrics": [
@@ -878,12 +888,11 @@
         {
             "name": "s3_deleteObject",
             "description": "Delete a single S3 object",
-            "metadata": [{ "type": "result" }]
-        },
-        {
-            "name": "s3_deleteObjects",
-            "description": "Delete multiple S3 objects",
-            "metadata": [{ "type": "result" }]
+            "metadata": [
+                { "type": "result" },
+                { "type": "successCount", "required": false},
+                { "type": "failedCount", "required": false}
+            ]
         },
         {
             "name": "s3_createFolder",


### PR DESCRIPTION
Modify s3_deleteObject and remove s3_deleteObjects
- adds successCount and failedCount metadata to bulk s3 operations
- migrating away from plural metric names for bulk s3 operations (does not affect existing code)

This is an approach to simplify emitting bulk operation metrics - if we like this approach, we can do this to more metrics in the future.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

