### PR TITLE
Add Empty state to UserDecision event

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -519,7 +519,7 @@
             "name": "codewhispererSuggestionState",
             "type": "string",
             "description": "User decision of each of the suggestion returned from CodeWhisperer",
-            "allowedValues": ["Accept", "Reject", "Discard", "Ignore", "Filter", "Unseen"]
+            "allowedValues": ["Accept", "Reject", "Discard", "Ignore", "Filter", "Unseen", "Empty"]
         },
         {
             "name": "codewhispererTotalTokens",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
CodeWhisperer may return empty recommendations to the client, this includes an empty list of recommendations, or a list of recommendations with recommendations as empty strings, we want to record telemetry for such behavior for better tracking purpose.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s)
<!--- What is the related issue you are trying to fix? -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

