### PR TITLE
Define metric for create/delete access key for IAM user

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1431,12 +1431,22 @@
             ]
         },
         {
-            "name": "iam_editPolicy",
-            "description": "Edits policy associated with an IAM resource",
+            "name": "iam_edit",
+            "description": "Edits policy/configuration associated with an IAM resource",
             "metadata": [
                 { "type": "result" },
                 { "type": "iamResourceType" }
             ]
+        },
+        {
+            "name": "iam_createUserAccessKey",
+            "description": "Create Access Key for an IAM user",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "iam_deleteUserAccessKey",
+            "description": "Delete Access Key for an IAM user",
+            "metadata": [{ "type": "result" }]
         },
         {
             "name": "lambda_delete",


### PR DESCRIPTION
## Problem
Defines metric for creation/deletion of access key for an IAM user.
This change also updates the definition for editing IAM resource to be generic instead of indicating just policy updates.
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
