### PR TITLE
Allow long filenames when cloning SDK generator for VS toolkit telemetry

### DIFF
--- a/telemetry/csharp/TelemetryClient.proj
+++ b/telemetry/csharp/TelemetryClient.proj
@@ -30,7 +30,7 @@
     <!-- Produce a generated csproj and files in a temp location -->
     <Target Name="clone-sdk">
         <Message Text="Cloning AWS .NET SDK into $(DotNetSdkClone) (this will take a while)" />
-        <Exec Command="git clone --depth 1 --branch $(DotNetSdkTag) https://github.com/aws/aws-sdk-net.git $(DotNetSdkClone)" />
+        <Exec Command="git clone -c core.longpaths=true --depth 1 --branch $(DotNetSdkTag) https://github.com/aws/aws-sdk-net.git $(DotNetSdkClone)" />
     </Target>
 
     <Target Name="restore-sdk-generator">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change allows long filenames when cloning the SDK generator for VS toolkit telemetry.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

