### PR TITLE
add crossfile + utg metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -571,6 +571,26 @@
             "description": "The number of import statements included with recommendation."
         },
         {
+            "name": "codewhispererSupplementalContextTimeout",
+            "type": "boolean",
+            "description": "If the supplemental context fetching timeout or not"
+        },
+        {
+            "name": "codewhispererSupplementalContextIsUtg",
+            "type": "boolean",
+            "description": "If the supplemental context is for test file(UTG) or src file"
+        },
+        {
+            "name": "codewhispererSupplementalContextLatency",
+            "type": "int",
+            "description": "Latency to obtain supplemental context"
+        },
+        {
+            "name": "codewhispererSupplementalContextLength",
+            "type": "int",
+            "description": "Length of codewhisperer supplemental context extracted from files"
+        },
+        {
             "name": "codewhispererImportRecommendationEnabled",
             "type": "boolean",
             "description": "Whether Import Recommendation is enabled."
@@ -2461,6 +2481,22 @@
                 },
                 {
                     "type": "codewhispererSessionId",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextTimeout",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextIsUtg",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextLatency",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextLength",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -582,7 +582,7 @@
         },
         {
             "name": "codewhispererSupplementalContextLatency",
-            "type": "int",
+            "type": "double",
             "description": "Latency to obtain supplemental context"
         },
         {


### PR DESCRIPTION
## Context
### UTG
unit test generator, which will be triggered in tst files, how we find "focal files" for UTG, findFocalFileByName first then findFocalFileByContent.

### CrossFileContext
will be trigger in src files, and we obtain 60 code chunks from imported files first then files within same package


## Solution
adding the following fields in `codewhisperer_serviceInvocation`:

- `codewhispererSupplementalContextTimeout`

- `codewhispererSupplementalContextIsUtg`: We need to know how much portion of customers are trying to use Cwspr to generate Unit test 

- `codewhispererSupplementalContextLatency`: Currently we have a 50ms timeout threadshold, we need this to help us improve and make decision if we need to update the number

- `codewhispererSupplementalContextLength`: It will help us determine the effectiveness of cross file context & utg
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
