### PR TITLE
Add open url metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -433,6 +433,11 @@
             "metadata": [{ "type": "result" }]
         },
         {
+            "name": "aws_openUrl",
+            "description": "Opens a url",
+            "metadata": [{ "type": "result" }, { "type": "url", "required": false }]
+        },
+        {
             "name": "aws_saveCredentials",
             "description": "Save credentials"
         },


### PR DESCRIPTION

This change adds a metric we can use to associate with informational links that are opened from the Toolkit.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

