### PR TITLE
[CodeWhisperer] add JSX enum type in CodeWhispererProgrammingLanguage

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -462,7 +462,7 @@
             "name": "codewhispererLanguage",
             "type": "string",
             "description": "Programming language of the CodeWhisperer recommendation",
-            "allowedValues": ["java", "python", "javascript", "plaintext"]
+            "allowedValues": ["java", "python", "javascript", "plaintext", "jsx"]
         },
         {
             "name": "codewhispererLastSuggestionIndex",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1625,6 +1625,9 @@
                     "type": "codewhispererTotalTokens"
                 },
                 {
+                    "type": "enabled"
+                },
+                {
                     "type": "reason",
                     "required": false
                 }

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1625,9 +1625,6 @@
                     "type": "codewhispererTotalTokens"
                 },
                 {
-                    "type": "enabled"
-                },
-                {
                     "type": "reason",
                     "required": false
                 }


### PR DESCRIPTION
As title, CodeWhisperer team aims to support JSX files, add a new programmingLanguage type for us to track JSX use cases.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **README** document
- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

