### PR TITLE
feat(codewhisperer): Add telemetry field of overall customer project size for security scan

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -403,6 +403,11 @@
             "description": "How many lines of code being sent for security scan"
         },
         {
+            "name": "codewhispererCodeScanProjectBytes",
+            "type": "double",
+            "description": "The total size in bytes of customer project to perform security scan on"
+        },
+        {
             "name": "codewhispererCodeScanSrcPayloadBytes",
             "type": "int",
             "description": "The uncompressed payload size in bytes of the source files in customer project context sent for security scan"
@@ -1635,6 +1640,10 @@
                 },
                 {
                     "type": "codewhispererCodeScanJobId",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererCodeScanProjectBytes",
                     "required": false
                 },
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In order to collect data points about what's the P90 project size used for CWSPR security scan feature, so we can use it to scale our backend service, will need to add this additional field to emit the metrics.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Description
Add telemetry field of overall customer project size for security scan.

## Motivation and Context
Provide data point for backend scalability.


## Testing

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

