### PR TITLE
Update repo to reference main branch instead of master

### DIFF
--- a/.github/workflows/csharp-ci.yaml
+++ b/.github/workflows/csharp-ci.yaml
@@ -1,9 +1,9 @@
 name: CI for C# Toolkit Common Telemetry
 on:
     push:
-        branches: [master]
+        branches: [main, master]
     pull_request:
-        branches: [master, feature/*]
+        branches: [main, master, feature/*]
 
 env:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ reported the issue. Please try to include as much information as you can. Detail
 
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the `main` branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode-supplemental.txt
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 
 /// --------------------------------------------------------------------------------
-/// This file is generated from https://github.com/aws/aws-toolkit-common/tree/master/telemetry
+/// This file is generated from https://github.com/aws/aws-toolkit-common/tree/main/telemetry
 /// --------------------------------------------------------------------------------
 
 namespace Test

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/test-data/expectedCode.txt
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 
 /// --------------------------------------------------------------------------------
-/// This file is generated from https://github.com/aws/aws-toolkit-common/tree/master/telemetry
+/// This file is generated from https://github.com/aws/aws-toolkit-common/tree/main/telemetry
 /// --------------------------------------------------------------------------------
 
 namespace Test

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
@@ -97,7 +97,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator
 
             // Add a top level comment
             blankNamespace.Comments.Add(new CodeCommentStatement("--------------------------------------------------------------------------------", true));
-            blankNamespace.Comments.Add(new CodeCommentStatement("This file is generated from https://github.com/aws/aws-toolkit-common/tree/master/telemetry", true));
+            blankNamespace.Comments.Add(new CodeCommentStatement("This file is generated from https://github.com/aws/aws-toolkit-common/tree/main/telemetry", true));
             blankNamespace.Comments.Add(new CodeCommentStatement("--------------------------------------------------------------------------------", true));
 
             // Set up top level using statements

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/Utils/MetricTypeExtensionMethods.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/Utils/MetricTypeExtensionMethods.cs
@@ -8,7 +8,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator.Utils
     {
         static readonly Dictionary<string, System.Type> AliasedTypes = new Dictionary<string, System.Type>()
         {
-            // See https://github.com/aws/aws-toolkit-common/blob/master/telemetry/telemetrySchema.json
+            // See https://github.com/aws/aws-toolkit-common/blob/main/telemetry/telemetrySchema.json
             // properties/types/items/properties/type
             {"int", typeof(int) },
             {"double", typeof(double) },

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/GeneratedCode.cs
@@ -12,7 +12,7 @@ using System;
 using System.Collections.Generic;
 
 /// --------------------------------------------------------------------------------
-/// This file is generated from https://github.com/aws/aws-toolkit-common/tree/master/telemetry
+/// This file is generated from https://github.com/aws/aws-toolkit-common/tree/main/telemetry
 /// --------------------------------------------------------------------------------
 
 namespace Amazon.AwsToolkit.Telemetry.Events.Generated

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Generated/SupplementalCode.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 
 /// --------------------------------------------------------------------------------
-/// This file is generated from https://github.com/aws/aws-toolkit-common/tree/master/telemetry
+/// This file is generated from https://github.com/aws/aws-toolkit-common/tree/main/telemetry
 /// --------------------------------------------------------------------------------
 
 namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Generated


### PR DESCRIPTION
This change prepares the repo to have its main branch renamed from `master` to `main`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
