### PR TITLE
Update Telemetry service model's Value type, and add the OS architecture field

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+telemetry/service/service-model.json

--- a/telemetry/service/service-model.json
+++ b/telemetry/service/service-model.json
@@ -189,6 +189,7 @@
         "AWSProductVersion":{"shape":"AWSProductVersion"},
         "ClientID":{"shape":"ClientID"},
         "OS":{"shape":"Value"},
+        "OSArchitecture":{"shape":"Value"},
         "OSVersion":{"shape":"Value"},
         "ParentProduct":{"shape":"Value"},
         "ParentProductVersion":{"shape":"Value"},
@@ -229,8 +230,7 @@
     },
     "Value":{
       "type":"string",
-      "max":200,
-      "min":1
+      "max":65536
     }
   }
 }


### PR DESCRIPTION
This change also adds a `.prettierignore` file so that the service model does not get auto-formatted.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
