### PR TITLE
add source metadata to showNotification

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -54,7 +54,7 @@
         },
         {
             "name": "component",
-            "allowedValues": ["editor", "viewer", "filesystem"],
+            "allowedValues": ["editor", "viewer", "filesystem", "explorer", "infobar"],
             "description": "The IDE or OS component used for the action. (Examples: S3 download to filesystem, S3 upload from editor, ...)"
         },
         {
@@ -2195,7 +2195,7 @@
                     "required": true
                 },
                 {
-                    "type": "source",
+                    "type": "component",
                     "required": true
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2195,6 +2195,10 @@
                     "required": true
                 },
                 {
+                    "type": "source",
+                    "required": true
+                },
+                {
                     "type": "reason",
                     "required": false
                 }


### PR DESCRIPTION
add source metadata to showNotification. 
This will be used to track which area of the toolkit is surfacing the Notification. 
(e.g. VS Info Bar vs. AWS Explorer)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
