### PR TITLE
[CodeWhisperer] Remove metric codewhisperer_percentage's codewhispererStartTime field and its definition

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -506,11 +506,6 @@
             "description": "The unique identifier for a CodeWhisperer session(which can contain multiple requests)"
         },
         {
-            "name": "codewhispererStartTime",
-            "type": "string",
-            "description": "The start time of user typed code in minutes"
-        },
-        {
             "name": "codewhispererSuggestionIndex",
             "type": "int",
             "description": "The index for each suggestion, respectively, in the list of suggestions returned from service invocation"
@@ -1620,9 +1615,6 @@
                 },
                 {
                     "type": "codewhispererPercentage"
-                },
-                {
-                    "type": "codewhispererStartTime"
                 },
                 {
                     "type": "codewhispererTotalTokens"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As titled, remove field `codewhispererStartTime` and its usage as cwspr team is not use this field and it is adding a churn for telemetry to digest codewhisperer_codePercentage metric.
## Types of changes


## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

