### PR TITLE
telemetry: allow filter-related fields on cloudwatchlogs_open

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1125,7 +1125,7 @@
         },
         {
             "name": "cloudwatchlogs_filter",
-            "description": "Filters a CloudWatch Logs entity. Deprecated: use cloudwatchlogs_open instead.",
+            "description": "Filters a CloudWatch Logs entity. (Essentially a subset of cloudwatchlogs_open)",
             "metadata": [
                 { "type": "result" },
                 { "type": "cloudWatchResourceType" },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1052,6 +1052,8 @@
                 { "type": "cloudWatchResourceType" },
                 { "type": "cloudWatchLogsPresentation", "required": false },
                 { "type": "serviceType", "required": false },
+                { "type": "hasTextFilter", "required": false },
+                { "type": "hasTimeFilter", "required": false },
                 { "type": "source" }
             ]
         },
@@ -1123,7 +1125,7 @@
         },
         {
             "name": "cloudwatchlogs_filter",
-            "description": "Filters a CloudWatch Logs entity.",
+            "description": "Filters a CloudWatch Logs entity. Deprecated: use cloudwatchlogs_open instead.",
             "metadata": [
                 { "type": "result" },
                 { "type": "cloudWatchResourceType" },


### PR DESCRIPTION
`cloudwatchlogs_open` generally covers all cases where cloudwatch logs are fetched in various ways, which may include filter parameters. Adding these fields to `cloudwatchlogs_open` allows that metric to be used generically instead of the special-case `cloudwatchlogs_filter`.

After this change, `cloudwatchlogs_filter` metric is redundant/unnecessary.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
