### PR TITLE
Minor adjustments to login with browser and delete queue metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -792,6 +792,7 @@
             "name": "aws_loginWithBrowser",
             "description": "Called when a connection requires login using the browser",
             "metadata": [
+                { "type": "result" }, 
                 { "type": "credentialType", "required": false }, 
                 { "type": "credentialSourceId", "required": false }
             ]
@@ -1861,7 +1862,7 @@
         {
             "name": "sqs_deleteQueue",
             "description": "Called when user deletes a SQS queue",
-            "metadata": [{ "type": "result" }, { "type": "sqsQueueType" }]
+            "metadata": [{ "type": "result" }, { "type": "sqsQueueType", "required": false }]
         },
         {
             "name": "sns_createTopic",


### PR DESCRIPTION
## Problem
Minor adjustments to some metrics:
* Delete queue metric now has the queueType as optional
* Login with browser metric now has an associated result field

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
