### PR TITLE
allow additional 10 codewhispererLanguages for GA

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -480,7 +480,8 @@
             "name": "codewhispererLanguage",
             "type": "string",
             "description": "Programming language of the CodeWhisperer recommendation",
-            "allowedValues": ["java", "python", "javascript", "plaintext", "jsx", "typescript", "tsx", "csharp"]
+            "allowedValues": ["java", "python", "javascript", "plaintext", "jsx", "typescript", "tsx", "csharp",
+                "c", "cpp", "go", "kotlin", "php", "ruby", "rust", "scala", "shell", "sql"]
         },
         {
             "name": "codewhispererLastSuggestionIndex",


### PR DESCRIPTION
## Problem
Add 10 more codewhisperer languages to common
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
