### PR TITLE
Update cloudwatch logs filter metric to indicate filter types separately

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -46,11 +46,6 @@
             "description": "The duration of the operation in milliseconds"
         },
         {
-            "name": "filterBy",
-            "allowedValues": ["prefix", "time"],
-            "description": "Type of filter applied"
-        },
-        {
             "name": "result",
             "allowedValues": ["Succeeded", "Failed", "Cancelled"],
             "description": "The result of the operation"
@@ -59,6 +54,16 @@
             "name": "component",
             "allowedValues": ["editor", "viewer", "filesystem"],
             "description": "The IDE or OS component used for the action. (Examples: S3 download to filesystem, S3 upload from editor, ...)"
+        },
+        {
+            "name": "isTextFilter",
+            "type": "boolean",
+            "description": "A text based filter was used"
+        },
+        {
+            "name": "isTimeFilter",
+            "type": "boolean",
+            "description": "A time based filter was used"
         },
         {
             "name": "lambdaPackageType",
@@ -673,8 +678,9 @@
             "description": "Filters a CloudWatch Logs entity.",
             "metadata": [
                 { "type": "result" },
-                { "type": "filterBy" },
-                { "type": "cloudWatchResourceType" }
+                { "type": "cloudWatchResourceType" },
+                { "type": "isTextFilter", "required": false },
+                { "type": "isTimeFilter", "required": false }
             ]
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -56,12 +56,12 @@
             "description": "The IDE or OS component used for the action. (Examples: S3 download to filesystem, S3 upload from editor, ...)"
         },
         {
-            "name": "isTextFilter",
+            "name": "hasTextFilter",
             "type": "boolean",
             "description": "A text based filter was used"
         },
         {
-            "name": "isTimeFilter",
+            "name": "hasTimeFilter",
             "type": "boolean",
             "description": "A time based filter was used"
         },
@@ -679,8 +679,8 @@
             "metadata": [
                 { "type": "result" },
                 { "type": "cloudWatchResourceType" },
-                { "type": "isTextFilter", "required": false },
-                { "type": "isTimeFilter", "required": false }
+                { "type": "hasTextFilter", "required": false },
+                { "type": "hasTimeFilter", "required": false }
             ]
         },
         {


### PR DESCRIPTION

## Description

This change is a follow-up to #325 , to adjust the "filter logs" metric so that filter types are not mutually exclusive.


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

