### PR TITLE
[CodeWhisperer] add new telemetry definition aws_modifySetting

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -355,6 +355,16 @@
             "description": "The id of the experiment being activated or deactivated"
         },
         {
+            "name": "settingId",
+            "type": "string",
+            "description": "The id of the setting being changed"
+        },
+        {
+            "name": "settingState",
+            "type": "string",
+            "description": "The state of the setting being changed to"
+        },
+        {
             "name": "toolId",
             "type": "string",
             "description": "The tool being installed",
@@ -374,12 +384,6 @@
             "name": "codewhispererAcceptedTokens",
             "type": "int",
             "description": "The metrics accepted on suggested CodeWhisperer code"
-        },
-        {
-            "name": "codewhispererAutomatedTriggerState",
-            "type": "string",
-            "description": "State of cwspr auto-suggestion",
-            "allowedValues": ["activated", "deactivated"]
         },
         {
             "name": "codewhispererAutomatedTriggerType",
@@ -1575,6 +1579,19 @@
             "passive": true
         },
         {
+            "name": "aws_modifySetting",
+            "description": "An setting was changed by users in the toolkit",
+            "metadata": [
+                {
+                    "type": "settingId"
+                },
+                {
+                    "type": "settingState",
+                    "required": false
+                }
+            ]
+        },
+        {
             "name": "deeplink_open",
             "description": "User requested that a resource be opened in the browser using the deeplink service",
             "metadata": [
@@ -1590,15 +1607,6 @@
                 }
             ],
             "passive": true
-        },
-        {
-            "name": "codewhisperer_autoSuggestionActivation",
-            "description": "User activate or deactivate automated trigger for CodeWhisperer code suggestion",
-            "metadata":  [
-                {
-                    "type": "codewhispererAutomatedTriggerState"
-                }
-            ]
         },
         {
             "name": "codewhisperer_codePercentage",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -376,6 +376,12 @@
             "description": "The metrics accepted on suggested CodeWhisperer code"
         },
         {
+            "name": "codewhispererAutomatedTriggerState",
+            "type": "string",
+            "description": "State of cwspr auto-suggestion",
+            "allowedValues": ["activated", "deactivated"]
+        },
+        {
             "name": "codewhispererAutomatedTriggerType",
             "type": "string",
             "description": "The type of the Automated trigger to send request to CodeWhisperer service",
@@ -1584,6 +1590,15 @@
                 }
             ],
             "passive": true
+        },
+        {
+            "name": "codewhisperer_autoSuggestionActivation",
+            "description": "State of cwspr auto-suggestion",
+            "metadata":  [
+                {
+                    "type": "codewhispererAutomatedTriggerState"
+                }
+            ]
         },
         {
             "name": "codewhisperer_codePercentage",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -357,12 +357,12 @@
         {
             "name": "settingId",
             "type": "string",
-            "description": "The id of the setting being changed"
+            "description": "The id of the setting being changed. Consistent namespace should be used for the id, e.g. codewhisperer_autoSuggestionActivation"
         },
         {
             "name": "settingState",
             "type": "string",
-            "description": "The state of the setting being changed to"
+            "description": "The state of the setting being changed to. This should not be recorded for free-form settings like file-system paths. Instead, stick to things like flags, numbers, and enums."
         },
         {
             "name": "toolId",
@@ -1555,7 +1555,7 @@
         },
         {
             "name": "aws_experimentActivation",
-            "description": "An experiment was activated or deactivated in the toolkit",
+            "description": "An experiment was activated or deactivated in the Toolkit",
             "metadata": [
                 {
                     "type": "experimentId"
@@ -1580,7 +1580,7 @@
         },
         {
             "name": "aws_modifySetting",
-            "description": "An setting was changed by users in the toolkit",
+            "description": "An setting was changed by users in the Toolkit. This metric can optionally provide the new state of the setting via settingState.",
             "metadata": [
                 {
                     "type": "settingId"

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1593,7 +1593,7 @@
         },
         {
             "name": "codewhisperer_autoSuggestionActivation",
-            "description": "State of cwspr auto-suggestion",
+            "description": "User activate or deactivate automated trigger for CodeWhisperer code suggestion",
             "metadata":  [
                 {
                     "type": "codewhispererAutomatedTriggerState"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add new cwspr telemetry definition for tracking users enabling/disabling auto suggestion

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

