### PR TITLE
LSP: Fix bug in matching strategy when working with multiple providers

### DIFF
--- a/lsp/.vscode/launch.json
+++ b/lsp/.vscode/launch.json
@@ -7,7 +7,7 @@
             "type": "node",
             "request": "attach",
             "port": 6012, // Hard defined in the vscode client activation.ts
-            "outFiles": ["${workspaceFolder}/out/src/server/**/*.js"],
+            "outFiles": ["${workspaceFolder}/out/src/server/**/*.js", "${workspaceFolder}/out/src/service/**/*.js"],
             "restart": {
                 "maxAttempts": 10,
                 "delay": 1000

--- a/lsp/src/service/registry/registry.ts
+++ b/lsp/src/service/registry/registry.ts
@@ -26,6 +26,13 @@ export class LanguageServiceRegistry implements LanguageServiceContext {
     }
 
     private async getMatchingStrategy(textDocument: TextDocument): Promise<LanguageServiceStrategy | undefined> {
-        return Promise.any(this.strategies.filter(strategy => strategy.isMatch(textDocument)))
+        for (const strategy of this.strategies) {
+            const isMatch = await strategy.isMatch(textDocument)
+            if (isMatch) {
+                return strategy
+            }
+        }
+
+        return undefined
     }
 }


### PR DESCRIPTION

When we have multiple language providers, where is a bug where the selector does not choose the first applicable provider. This change fixes that bug.

I also found that I couldn't place breakpoints on service files, so I updated launch.json to fix that problem.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
