### PR TITLE
Add file type for serverless template

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -24,6 +24,7 @@
                 "eventbridgeSchema",
                 "iamPolicy",
                 "samconfig",
+                "serverless",
                 "stepfunctionsAsl",
                 "smithyModel",
                 "ssmDocument",


### PR DESCRIPTION
## Description
Adds an allowed value for file type corresponding to` serverless` template relevant to VS toolkit.
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
