### PR TITLE
telemetry: lift definitions out of aws-toolkit-vscode

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -66,9 +66,14 @@
             "description": "The Lambda Package type of the function"
         },
         {
+            "name": "architecture",
+            "allowedValues": ["x86_64", "arm64"],
+            "description": "DEPRECATED. Use lambdaArchitecture instead."
+        },
+        {
             "name": "lambdaArchitecture",
             "allowedValues": ["x86_64", "arm64"],
-            "description": "The Lambda Architecture of the function"
+            "description": "Lambda architecture identifier"
         },
         {
             "name": "serviceType",
@@ -379,7 +384,9 @@
                 { "type": "runtime", "required": false },
                 { "type": "httpMethod", "required": false },
                 { "type": "result" },
-                { "type": "debug" }
+                { "type": "debug" },
+                { "type": "architecture", "required": false },
+                { "type": "lambdaArchitecture", "required": false }
             ]
         },
         {
@@ -959,7 +966,9 @@
                 { "type": "version", "required": false },
                 { "type": "lambdaPackageType" },
                 { "type": "result" },
-                { "type": "debug" }
+                { "type": "debug" },
+                { "type": "architecture", "required": false },
+                { "type": "lambdaArchitecture", "required": false }
             ]
         },
         {
@@ -1047,7 +1056,9 @@
                 { "type": "version", "required": false },
                 { "type": "lambdaPackageType", "required": false },
                 { "type": "reason", "required": false },
-                { "type": "eventBridgeSchema", "required": false }
+                { "type": "eventBridgeSchema", "required": false },
+                { "type": "architecture", "required": false },
+                { "type": "lambdaArchitecture", "required": false }
             ]
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -66,11 +66,6 @@
             "description": "The Lambda Package type of the function"
         },
         {
-            "name": "architecture",
-            "allowedValues": ["x86_64", "arm64"],
-            "description": "DEPRECATED. Use lambdaArchitecture instead."
-        },
-        {
             "name": "lambdaArchitecture",
             "allowedValues": ["x86_64", "arm64"],
             "description": "Lambda architecture identifier"
@@ -385,7 +380,6 @@
                 { "type": "httpMethod", "required": false },
                 { "type": "result" },
                 { "type": "debug" },
-                { "type": "architecture", "required": false },
                 { "type": "lambdaArchitecture", "required": false }
             ]
         },
@@ -967,7 +961,6 @@
                 { "type": "lambdaPackageType" },
                 { "type": "result" },
                 { "type": "debug" },
-                { "type": "architecture", "required": false },
                 { "type": "lambdaArchitecture", "required": false }
             ]
         },
@@ -1057,7 +1050,6 @@
                 { "type": "lambdaPackageType", "required": false },
                 { "type": "reason", "required": false },
                 { "type": "eventBridgeSchema", "required": false },
-                { "type": "architecture", "required": false },
                 { "type": "lambdaArchitecture", "required": false }
             ]
         },

--- a/telemetry/definitions/vscodeDefinitions.json
+++ b/telemetry/definitions/vscodeDefinitions.json
@@ -62,7 +62,6 @@
                 { "type": "runtime" },
                 { "type": "attempts" },
                 { "type": "duration" },
-                { "type": "architecture", "required": false },
                 { "type": "lambdaArchitecture", "required": false }
             ]
         },

--- a/telemetry/definitions/vscodeDefinitions.json
+++ b/telemetry/definitions/vscodeDefinitions.json
@@ -56,7 +56,14 @@
         {
             "name": "sam_attachDebugger",
             "description": "Called after trying to attach a debugger to a local sam invoke",
-            "metadata": [{ "type": "result" }, { "type": "lambdaPackageType" }, { "type": "runtime" }, { "type": "attempts" }, { "type": "duration" }]
+            "metadata": [
+                { "type": "result" },
+                { "type": "lambdaPackageType" },
+                { "type": "runtime" },
+                { "type": "attempts" },
+                { "type": "duration" },
+                { "type": "lambdaArchitecture", "required": false }
+            ]
         },
         {
             "name": "sam_openConfigUi",

--- a/telemetry/definitions/vscodeDefinitions.json
+++ b/telemetry/definitions/vscodeDefinitions.json
@@ -62,6 +62,7 @@
                 { "type": "runtime" },
                 { "type": "attempts" },
                 { "type": "duration" },
+                { "type": "architecture", "required": false },
                 { "type": "lambdaArchitecture", "required": false }
             ]
         },


### PR DESCRIPTION
- ~~BREAKING CHANGE: rename `lambdaArchitecture` to `architecture`~~
- Lift vscode metrics defs from https://github.com/aws/aws-toolkit-vscode/pull/2102
- Backwards-compatible change: add redundant `lambdaArchitecture` field to metrics with `architecture` field

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

