### PR TITLE
Update C# Packages to .NET Framework 4.7.2

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/AwsToolkit.Telemetry.Events.Generator.Tests.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/AwsToolkit.Telemetry.Events.Generator.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/AwsToolkit.Telemetry.Events.Tests.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/AwsToolkit.Telemetry.Events.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/AwsToolkit.Telemetry.Events.Tests.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/AwsToolkit.Telemetry.Events.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net46</TargetFramework>
+		<TargetFramework>net472</TargetFramework>
 		<RootNamespace>Amazon.AwsToolkit.Telemetry.Events.Tests</RootNamespace>
 		<Optimize>false</Optimize>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net46</TargetFramework>
+		<TargetFramework>net472</TargetFramework>
 		<RootNamespace>Amazon.AwsToolkit.Telemetry.Events</RootNamespace>
 		<AssemblyName>Amazon.AwsToolkit.Telemetry.Events</AssemblyName>
 		<PackageId>AWS.Toolkit.Telemetry.Events</PackageId>

--- a/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.csproj
@@ -5,7 +5,7 @@
 		<RootNamespace>Amazon.AwsToolkit.Telemetry.SDK</RootNamespace>
 		<AssemblyName>Amazon.AwsToolkit.Telemetry.SDK</AssemblyName>
 		<PackageId>AWS.Toolkit.Telemetry.SDK</PackageId>
-		<TargetFramework>net46</TargetFramework>
+		<TargetFramework>net472</TargetFramework>
 		<Authors>Amazon Web Services</Authors>
 		<Company>Amazon Web Services</Company>
 		<Product>AWS Toolkit Telemetry</Product>

--- a/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.nuspec
+++ b/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.nuspec
@@ -13,7 +13,7 @@
     <copyright>$copyright$</copyright>
     <tags>AWS AWSToolkit</tags>
     <dependencies>
-      <group targetFramework=".NETFramework4.6">
+      <group targetFramework="net472">
         <dependency id="AWSSDK.Core" version="3.5.1.31" />
       </group>
     </dependencies>


### PR DESCRIPTION

.NET Framework 4.6 is out of support, and the Toolkit is being updated to target 4.7.2. This change updates the Telemetry packages to target 4.7.2, so that we can continue to update referenced packages (which are starting to require 4.7.2 at a minimum).

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

