### PR TITLE
telemetry: add generic `requestId`

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -90,7 +90,7 @@
         {
             "name": "requestServiceType",
             "type": "string",
-            "description": "The service identifier associated with a request. Values should have the same shape as `serviceType`. This is distinct from `serviceType` which describes the originator of the request rather than the request itself."
+            "description": "Per-request service identifier. Unlike `serviceType` (which describes the originator of the request), this describes the request itself."
         },
         {
             "name": "requestId",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -88,6 +88,11 @@
             "description": "The name of the AWS service acted on. These values come from the AWS SDK. To find them in the JAVA SDK search for SERVICE_NAME in each service client, or look for serviceId in metadata in the service2.json"
         },
         {
+            "name": "requestId",
+            "type": "string",
+            "description": "A generic request ID field. The semantics are contextual based off of other fields (e.g. `serviceType`). For example, an event with `serviceType: s3` means that the request ID is associated with an S3 API call. Events that cover mutliple API calls should use the request ID of the most recent call."
+        },
+        {
             "name": "name",
             "type": "string",
             "description": "A generic name metadata"

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -90,7 +90,7 @@
         {
             "name": "requestServiceId",
             "type": "string",
-            "description": "The service identifier associated with a request. This is distinct from `serviceType` which describes the originator of the request rather than the reqeust itself."
+            "description": "The service identifier associated with a request. Values should have the same shape as `serviceType`. This is distinct from `serviceType` which describes the originator of the request rather than the reqeust itself."
         },
         {
             "name": "requestId",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -88,14 +88,14 @@
             "description": "The name of the AWS service acted on. These values come from the AWS SDK. To find them in the JAVA SDK search for SERVICE_NAME in each service client, or look for serviceId in metadata in the service2.json"
         },
         {
-            "name": "requestServiceId",
+            "name": "requestServiceType",
             "type": "string",
             "description": "The service identifier associated with a request. Values should have the same shape as `serviceType`. This is distinct from `serviceType` which describes the originator of the request rather than the request itself."
         },
         {
             "name": "requestId",
             "type": "string",
-            "description": "A generic request ID field. The semantics are contextual based off of other fields (e.g. `requestServiceId`). For example, an event with `requestServiceId: s3` means that the request ID is associated with an S3 API call. Events that cover mutliple API calls should use the request ID of the most recent call."
+            "description": "A generic request ID field. The semantics are contextual based off of other fields (e.g. `requestServiceType`). For example, an event with `requestServiceType: s3` means that the request ID is associated with an S3 API call. Events that cover mutliple API calls should use the request ID of the most recent call."
         },
         {
             "name": "name",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -88,9 +88,14 @@
             "description": "The name of the AWS service acted on. These values come from the AWS SDK. To find them in the JAVA SDK search for SERVICE_NAME in each service client, or look for serviceId in metadata in the service2.json"
         },
         {
+            "name": "requestServiceId",
+            "type": "string",
+            "description": "The service identifier associated with a request. This is distinct from `serviceType` which describes the originator of the request rather than the reqeust itself."
+        },
+        {
             "name": "requestId",
             "type": "string",
-            "description": "A generic request ID field. The semantics are contextual based off of other fields (e.g. `serviceType`). For example, an event with `serviceType: s3` means that the request ID is associated with an S3 API call. Events that cover mutliple API calls should use the request ID of the most recent call."
+            "description": "A generic request ID field. The semantics are contextual based off of other fields (e.g. `requestServiceId`). For example, an event with `requestServiceId: s3` means that the request ID is associated with an S3 API call. Events that cover mutliple API calls should use the request ID of the most recent call."
         },
         {
             "name": "name",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -90,7 +90,7 @@
         {
             "name": "requestServiceId",
             "type": "string",
-            "description": "The service identifier associated with a request. Values should have the same shape as `serviceType`. This is distinct from `serviceType` which describes the originator of the request rather than the reqeust itself."
+            "description": "The service identifier associated with a request. Values should have the same shape as `serviceType`. This is distinct from `serviceType` which describes the originator of the request rather than the request itself."
         },
         {
             "name": "requestId",


### PR DESCRIPTION
**This field is intentionally "lossy" in order to accommodate a wide variety of scenarios**

I know I said that unambiguous data is favorable over duplication [here](https://github.com/aws/aws-toolkit-common/pull/478#discussion_r1184051015). That's still true. But data with a small amount of uncertainty is still more useful than no data. As much as I would like to differentiate every single API call made during a workflow, that's just not practical right now.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
