### PR TITLE
Define metric when a connection requires a browser login

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -789,6 +789,14 @@
             "passive": true
         },
         {
+            "name": "aws_loginWithBrowser",
+            "description": "Called when a connection requires login using the browser",
+            "metadata": [
+                { "type": "credentialType", "required": false }, 
+                { "type": "credentialSourceId", "required": false }
+            ]
+        },
+        {
             "name": "aws_help",
             "description": "Open docs for the extension",
             "metadata": [{ "type": "name", "required": false }]


### PR DESCRIPTION
## Description
Defines a metric for when a connection requires a login using the browser

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
