### PR TITLE
Add dotnet7 lambda runtime

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -140,6 +140,7 @@
                 "dotnetcore2.1",
                 "dotnet5.0",
                 "dotnet6",
+                "dotnet7",
                 "nodejs18.x",
                 "nodejs16.x",
                 "nodejs14.x",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds .NET 7 as a Lambda runtime.

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.

