### PR TITLE
vscode: update codegen to use `globals` instead of `ext`

### DIFF
--- a/telemetry/telemetryformat.md
+++ b/telemetry/telemetryformat.md
@@ -123,8 +123,8 @@ interface LambdaRemoteinvoke {
  * @returns Nothing
  */
 export function recordLambdaRemoteinvoke(args: LambdaRemoteinvoke) {
-    ext.telemetry.record({
-        createTime: args?.createTime ?? new Date(),
+    globals.telemetry.record({
+        createTime: args?.createTime ?? new globals.clock.Date(),
         data: [
             {
                 MetricName: 'lambda_invokeRemote',

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -127,10 +127,10 @@ export function generateTelemetry(telemetryJson: MetricDefinitionRoot): string {
                 `if(args?.${item.name}) {metadata.push({Key: '${item.name}', Value: args.${item.name}.toString()})}`
         )
         .join('\n')}
-    ext.telemetry.record({
+        globals.telemetry.record({
             MetricName: '${metric.name}',
             Value: args?.value ?? 1,
-            EpochTimestamp: (args?.createTime ?? new Date()).getTime(),
+            EpochTimestamp: (args?.createTime ?? new globals.clock.Date()).getTime(),
             Unit: '${metric.unit ?? 'None'}',
             Passive: args?.passive ?? ${metric.passive},
             Metadata: metadata
@@ -148,7 +148,7 @@ export async function generate(args: CommandLineArguments) {
      * SPDX-License-Identifier: Apache-2.0
      */
 
-    import { ext } from '../extensionGlobals'
+    import globals from '../extensionGlobals'
     `
 
     const rawDefinitions: MetricDefinitionRoot = args.inputFiles
@@ -185,7 +185,7 @@ export function generateHelperFunctions(): string {
     return `
 
 export function millisecondsSince(d: Date): number {
-    return Date.now() - Number(d)
+    return globals.clock.Date.now() - Number(d)
 }
 `
 }

--- a/telemetry/vscode/test/resources/generatorOutput
+++ b/telemetry/vscode/test/resources/generatorOutput
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ext } from '../extensionGlobals'
+import globals from '../extensionGlobals'
 export type LambdaRuntime = 'dotnetcore2.1' | 'nodejs12.x'
 interface LambdaDelete {
     // The duration of the operation in miliseconds
@@ -30,10 +30,10 @@ export function recordLambdaDelete(args: LambdaDelete) {
     if (args?.booltype) {
         metadata.push({ Key: 'booltype', Value: args.booltype.toString() })
     }
-    ext.telemetry.record({
+    globals.telemetry.record({
         MetricName: 'lambda_delete',
         Value: args?.value ?? 1,
-        EpochTimestamp: (args?.createTime ?? new Date()).getTime(),
+        EpochTimestamp: (args?.createTime ?? new globals.clock.Date()).getTime(),
         Unit: 'None',
         Passive: args?.passive ?? undefined,
         Metadata: metadata,
@@ -64,10 +64,10 @@ export function recordLambdaCreate(args: LambdaCreate) {
     if (args?.arbitraryString) {
         metadata.push({ Key: 'arbitraryString', Value: args.arbitraryString.toString() })
     }
-    ext.telemetry.record({
+    globals.telemetry.record({
         MetricName: 'lambda_create',
         Value: args?.value ?? 1,
-        EpochTimestamp: (args?.createTime ?? new Date()).getTime(),
+        EpochTimestamp: (args?.createTime ?? new globals.clock.Date()).getTime(),
         Unit: 'None',
         Passive: args?.passive ?? undefined,
         Metadata: metadata,
@@ -98,10 +98,10 @@ export function recordLambdaRemoteinvoke(args: LambdaRemoteinvoke) {
     if (args?.inttype) {
         metadata.push({ Key: 'inttype', Value: args.inttype.toString() })
     }
-    ext.telemetry.record({
+    globals.telemetry.record({
         MetricName: 'lambda_remoteinvoke',
         Value: args?.value ?? 1,
-        EpochTimestamp: (args?.createTime ?? new Date()).getTime(),
+        EpochTimestamp: (args?.createTime ?? new globals.clock.Date()).getTime(),
         Unit: 'None',
         Passive: args?.passive ?? undefined,
         Metadata: metadata,
@@ -123,10 +123,10 @@ interface NoMetadata {
 export function recordNoMetadata(args?: NoMetadata) {
     let metadata: any[] = []
 
-    ext.telemetry.record({
+    globals.telemetry.record({
         MetricName: 'no_metadata',
         Value: args?.value ?? 1,
-        EpochTimestamp: (args?.createTime ?? new Date()).getTime(),
+        EpochTimestamp: (args?.createTime ?? new globals.clock.Date()).getTime(),
         Unit: 'None',
         Passive: args?.passive ?? undefined,
         Metadata: metadata,
@@ -148,10 +148,10 @@ interface PassivePassive {
 export function recordPassivePassive(args?: PassivePassive) {
     let metadata: any[] = []
 
-    ext.telemetry.record({
+    globals.telemetry.record({
         MetricName: 'passive_passive',
         Value: args?.value ?? 1,
-        EpochTimestamp: (args?.createTime ?? new Date()).getTime(),
+        EpochTimestamp: (args?.createTime ?? new globals.clock.Date()).getTime(),
         Unit: 'None',
         Passive: args?.passive ?? true,
         Metadata: metadata,
@@ -159,5 +159,5 @@ export function recordPassivePassive(args?: PassivePassive) {
 }
 
 export function millisecondsSince(d: Date): number {
-    return Date.now() - Number(d)
+    return globals.clock.Date.now() - Number(d)
 }

--- a/telemetry/vscode/test/resources/generatorOverrideOutput
+++ b/telemetry/vscode/test/resources/generatorOverrideOutput
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ext } from '../extensionGlobals'
+import globals from '../extensionGlobals'
 export type Result = 'Succeeded'
 interface MetadataHasResult {
     // The time that the event took place,
@@ -21,10 +21,10 @@ interface MetadataHasResult {
 export function recordMetadataHasResult(args?: MetadataHasResult) {
     let metadata: any[] = []
 
-    ext.telemetry.record({
+    globals.telemetry.record({
         MetricName: 'metadata_hasResult',
         Value: args?.value ?? 1,
-        EpochTimestamp: (args?.createTime ?? new Date()).getTime(),
+        EpochTimestamp: (args?.createTime ?? new globals.clock.Date()).getTime(),
         Unit: 'None',
         Passive: args?.passive ?? undefined,
         Metadata: metadata,
@@ -32,5 +32,5 @@ export function recordMetadataHasResult(args?: MetadataHasResult) {
 }
 
 export function millisecondsSince(d: Date): number {
-    return Date.now() - Number(d)
+    return globals.clock.Date.now() - Number(d)
 }


### PR DESCRIPTION
Just renaming the import and using a scoped-down form of `Date`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

