### PR TITLE
Update yaml-language-server

### DIFF
--- a/lsp/package-lock.json
+++ b/lsp/package-lock.json
@@ -13,7 +13,7 @@
                 "vscode-languageserver": "^7.0.0",
                 "vscode-languageserver-textdocument": "^1.0.4",
                 "vscode-uri": "^3.0.7",
-                "yaml-language-server": "^1.11.0"
+                "yaml-language-server": "^1.13.0"
             },
             "bin": {
                 "awsdocuments-language-server": "out/src/server/server.js"
@@ -2138,6 +2138,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "node_modules/lodash.get": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -2808,10 +2813,10 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-            "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
-            "dev": true,
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+            "devOptional": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -3841,19 +3846,20 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "2.0.0-11",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-11.tgz",
-            "integrity": "sha512-5kGSQrzDyjCk0BLuFfjkoUE9vYcoyrwZIZ+GnpOSM9vhkvPjItYiWJ1jpRSo0aU4QmsoNrFwDT4O7XS2UGcBQg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+            "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
             "engines": {
-                "node": ">= 12"
+                "node": ">= 14"
             }
         },
         "node_modules/yaml-language-server": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.11.0.tgz",
-            "integrity": "sha512-1TBlhK1nMSpDiq3iZfAyDOg4xwagozZAnqr0AOrZG5UteMt3zbfhOVqhRuAunRIZ8kktfGMjsKxDjO+utGAJaA==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.13.0.tgz",
+            "integrity": "sha512-CzekVjFOUkiXI6tg3BPuSkxE60keDT4/+LjPLXwnt4gCRzaaWMCjT92NxOHv1derbBLHWoecay48tse/De181Q==",
             "dependencies": {
                 "ajv": "^8.11.0",
+                "lodash": "4.17.21",
                 "request-light": "^0.5.7",
                 "vscode-json-languageservice": "4.1.8",
                 "vscode-languageserver": "^7.0.0",
@@ -3861,13 +3867,13 @@
                 "vscode-languageserver-types": "^3.16.0",
                 "vscode-nls": "^5.0.0",
                 "vscode-uri": "^3.0.2",
-                "yaml": "2.0.0-11"
+                "yaml": "2.2.2"
             },
             "bin": {
                 "yaml-language-server": "bin/yaml-language-server"
             },
             "optionalDependencies": {
-                "prettier": "2.0.5"
+                "prettier": "2.8.7"
             }
         },
         "node_modules/yaml-language-server/node_modules/ajv": {
@@ -3890,27 +3896,10 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
-        "node_modules/yaml-language-server/node_modules/prettier": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-            "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
-            "optional": true,
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/yaml-language-server/node_modules/request-light": {
             "version": "0.5.8",
             "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
             "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="
-        },
-        "node_modules/yaml-language-server/node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
         "node_modules/yargs": {
             "version": "16.2.0",
@@ -5492,6 +5481,11 @@
                 "p-locate": "^5.0.0"
             }
         },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "lodash.get": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -5989,10 +5983,10 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-            "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
-            "dev": true
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+            "devOptional": true
         },
         "pretty-quick": {
             "version": "3.1.3",
@@ -6774,17 +6768,18 @@
             "dev": true
         },
         "yaml": {
-            "version": "2.0.0-11",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-11.tgz",
-            "integrity": "sha512-5kGSQrzDyjCk0BLuFfjkoUE9vYcoyrwZIZ+GnpOSM9vhkvPjItYiWJ1jpRSo0aU4QmsoNrFwDT4O7XS2UGcBQg=="
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+            "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
         },
         "yaml-language-server": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.11.0.tgz",
-            "integrity": "sha512-1TBlhK1nMSpDiq3iZfAyDOg4xwagozZAnqr0AOrZG5UteMt3zbfhOVqhRuAunRIZ8kktfGMjsKxDjO+utGAJaA==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.13.0.tgz",
+            "integrity": "sha512-CzekVjFOUkiXI6tg3BPuSkxE60keDT4/+LjPLXwnt4gCRzaaWMCjT92NxOHv1derbBLHWoecay48tse/De181Q==",
             "requires": {
                 "ajv": "^8.11.0",
-                "prettier": "2.0.5",
+                "lodash": "4.17.21",
+                "prettier": "2.8.7",
                 "request-light": "^0.5.7",
                 "vscode-json-languageservice": "4.1.8",
                 "vscode-languageserver": "^7.0.0",
@@ -6792,7 +6787,7 @@
                 "vscode-languageserver-types": "^3.16.0",
                 "vscode-nls": "^5.0.0",
                 "vscode-uri": "^3.0.2",
-                "yaml": "2.0.0-11"
+                "yaml": "2.2.2"
             },
             "dependencies": {
                 "ajv": {
@@ -6811,21 +6806,10 @@
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
                 },
-                "prettier": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-                    "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
-                    "optional": true
-                },
                 "request-light": {
                     "version": "0.5.8",
                     "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
                     "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="
-                },
-                "vscode-languageserver-types": {
-                    "version": "3.16.0",
-                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-                    "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
                 }
             }
         },

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -36,7 +36,7 @@
         "vscode-languageserver": "^7.0.0",
         "vscode-languageserver-textdocument": "^1.0.4",
         "vscode-uri": "^3.0.7",
-        "yaml-language-server": "^1.11.0"
+        "yaml-language-server": "^1.13.0"
     },
     "devDependencies": {
         "@types/chai": "^4.3.4",

--- a/lsp/src/utils/yaml/service.ts
+++ b/lsp/src/utils/yaml/service.ts
@@ -10,11 +10,11 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 import { createConnection } from 'vscode-languageserver/lib/node/main'
 import { URI } from 'vscode-uri'
 import {
-    getLanguageService as getYamlLanguageService,
-    LanguageService as OriginalYamlLanguageService,
     LanguageSettings,
+    LanguageService as OriginalYamlLanguageService,
     SchemaRequestService,
     SchemasSettings,
+    getLanguageService as getYamlLanguageService,
 } from 'yaml-language-server'
 import { LanguageService } from '../../service/types'
 import { UriContentResolver } from '../uri/resolve'
@@ -92,7 +92,12 @@ export class YamlLanguageServiceBuilder {
         }
         const connection = createConnection()
         const yamlTelemetry = new YAMLTelemetry(connection)
-        const yaml = getYamlLanguageService(schemaResolver, workspaceContext, connection, yamlTelemetry, null as any)
+        const yaml = getYamlLanguageService({
+            schemaRequestService: schemaResolver,
+            workspaceContext,
+            connection,
+            telemetry: yamlTelemetry,
+        })
 
         if (languageSettings) {
             yaml.configure(languageSettings)


### PR DESCRIPTION

This change updates the yaml language server dependency to address the `npm audit` warning.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
