### PR TITLE
Fix Kotlin generator with long enum names where new lines are placed …

### DIFF
--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
@@ -106,7 +106,7 @@ private fun FileSpec.Builder.generateTelemetryEnumType(item: TelemetryMetricType
             FunSpec.builder("from")
                 .returns(ClassName("", item.name.toTypeFormat()))
                 .addParameter("type", String::class)
-                .addStatement("return values().firstOrNull { it.value == type } ?: $unknownType")
+                .addStatement("return values().firstOrNull·{·it.value·==·type·} ?:·$unknownType")
                 .build()
         )
         .build()

--- a/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
+++ b/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
@@ -40,6 +40,11 @@ class GeneratorTest {
     }
 
     @Test
+    fun longEnum() {
+        testGenerator(defaultDefinitionsFile = "/testLongEnumInput.json", expectedOutputFile = "/testLongEnumOutput")
+    }
+
+    @Test
     fun generateGeneratesWithDefaultDefinitions() {
         generateTelemetryFromFiles(inputFiles = listOf(), outputFolder = folder.root)
         val outputFile = Paths.get(folder.root.absolutePath, "software", "aws", "toolkits", "telemetry", "TelemetryDefinitions.kt")

--- a/telemetry/jetbrains/src/test/resources/testGeneratorOutput
+++ b/telemetry/jetbrains/src/test/resources/testGeneratorOutput
@@ -31,8 +31,8 @@ public enum class LambdaRuntime(
     public override fun toString(): String = value
 
     public companion object {
-        public fun from(type: String): LambdaRuntime = values().firstOrNull { it.value == type } ?:
-                Unknown
+        public fun from(type: String): LambdaRuntime = values().firstOrNull { it.value == type }
+                ?: Unknown
     }
 }
 

--- a/telemetry/jetbrains/src/test/resources/testLongEnumInput.json
+++ b/telemetry/jetbrains/src/test/resources/testLongEnumInput.json
@@ -1,0 +1,10 @@
+{
+    "types": [
+        {
+            "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "allowedValues": ["A", "B", "C", "D"],
+            "description": "an enum"
+        }
+    ],
+    "metrics": []
+}

--- a/telemetry/jetbrains/src/test/resources/testLongEnumOutput
+++ b/telemetry/jetbrains/src/test/resources/testLongEnumOutput
@@ -1,0 +1,32 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// THIS FILE IS GENERATED! DO NOT EDIT BY HAND!
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
+
+package software.aws.toolkits.telemetry
+
+import kotlin.String
+import kotlin.Suppress
+
+/**
+ * an enum
+ */
+public enum class
+        Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
+    private val `value`: String,
+) {
+    A("A"),
+    B("B"),
+    C("C"),
+    D("D"),
+    Unknown("unknown"),
+    ;
+
+    public override fun toString(): String = value
+
+    public companion object {
+        public fun from(type: String):
+                Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+                = values().firstOrNull { it.value == type } ?: Unknown
+    }
+}


### PR DESCRIPTION
…in syntactically incorrect locations

Add the `·` character to prevent Kotlinpoet from adding a new line.
This is only needed after the method name and between the equality operands, but we might as well make the output prettier

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

