### PR TITLE
Add metric for toolkit notification

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -313,6 +313,11 @@
             "name": "failedCount",
             "type": "int",
             "description": "The number of failed operations"
+        },
+        {
+            "name": "notificationId",
+            "type": "string",
+            "description": "The ID of the notification being shown"
         }
     ],
     "metrics": [
@@ -1167,6 +1172,28 @@
                 }
             ],
             "passive": true
+        },
+        {
+            "name": "toolkit_showNotification",
+            "description": "The toolkit tried to retrieve and show notification message",
+            "metadata": [
+                {
+                    "type": "result",
+                    "required": true
+                },
+                {
+                    "type": "notificationId",
+                    "required": true
+                },
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "url",
+                    "required": false
+                }
+            ]
         },
         {
             "name": "dynamicresource_getResource",


### PR DESCRIPTION
Add metric for toolkit notification. Emits the following:
- Result to track success/failure
- NotificationId to map the metric to the source Notification message
- Reason (optional) to describe failures
- url (optional) to emit on failures 
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
