### PR TITLE
Add metric: View Toolkit Logs

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1371,6 +1371,10 @@
             "passive": true
         },
         {
+            "name": "toolkit_viewLogs",
+            "description": "View logs for the toolkit"
+        },
+        {
             "name": "sqs_openQueue",
             "description": "Open an SQS queue. Initially opens to either the send message pane or poll messages pane.",
             "metadata": [{ "type": "sqsQueueType" }]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds metric to be recorded when `View Toolkit Logs` action is performed.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

