### PR TITLE
fix(parser): parser fails in consumers

### DIFF
--- a/telemetry/vscode/package.json
+++ b/telemetry/vscode/package.json
@@ -7,7 +7,7 @@
         "build": "ts-node ./scripts/setUpPackage.ts && tsc -p ./",
         "validatePackaged": "ts-node ./scripts/validatePackagedJson.ts",
         "prepack": "npm run build && npm run test && npm run validatePackaged",
-        "test": "jest"
+        "test": "npm run build && jest"
     },
     "repository": {
         "type": "git",

--- a/telemetry/vscode/src/parser.ts
+++ b/telemetry/vscode/src/parser.ts
@@ -42,7 +42,7 @@ export interface MetricDefinitionRoot {
 
 export function validateInput(fileText: string, fileName: string): MetricDefinitionRoot {
     try {
-        const schemaInput = readFileSync(path.join(__dirname, '../../telemetrySchema.json'), 'utf8')
+        const schemaInput = readFileSync(path.join(__dirname, '../lib/telemetrySchema.json'), 'utf8')
         const schema = JSON.parse(schemaInput)
         const jsonValidator = new Ajv().compile(schema)
         const input = JSON.parse(fileText)


### PR DESCRIPTION
Problem:
39cb2fb900d2 changed this parser path to avoid needing to "package" the
project just to test it. But that path is based on assumptions about the
distributed artifact layout.

Solution:
Revert the path change and modify the "test" task so that it arranges
the "lib/" directory as expected by parser.ts.


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

