### PR TITLE
Define metrics for ECS Cluster/Task operations

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1378,6 +1378,28 @@
             "metadata": [{ "type": "result" }]
         },
         {
+            "name": "ecs_editService",
+            "description": "Edit configuration of an ECS service",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "ecs_deleteCluster",
+            "description": "Delete an ECS cluster",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "ecs_stopTask",
+            "unit": "Count",
+            "description": "Stop ECS task(s)",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "ecs_deleteScheduledTask",
+            "unit": "Count",
+            "description": "Delete ECS Scheduled task(s)",
+            "metadata": [{ "type": "result" }]
+        },
+        {
             "name": "feedback_result",
             "description": "Called while submitting in-IDE feedback",
             "metadata": [{ "type": "result" }]


### PR DESCRIPTION
## Problem
Defines metrics for ECS operations:
* Delete ECS cluster
* Stop ECS tasks
* Delete ECS Scheduled Tasks
* Edit ECS service

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
