### PR TITLE
Add exception handler for optional telemetry callback

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/DefinitionsBuilderTests.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/DefinitionsBuilderTests.cs
@@ -38,6 +38,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator.Tests
         private void AssertGeneratedCode(string expectedCodePath)
         {
             var expectedCode = File.ReadAllText(expectedCodePath);
+            var re = NormalizeLineEndings(_sut.Build());
             Assert.Equal(NormalizeLineEndings(expectedCode), NormalizeLineEndings(_sut.Build()));
         }
 

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/DefinitionsBuilderTests.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/DefinitionsBuilderTests.cs
@@ -38,7 +38,6 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator.Tests
         private void AssertGeneratedCode(string expectedCodePath)
         {
             var expectedCode = File.ReadAllText(expectedCodePath);
-            var re = NormalizeLineEndings(_sut.Build());
             Assert.Equal(NormalizeLineEndings(expectedCode), NormalizeLineEndings(_sut.Build()));
         }
 

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
@@ -56,7 +56,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -100,7 +100,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -154,7 +154,7 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -208,7 +208,7 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -274,7 +274,7 @@ namespace Test
                     datum.AddMetadata("runtime", payload.Runtime.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -318,7 +318,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
@@ -56,18 +56,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -111,18 +100,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -176,18 +154,7 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -241,18 +208,7 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -318,18 +274,7 @@ namespace Test
                     datum.AddMetadata("runtime", payload.Runtime.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -373,18 +318,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
@@ -56,9 +56,17 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -103,9 +111,17 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -160,9 +176,17 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -217,9 +241,17 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -286,9 +318,17 @@ namespace Test
                     datum.AddMetadata("runtime", payload.Runtime.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -333,9 +373,17 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
@@ -56,7 +56,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -100,7 +100,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -154,7 +154,7 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -208,7 +208,7 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -274,7 +274,7 @@ namespace Test
                     datum.AddMetadata("runtime", payload.Runtime.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -318,7 +318,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
@@ -56,18 +56,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -111,18 +100,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -176,18 +154,7 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -241,18 +208,7 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -318,18 +274,7 @@ namespace Test
                     datum.AddMetadata("runtime", payload.Runtime.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -373,18 +318,7 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
@@ -56,9 +56,17 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -103,9 +111,17 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -160,9 +176,17 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -217,9 +241,17 @@ namespace Test
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -286,9 +318,17 @@ namespace Test
                     datum.AddMetadata("runtime", payload.Runtime.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -333,9 +373,17 @@ namespace Test
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
@@ -438,7 +438,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator
 
             var catchClause = new CodeCatchClause("e", new CodeTypeReference(typeof(Exception)));
             catchClause.Statements.Add(new CodeExpressionStatement(
-                new CodeMethodInvokeExpression(new CodeFieldReferenceExpression(new CodeArgumentReferenceExpression("telemetryLogger"), "Logger"),
+                new CodeMethodInvokeExpression(
+                    new CodeFieldReferenceExpression(new CodeArgumentReferenceExpression("telemetryLogger"), "Logger"),
                     "Error",
                     new CodePrimitiveExpression("Error recording telemetry event"),
                     new CodeArgumentReferenceExpression("e"))

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
@@ -422,12 +422,9 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator
             });
 
             // Generate: "InvokeTransform function on datum"
-            // datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum) 
+            // datum = datum.InvokeTransform(transformDatum) 
             var datumInvoke = new CodeMethodReferenceExpression(datum, InvokeTransformMethodName);
-            var logger =
-                new CodeFieldReferenceExpression(new CodeArgumentReferenceExpression("telemetryLogger"), "Logger");
-            var invokeTransform = new CodeMethodInvokeExpression(datumInvoke,
-                logger, transformDatum);
+            var invokeTransform = new CodeMethodInvokeExpression(datumInvoke, transformDatum);
             var assignTransform = new CodeAssignStatement(datum, invokeTransform);
             tryStatements.Add(new CodeSnippetStatement());
             tryStatements.Add(assignTransform);
@@ -441,7 +438,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator
 
             var catchClause = new CodeCatchClause("e", new CodeTypeReference(typeof(Exception)));
             catchClause.Statements.Add(new CodeExpressionStatement(
-                new CodeMethodInvokeExpression(logger,
+                new CodeMethodInvokeExpression(new CodeFieldReferenceExpression(new CodeArgumentReferenceExpression("telemetryLogger"), "Logger"),
                     "Error",
                     new CodePrimitiveExpression("Error recording telemetry event"),
                     new CodeArgumentReferenceExpression("e"))

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Core/MetricDatumExtensionMethodsTests.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Core/MetricDatumExtensionMethodsTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Amazon.AwsToolkit.Telemetry.Events.Core;
-using log4net;
-using Moq;
 using Xunit;
 
 namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Core
@@ -9,7 +7,6 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Core
     public class MetricDatumExtensionMethodsTests
     {
         private readonly MetricDatum _sut = new MetricDatum();
-        private readonly Mock<ILog> _logger = new Mock<ILog>();
         private const string Key = "sampleKey";
 
         [Fact]
@@ -53,9 +50,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Core
         [Fact]
         public void InvokeTransform_Null()
         {
-            var updatedDatum = _sut.InvokeTransform(_logger.Object, null);
+            var updatedDatum = _sut.InvokeTransform(null);
             Assert.Equal(_sut, updatedDatum);
-            _logger.Verify(mock => mock.Error(It.IsAny<object>(), It.IsAny<Exception>()), Times.Never);
         }
 
         [Fact]
@@ -66,9 +62,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Core
                 throw new ArgumentException("sample transform exception");
             }
 
-            var updatedDatum = _sut.InvokeTransform(_logger.Object, TransformFunction);
+            var updatedDatum = _sut.InvokeTransform(TransformFunction);
             Assert.NotNull(updatedDatum);
-            _logger.Verify(mock => mock.Error(It.IsAny<object>(), It.IsAny<Exception>()), Times.Once);
         }
 
         [Fact]
@@ -80,9 +75,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Core
                 return datum;
             }
 
-            var updatedDatum = _sut.InvokeTransform(_logger.Object, TransformFunction);
+            var updatedDatum = _sut.InvokeTransform(TransformFunction);
             Assert.Equal("hello", updatedDatum.Metadata[Key]);
-            _logger.Verify(mock => mock.Error(It.IsAny<object>(), It.IsAny<Exception>()), Times.Never);
         }
     }
 }

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
@@ -57,9 +57,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -120,9 +128,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("lambdaArchitecture", payload.LambdaArchitecture.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -171,9 +187,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("httpMethod", payload.HttpMethod);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -220,9 +244,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -267,9 +299,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -314,9 +354,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -367,9 +415,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -416,9 +472,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -465,9 +529,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -519,9 +591,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("appRunnerServiceStatus", payload.AppRunnerServiceStatus.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -568,9 +648,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -615,9 +703,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -662,9 +758,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -711,9 +815,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -762,9 +874,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -819,9 +939,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("credentialSourceId", payload.CredentialSourceId.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -866,9 +994,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -915,9 +1051,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("partitionId", payload.PartitionId);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -964,9 +1108,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1015,9 +1167,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("url", payload.Url);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1062,9 +1222,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1115,9 +1283,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("source", payload.Source);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1164,9 +1340,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("credentialSourceId", payload.CredentialSourceId);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1211,9 +1395,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1262,9 +1454,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("runtimeString", payload.RuntimeString);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1321,9 +1521,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("credentialSourceId", payload.CredentialSourceId.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1370,9 +1578,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("name", payload.Name);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1419,9 +1635,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1466,9 +1690,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1513,9 +1745,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1562,9 +1802,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1609,9 +1857,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1674,9 +1930,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("enhancedHealthEnabled", payload.EnhancedHealthEnabled.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1723,9 +1987,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1772,9 +2044,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1821,9 +2101,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1870,9 +2158,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1919,9 +2215,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -1970,9 +2274,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2030,9 +2342,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("source", payload.Source);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2081,9 +2401,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2132,9 +2460,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2183,9 +2519,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2234,9 +2578,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2283,9 +2635,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2332,9 +2692,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2381,9 +2749,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2430,9 +2806,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("enabled", payload.Enabled);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2479,9 +2863,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("enabled", payload.Enabled);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2528,9 +2920,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2575,9 +2975,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2622,9 +3030,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2685,9 +3101,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("hasTimeFilter", payload.HasTimeFilter.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2734,9 +3158,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2783,9 +3215,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2832,9 +3272,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2883,9 +3331,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("templateName", payload.TemplateName);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2934,9 +3390,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("initialDeploy", payload.InitialDeploy);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -2983,9 +3447,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3034,9 +3506,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3085,9 +3565,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3139,9 +3627,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("credentialType", payload.CredentialType.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3188,9 +3684,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3244,9 +3748,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("dynamoDbIndexType", payload.DynamoDbIndexType.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3295,9 +3807,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ec2InstanceState", payload.Ec2InstanceState);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3346,9 +3866,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ec2ConnectionType", payload.Ec2ConnectionType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3395,9 +3923,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3444,9 +3980,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3493,9 +4037,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3542,9 +4094,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3591,9 +4151,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3640,9 +4208,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3689,9 +4265,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3738,9 +4322,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3787,9 +4379,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3836,9 +4436,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3887,9 +4495,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsExecuteCommandType", payload.EcsExecuteCommandType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3934,9 +4550,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -3981,9 +4605,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4030,9 +4662,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4079,9 +4719,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4128,9 +4776,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4182,9 +4838,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("ecrDeploySource", payload.EcrDeploySource.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4233,9 +4897,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsLaunchType", payload.EcsLaunchType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4284,9 +4956,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsLaunchType", payload.EcsLaunchType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4335,9 +5015,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsLaunchType", payload.EcsLaunchType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4386,9 +5074,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("duration", payload.Duration);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4435,9 +5131,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4484,9 +5188,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4533,9 +5245,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4586,9 +5306,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("filenameExt", payload.FilenameExt);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4635,9 +5363,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4684,9 +5420,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4733,9 +5477,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4784,9 +5536,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4833,9 +5593,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4882,9 +5650,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4937,9 +5713,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("variant", payload.Variant);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -4986,9 +5770,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5042,9 +5834,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5096,9 +5896,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5161,9 +5969,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("lambdaArchitecture", payload.LambdaArchitecture.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5215,9 +6031,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5269,9 +6093,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5341,9 +6173,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("xrayEnabled", payload.XrayEnabled.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5390,9 +6230,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5443,9 +6291,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseEngine", payload.DatabaseEngine);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5492,9 +6348,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5541,9 +6405,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5590,9 +6462,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5643,9 +6523,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseEngine", payload.DatabaseEngine);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5694,9 +6582,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseCredentials", payload.DatabaseCredentials);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5745,9 +6641,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseCredentials", payload.DatabaseCredentials);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5796,9 +6700,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("version", payload.Version);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5868,9 +6780,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("lambdaArchitecture", payload.LambdaArchitecture.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5917,9 +6837,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -5971,9 +6899,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("schemaLanguage", payload.SchemaLanguage.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6020,9 +6956,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6067,9 +7011,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6114,9 +7066,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6161,9 +7121,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6208,9 +7176,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6257,9 +7233,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6308,9 +7292,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("presigned", payload.Presigned);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6357,9 +7349,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6406,9 +7406,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6465,9 +7473,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("failedCount", payload.FailedCount.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6514,9 +7530,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6578,9 +7602,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("component", payload.Component.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6627,9 +7659,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6691,9 +7731,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("component", payload.Component.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6740,9 +7788,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6789,9 +7845,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6838,9 +7902,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6892,9 +7964,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("component", payload.Component.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6941,9 +8021,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -6990,9 +8078,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7047,9 +8143,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("duration", payload.Duration.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7096,9 +8200,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7150,9 +8262,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("sqsQueueType", payload.SqsQueueType.Value);
                 }
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7201,9 +8321,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7252,9 +8380,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7303,9 +8439,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7354,9 +8498,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7405,9 +8557,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7456,9 +8616,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7505,9 +8673,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7554,9 +8730,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7603,9 +8787,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7652,9 +8844,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7701,9 +8901,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7750,9 +8958,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7799,9 +9015,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7848,9 +9072,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7897,9 +9129,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("insightsDialogOpenSource", payload.InsightsDialogOpenSource);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7950,9 +9190,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("insightsQueryStringType", payload.InsightsQueryStringType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -7999,9 +9247,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8048,9 +9304,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8097,9 +9361,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8150,9 +9422,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8201,9 +9481,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("resourceType", payload.ResourceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8252,9 +9540,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("resourceType", payload.ResourceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8299,9 +9595,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8348,9 +9652,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("resourceType", payload.ResourceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8403,9 +9715,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("duration", payload.Duration);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8454,9 +9774,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("experimentState", payload.ExperimentState);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8505,9 +9833,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8556,9 +9892,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("settingState", payload.SettingState);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8609,9 +9953,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8668,9 +10020,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("successCount", payload.SuccessCount);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8754,9 +10114,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8841,9 +10209,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8918,9 +10294,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("codewhispererTriggerType", payload.CodewhispererTriggerType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -8986,9 +10370,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("codewhispererTriggerType", payload.CodewhispererTriggerType);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -9045,9 +10437,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("codewhispererLanguage", payload.CodewhispererLanguage);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
@@ -57,18 +57,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -128,18 +117,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("lambdaArchitecture", payload.LambdaArchitecture.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -187,18 +165,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("httpMethod", payload.HttpMethod);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -244,18 +211,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -299,18 +255,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -354,18 +299,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -415,18 +349,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -472,18 +395,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -529,18 +441,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -591,18 +492,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("appRunnerServiceStatus", payload.AppRunnerServiceStatus.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -648,18 +538,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -703,18 +582,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -758,18 +626,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -815,18 +672,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -874,18 +720,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -939,18 +774,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("credentialSourceId", payload.CredentialSourceId.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -994,18 +818,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1051,18 +864,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("partitionId", payload.PartitionId);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1108,18 +910,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1167,18 +958,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("url", payload.Url);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1222,18 +1002,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1283,18 +1052,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("source", payload.Source);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1340,18 +1098,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("credentialSourceId", payload.CredentialSourceId);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1395,18 +1142,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1454,18 +1190,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("runtimeString", payload.RuntimeString);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1521,18 +1246,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("credentialSourceId", payload.CredentialSourceId.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1578,18 +1292,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("name", payload.Name);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1635,18 +1338,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1690,18 +1382,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1745,18 +1426,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1802,18 +1472,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1857,18 +1516,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1930,18 +1578,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("enhancedHealthEnabled", payload.EnhancedHealthEnabled.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1987,18 +1624,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2044,18 +1670,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2101,18 +1716,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2158,18 +1762,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2215,18 +1808,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2274,18 +1856,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2342,18 +1913,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("source", payload.Source);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2401,18 +1961,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2460,18 +2009,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2519,18 +2057,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2578,18 +2105,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2635,18 +2151,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2692,18 +2197,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2749,18 +2243,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2806,18 +2289,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("enabled", payload.Enabled);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2863,18 +2335,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("enabled", payload.Enabled);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2920,18 +2381,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2975,18 +2425,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3030,18 +2469,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3101,18 +2529,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("hasTimeFilter", payload.HasTimeFilter.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3158,18 +2575,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3215,18 +2621,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3272,18 +2667,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3331,18 +2715,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("templateName", payload.TemplateName);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3390,18 +2763,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("initialDeploy", payload.InitialDeploy);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3447,18 +2809,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3506,18 +2857,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3565,18 +2905,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3627,18 +2956,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("credentialType", payload.CredentialType.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3684,18 +3002,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3748,18 +3055,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("dynamoDbIndexType", payload.DynamoDbIndexType.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3807,18 +3103,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ec2InstanceState", payload.Ec2InstanceState);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3866,18 +3151,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ec2ConnectionType", payload.Ec2ConnectionType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3923,18 +3197,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3980,18 +3243,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4037,18 +3289,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4094,18 +3335,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4151,18 +3381,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4208,18 +3427,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4265,18 +3473,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4322,18 +3519,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4379,18 +3565,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4436,18 +3611,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4495,18 +3659,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsExecuteCommandType", payload.EcsExecuteCommandType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4550,18 +3703,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4605,18 +3747,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4662,18 +3793,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4719,18 +3839,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4776,18 +3885,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4838,18 +3936,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("ecrDeploySource", payload.EcrDeploySource.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4897,18 +3984,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsLaunchType", payload.EcsLaunchType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4956,18 +4032,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsLaunchType", payload.EcsLaunchType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5015,18 +4080,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsLaunchType", payload.EcsLaunchType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5074,18 +4128,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("duration", payload.Duration);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5131,18 +4174,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5188,18 +4220,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5245,18 +4266,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5306,18 +4316,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("filenameExt", payload.FilenameExt);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5363,18 +4362,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5420,18 +4408,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5477,18 +4454,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5536,18 +4502,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5593,18 +4548,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5650,18 +4594,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5713,18 +4646,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("variant", payload.Variant);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5770,18 +4692,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5834,18 +4745,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5896,18 +4796,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5969,18 +4858,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("lambdaArchitecture", payload.LambdaArchitecture.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6031,18 +4909,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6093,18 +4960,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6173,18 +5029,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("xrayEnabled", payload.XrayEnabled.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6230,18 +5075,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6291,18 +5125,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseEngine", payload.DatabaseEngine);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6348,18 +5171,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6405,18 +5217,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6462,18 +5263,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6523,18 +5313,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseEngine", payload.DatabaseEngine);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6582,18 +5361,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseCredentials", payload.DatabaseCredentials);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6641,18 +5409,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseCredentials", payload.DatabaseCredentials);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6700,18 +5457,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("version", payload.Version);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6780,18 +5526,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("lambdaArchitecture", payload.LambdaArchitecture.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6837,18 +5572,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6899,18 +5623,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("schemaLanguage", payload.SchemaLanguage.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6956,18 +5669,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7011,18 +5713,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7066,18 +5757,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7121,18 +5801,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7176,18 +5845,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7233,18 +5891,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7292,18 +5939,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("presigned", payload.Presigned);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7349,18 +5985,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7406,18 +6031,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7473,18 +6087,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("failedCount", payload.FailedCount.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7530,18 +6133,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7602,18 +6194,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("component", payload.Component.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7659,18 +6240,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7731,18 +6301,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("component", payload.Component.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7788,18 +6347,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7845,18 +6393,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7902,18 +6439,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7964,18 +6490,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("component", payload.Component.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8021,18 +6536,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8078,18 +6582,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8143,18 +6636,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("duration", payload.Duration.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8200,18 +6682,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8262,18 +6733,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("sqsQueueType", payload.SqsQueueType.Value);
                 }
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8321,18 +6781,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8380,18 +6829,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8439,18 +6877,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8498,18 +6925,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8557,18 +6973,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8616,18 +7021,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8673,18 +7067,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8730,18 +7113,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8787,18 +7159,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8844,18 +7205,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8901,18 +7251,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8958,18 +7297,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9015,18 +7343,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9072,18 +7389,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9129,18 +7435,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("insightsDialogOpenSource", payload.InsightsDialogOpenSource);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9190,18 +7485,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("insightsQueryStringType", payload.InsightsQueryStringType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9247,18 +7531,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9304,18 +7577,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9361,18 +7623,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9422,18 +7673,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9481,18 +7721,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("resourceType", payload.ResourceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9540,18 +7769,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("resourceType", payload.ResourceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9595,18 +7813,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9652,18 +7859,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("resourceType", payload.ResourceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9715,18 +7911,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("duration", payload.Duration);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9774,18 +7959,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("experimentState", payload.ExperimentState);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9833,18 +8007,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9892,18 +8055,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("settingState", payload.SettingState);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -9953,18 +8105,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -10020,18 +8161,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("successCount", payload.SuccessCount);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -10114,18 +8244,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -10209,18 +8328,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -10294,18 +8402,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("codewhispererTriggerType", payload.CodewhispererTriggerType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -10370,18 +8467,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("codewhispererTriggerType", payload.CodewhispererTriggerType);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -10437,18 +8523,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("codewhispererLanguage", payload.CodewhispererLanguage);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
@@ -57,7 +57,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -117,7 +117,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("lambdaArchitecture", payload.LambdaArchitecture.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -165,7 +165,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("httpMethod", payload.HttpMethod);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -211,7 +211,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -255,7 +255,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -299,7 +299,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -349,7 +349,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -395,7 +395,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -441,7 +441,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -492,7 +492,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("appRunnerServiceStatus", payload.AppRunnerServiceStatus.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -538,7 +538,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -582,7 +582,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -626,7 +626,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -672,7 +672,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -720,7 +720,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -774,7 +774,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("credentialSourceId", payload.CredentialSourceId.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -818,7 +818,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -864,7 +864,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("partitionId", payload.PartitionId);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -910,7 +910,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -958,7 +958,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("url", payload.Url);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1002,7 +1002,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1052,7 +1052,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("source", payload.Source);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1098,7 +1098,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("credentialSourceId", payload.CredentialSourceId);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1142,7 +1142,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1190,7 +1190,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("runtimeString", payload.RuntimeString);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1246,7 +1246,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("credentialSourceId", payload.CredentialSourceId.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1292,7 +1292,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("name", payload.Name);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1338,7 +1338,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1382,7 +1382,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1426,7 +1426,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1472,7 +1472,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1516,7 +1516,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1578,7 +1578,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("enhancedHealthEnabled", payload.EnhancedHealthEnabled.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1624,7 +1624,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1670,7 +1670,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1716,7 +1716,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1762,7 +1762,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1808,7 +1808,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1856,7 +1856,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1913,7 +1913,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("source", payload.Source);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -1961,7 +1961,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2009,7 +2009,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2057,7 +2057,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2105,7 +2105,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2151,7 +2151,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2197,7 +2197,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2243,7 +2243,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2289,7 +2289,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("enabled", payload.Enabled);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2335,7 +2335,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("enabled", payload.Enabled);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2381,7 +2381,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("cloudWatchResourceType", payload.CloudWatchResourceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2425,7 +2425,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2469,7 +2469,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2529,7 +2529,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("hasTimeFilter", payload.HasTimeFilter.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2575,7 +2575,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2621,7 +2621,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2667,7 +2667,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2715,7 +2715,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("templateName", payload.TemplateName);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2763,7 +2763,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("initialDeploy", payload.InitialDeploy);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2809,7 +2809,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2857,7 +2857,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2905,7 +2905,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -2956,7 +2956,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("credentialType", payload.CredentialType.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3002,7 +3002,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3055,7 +3055,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("dynamoDbIndexType", payload.DynamoDbIndexType.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3103,7 +3103,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ec2InstanceState", payload.Ec2InstanceState);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3151,7 +3151,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ec2ConnectionType", payload.Ec2ConnectionType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3197,7 +3197,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3243,7 +3243,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3289,7 +3289,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3335,7 +3335,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3381,7 +3381,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3427,7 +3427,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3473,7 +3473,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3519,7 +3519,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3565,7 +3565,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3611,7 +3611,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3659,7 +3659,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsExecuteCommandType", payload.EcsExecuteCommandType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3703,7 +3703,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3747,7 +3747,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3793,7 +3793,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3839,7 +3839,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3885,7 +3885,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3936,7 +3936,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("ecrDeploySource", payload.EcrDeploySource.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -3984,7 +3984,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsLaunchType", payload.EcsLaunchType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4032,7 +4032,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsLaunchType", payload.EcsLaunchType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4080,7 +4080,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("ecsLaunchType", payload.EcsLaunchType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4128,7 +4128,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("duration", payload.Duration);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4174,7 +4174,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4220,7 +4220,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4266,7 +4266,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4316,7 +4316,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("filenameExt", payload.FilenameExt);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4362,7 +4362,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4408,7 +4408,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4454,7 +4454,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4502,7 +4502,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4548,7 +4548,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4594,7 +4594,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("runtime", payload.Runtime);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4646,7 +4646,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("variant", payload.Variant);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4692,7 +4692,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4745,7 +4745,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4796,7 +4796,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4858,7 +4858,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("lambdaArchitecture", payload.LambdaArchitecture.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4909,7 +4909,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -4960,7 +4960,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5029,7 +5029,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("xrayEnabled", payload.XrayEnabled.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5075,7 +5075,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5125,7 +5125,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseEngine", payload.DatabaseEngine);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5171,7 +5171,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5217,7 +5217,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5263,7 +5263,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5313,7 +5313,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseEngine", payload.DatabaseEngine);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5361,7 +5361,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseCredentials", payload.DatabaseCredentials);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5409,7 +5409,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("databaseCredentials", payload.DatabaseCredentials);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5457,7 +5457,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("version", payload.Version);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5526,7 +5526,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("lambdaArchitecture", payload.LambdaArchitecture.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5572,7 +5572,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5623,7 +5623,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("schemaLanguage", payload.SchemaLanguage.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5669,7 +5669,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5713,7 +5713,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5757,7 +5757,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5801,7 +5801,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5845,7 +5845,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5891,7 +5891,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5939,7 +5939,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("presigned", payload.Presigned);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -5985,7 +5985,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6031,7 +6031,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6087,7 +6087,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("failedCount", payload.FailedCount.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6133,7 +6133,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6194,7 +6194,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("component", payload.Component.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6240,7 +6240,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6301,7 +6301,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("component", payload.Component.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6347,7 +6347,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6393,7 +6393,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6439,7 +6439,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6490,7 +6490,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("component", payload.Component.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6536,7 +6536,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6582,7 +6582,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6636,7 +6636,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("duration", payload.Duration.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6682,7 +6682,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6733,7 +6733,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                     datum.AddMetadata("sqsQueueType", payload.SqsQueueType.Value);
                 }
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6781,7 +6781,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6829,7 +6829,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6877,7 +6877,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6925,7 +6925,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -6973,7 +6973,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7021,7 +7021,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("sqsQueueType", payload.SqsQueueType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7067,7 +7067,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7113,7 +7113,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7159,7 +7159,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7205,7 +7205,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7251,7 +7251,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7297,7 +7297,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7343,7 +7343,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7389,7 +7389,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7435,7 +7435,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("insightsDialogOpenSource", payload.InsightsDialogOpenSource);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7485,7 +7485,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("insightsQueryStringType", payload.InsightsQueryStringType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7531,7 +7531,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7577,7 +7577,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7623,7 +7623,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7673,7 +7673,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("reason", payload.Reason);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7721,7 +7721,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("resourceType", payload.ResourceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7769,7 +7769,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("resourceType", payload.ResourceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7813,7 +7813,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7859,7 +7859,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("resourceType", payload.ResourceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7911,7 +7911,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("duration", payload.Duration);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -7959,7 +7959,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("experimentState", payload.ExperimentState);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8007,7 +8007,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8055,7 +8055,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("settingState", payload.SettingState);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8105,7 +8105,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("serviceType", payload.ServiceType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8161,7 +8161,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("successCount", payload.SuccessCount);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8244,7 +8244,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8328,7 +8328,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8402,7 +8402,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("codewhispererTriggerType", payload.CodewhispererTriggerType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8467,7 +8467,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("codewhispererTriggerType", payload.CodewhispererTriggerType);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -8523,7 +8523,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generated
 
                 datum.AddMetadata("codewhispererLanguage", payload.CodewhispererLanguage);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
@@ -68,7 +68,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -114,7 +114,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
 
                 datum.AddMetadata("bees", payload.Bees);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -158,7 +158,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -202,7 +202,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
+                datum = datum.InvokeTransform(transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
@@ -68,9 +68,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -117,9 +125,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
 
                 datum.AddMetadata("bees", payload.Bees);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -164,9 +180,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);
@@ -211,9 +235,17 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                if ((transformDatum != null))
+                try
                 {
-                    datum = transformDatum.Invoke(datum);
+                    if ((transformDatum != null))
+                    {
+                        datum = transformDatum.Invoke(datum);
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    telemetryLogger.Logger.Error("Error invoking transform function", e);
+                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
                 }
 
                 metrics.Data.Add(datum);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
@@ -68,18 +68,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
 
                 datum.AddMetadata("result", payload.Result);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -125,18 +114,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
 
                 datum.AddMetadata("bees", payload.Bees);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -180,18 +158,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);
@@ -235,18 +202,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated
                 datum.AddMetadata("awsAccount", payload.AwsAccount);
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
 
-                try
-                {
-                    if ((transformDatum != null))
-                    {
-                        datum = transformDatum.Invoke(datum);
-                    }
-                }
-                catch (System.Exception e)
-                {
-                    telemetryLogger.Logger.Error("Error invoking transform function", e);
-                    System.Diagnostics.Debug.Assert((System.Diagnostics.Debugger.IsAttached == false), "Error invoking transform function");
-                }
+                datum = datum.InvokeTransform(telemetryLogger.Logger, transformDatum);
 
                 metrics.Data.Add(datum);
                 telemetryLogger.Record(metrics);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/MetricDatumExtensionMethods.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/MetricDatumExtensionMethods.cs
@@ -6,6 +6,8 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
 {
     public static class MetricDatumExtensionMethods
     {
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(MetricDatumExtensionMethods));
+
         /// <summary>
         /// Add metadata to a metric datum, only if the value is non-blank
         /// </summary>
@@ -65,8 +67,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
         /// <summary>
         /// If the transform function isn't null, invoke it and assign metric datum to it's result
         /// </summary>
-        public static MetricDatum InvokeTransform(this MetricDatum metricDatum, ILog logger,
-            Func<MetricDatum, MetricDatum> transformDatum = null)
+        public static MetricDatum InvokeTransform(this MetricDatum metricDatum, Func<MetricDatum, MetricDatum> transformDatum = null)
         {
             try
             {
@@ -77,7 +78,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
             }
             catch (Exception e)
             {
-                logger.Error("Error invoking transform function", e);
+                Logger.Error("Error invoking transform function", e);
                 Debug.Assert(!Debugger.IsAttached, "Error invoking transform function");
             }
 

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/MetricDatumExtensionMethods.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/MetricDatumExtensionMethods.cs
@@ -1,4 +1,8 @@
-﻿namespace Amazon.AwsToolkit.Telemetry.Events.Core
+﻿using System;
+using System.Diagnostics;
+using log4net;
+
+namespace Amazon.AwsToolkit.Telemetry.Events.Core
 {
     public static class MetricDatumExtensionMethods
     {
@@ -56,6 +60,28 @@
         public static void AddMetadata(this MetricDatum metricDatum, string key, int value)
         {
             metricDatum.AddMetadata(key, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// If the transform function isn't null, invoke it and assign metric datum to it's result
+        /// </summary>
+        public static MetricDatum InvokeTransform(this MetricDatum metricDatum, ILog logger,
+            Func<MetricDatum, MetricDatum> transformDatum = null)
+        {
+            try
+            {
+                if (transformDatum != null)
+                {
+                    metricDatum = transformDatum.Invoke(metricDatum);
+                }
+            }
+            catch (Exception e)
+            {
+                logger.Error("Error invoking transform function", e);
+                Debug.Assert(!Debugger.IsAttached, "Error invoking transform function");
+            }
+
+            return metricDatum;
         }
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change is a follow-up to PR #296 adding a guard against exceptions to the optional callback introduced to transform the metric properties prior to sending them to the server. 
Updates to telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs are autogenerated. 
## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

