### PR TITLE
fix(codewhisperer): remove imports in the userDecision field

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -546,11 +546,6 @@
             "description": "Number of references the particular suggestion is referenced with."
         },
         {
-            "name": "codewhispererSuggestionImports",
-            "type": "string",
-            "description": "The list of import statement for a particular suggestion"
-        },
-        {
             "name": "codewhispererSuggestionImportCount",
             "type": "int",
             "description": "The number of import statements included with recommendation."
@@ -2488,10 +2483,6 @@
                 },
                 {
                     "type": "codewhispererSuggestionImportCount",
-                    "required": false
-                },
-                {
-                    "type": "codewhispererSuggestionImports",
                     "required": false
                 },
                 {


### PR DESCRIPTION
## Problem
A design revisit was done. The conclusion is: The string of import should be removed from userDecision field. 

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
