### PR TITLE
Update modifyCredential metric with optional flag

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -759,7 +759,8 @@
             "metadata": [
                 { "type": "result" },
                 { "type": "credentialModification" },
-                { "type": "source" }
+                { "type": "source" },
+                { "type": "serviceType", "required": false }
             ]
         },
         {


### PR DESCRIPTION
## Description
Adds an optional metadata field for capturing service alongwith the source from where the `modifyCredential` action originates from

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
