### PR TITLE
Define metrics for RDS create/delete operations

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1628,6 +1628,38 @@
             "metadata": [{ "type": "result" }]
         },
         {
+            "name": "rds_launchInstance",
+            "description": "Launch a RDS DB instance",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "rds_createSecurityGroup",
+            "description": "Create a RDS security group",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "rds_createSubnetGroup",
+            "description": "Create a RDS subnet group",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "rds_deleteInstance",
+            "description": "Delete a RDS DB instance",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "rds_deleteSecurityGroup",
+            "unit": "Count",
+            "description": "Delete RDS security group(s)",
+            "metadata": [{ "type": "result" }]
+        },
+        {
+            "name": "rds_deleteSubnetGroup",
+            "unit": "Count",
+            "description": "Delete RDS subnet group(s)",
+            "metadata": [{ "type": "result" }]
+        },
+        {
             "name": "rds_createConnectionConfiguration",
             "description": "Called when creating a new database connection configuration to for a RDS database. In Datagrip we do not get this infromation if it is created directly, so this is only counts actions.",
             "metadata": [


### PR DESCRIPTION
## Description
Defines metrics for create/delete resources for RDS
* Launch DB instance
* Create Security group
* Create Subnet group
* Delete DB instance
* Delete Security group
* Delete Subnet group


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
