### PR TITLE
Update telemetry service model

### DIFF
--- a/telemetry/service/service-model.json
+++ b/telemetry/service/service-model.json
@@ -54,7 +54,7 @@
     },
     "ClientID":{
       "type":"string",
-      "pattern":"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$"
+      "pattern":"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
     },
     "Command":{
       "type":"string",


### PR DESCRIPTION
Relaxes the `ClientId` validation to include all UUIDs instead of only v4

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

