### PR TITLE
Update Open url metric to record source

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -841,7 +841,11 @@
         {
             "name": "aws_openUrl",
             "description": "Opens a url",
-            "metadata": [{ "type": "result" }, { "type": "url", "required": false }]
+            "metadata": [
+                { "type": "result" },
+                { "type": "url", "required": false },
+                { "type": "source", "required": false }
+            ]
         },
         {
             "name": "aws_saveCredentials",


### PR DESCRIPTION
## Solution
Updates `aws_openUrl` metric to optionally record the source associated.
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
