### PR TITLE
Add dotnet6 lambda runtime

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
@@ -6981,6 +6981,55 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
         }
         
         /// Records Telemetry Event:
+        /// Create an SNS Topic
+        public static void RecordSnsCreateTopic(this ITelemetryLogger telemetryLogger, SnsCreateTopic payload, Func<MetricDatum, MetricDatum> transformDatum = null)
+        {
+            try
+            {
+                var metrics = new Metrics();
+                if (payload.CreatedOn.HasValue)
+                {
+                    metrics.CreatedOn = payload.CreatedOn.Value;
+                }
+                else
+                {
+                    metrics.CreatedOn = System.DateTime.Now;
+                }
+                metrics.Data = new List<MetricDatum>();
+
+                var datum = new MetricDatum();
+                datum.MetricName = "sns_createTopic";
+                datum.Unit = Unit.None;
+                datum.Passive = payload.Passive;
+                if (payload.Value.HasValue)
+                {
+                    datum.Value = payload.Value.Value;
+                }
+                else
+                {
+                    datum.Value = 1;
+                }
+                datum.AddMetadata("awsAccount", payload.AwsAccount);
+                datum.AddMetadata("awsRegion", payload.AwsRegion);
+
+                datum.AddMetadata("result", payload.Result);
+
+                if ((transformDatum != null))
+                {
+                    datum = transformDatum.Invoke(datum);
+                }
+
+                metrics.Data.Add(datum);
+                telemetryLogger.Record(metrics);
+            }
+            catch (System.Exception e)
+            {
+                telemetryLogger.Logger.Error("Error recording telemetry event", e);
+                System.Diagnostics.Debug.Assert(false, "Error Recording Telemetry");
+            }
+        }
+        
+        /// Records Telemetry Event:
         /// Open a window to view details of SNS Topic
         public static void RecordSnsOpenTopic(this ITelemetryLogger telemetryLogger, SnsOpenTopic payload, Func<MetricDatum, MetricDatum> transformDatum = null)
         {
@@ -8239,6 +8288,9 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
         
         /// dotnet5.0
         public static readonly Runtime Dotnet50 = new Runtime("dotnet5.0");
+        
+        /// dotnet6.0
+        public static readonly Runtime Dotnet60 = new Runtime("dotnet6.0");
         
         /// nodejs14.x
         public static readonly Runtime Nodejs14x = new Runtime("nodejs14.x");
@@ -10771,6 +10823,19 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
         public SqsQueueType SqsQueueType;
         
         public SqsPurgeQueue()
+        {
+            this.Passive = false;
+        }
+    }
+    
+    /// Create an SNS Topic
+    public sealed class SnsCreateTopic : BaseTelemetryEvent
+    {
+        
+        /// The result of the operation
+        public Result Result;
+        
+        public SnsCreateTopic()
         {
             this.Passive = false;
         }

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
@@ -8289,8 +8289,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
         /// dotnet5.0
         public static readonly Runtime Dotnet50 = new Runtime("dotnet5.0");
         
-        /// dotnet6.0
-        public static readonly Runtime Dotnet60 = new Runtime("dotnet6.0");
+        /// dotnet6
+        public static readonly Runtime Dotnet6 = new Runtime("dotnet6");
         
         /// nodejs14.x
         public static readonly Runtime Nodejs14x = new Runtime("nodejs14.x");

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -95,7 +95,7 @@
                 "dotnetcore3.1",
                 "dotnetcore2.1",
                 "dotnet5.0",
-                "dotnet6.0",
+                "dotnet6",
                 "nodejs14.x",
                 "nodejs12.x",
                 "nodejs10.x",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -95,6 +95,7 @@
                 "dotnetcore3.1",
                 "dotnetcore2.1",
                 "dotnet5.0",
+                "dotnet6.0",
                 "nodejs14.x",
                 "nodejs12.x",
                 "nodejs10.x",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds .NET 6 as a Lambda runtime.
Also updates generated code with latest definitions.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

