### PR TITLE
Support additional feedback metadata with Visual Studio

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/ITelemetryLogger.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/ITelemetryLogger.cs
@@ -23,7 +23,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
         /// </summary>
         /// <param name="sentiment">feedback sentiment e.g positive/negative</param>
         /// <param name="comment">feedback comment</param>
-        /// <param name="metadata">additional feedback metadata</param>
-        Task SendFeedback(Sentiment sentiment, string comment, IDictionary<string, string> metadata);
+        /// <param name="metadata">optional additional feedback metadata</param>
+        Task SendFeedback(Sentiment sentiment, string comment, IDictionary<string, string> metadata = null);
     }
 }

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/ITelemetryLogger.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/ITelemetryLogger.cs
@@ -1,5 +1,6 @@
 ﻿using log4net;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Amazon.AwsToolkit.Telemetry.Events.Core
 {
@@ -22,6 +23,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
         /// </summary>
         /// <param name="sentiment">feedback sentiment e.g positive/negative</param>
         /// <param name="comment">feedback comment</param>
-        Task SendFeedback(Sentiment sentiment, string comment);
+        /// <param name="metadata">additional feedback metadata</param>
+        Task SendFeedback(Sentiment sentiment, string comment, IDictionary<string, string> metadata);
     }
 }


### PR DESCRIPTION
## Description
This change adds support to send additional metadata when feedback is posted from Visual Studio.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

