### PR TITLE
add cwspr cross file attributes to userDecision & userTriggerDecision event

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2647,6 +2647,18 @@
                     "type": "codewhispererSuggestionState"
                 },
                 {
+                    "type": "codewhispererSupplementalContextTimeout",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextIsUtg",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextLength",
+                    "required": false
+                },
+                {
                     "type": "codewhispererTriggerType"
                 },
                 {
@@ -2747,6 +2759,18 @@
                 },
                 {
                     "type": "codewhispererClassifierResult",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextTimeout",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextIsUtg",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextLength",
                     "required": false
                 },
                 {


### PR DESCRIPTION
Previously we only have these fields in `codewhisperer_serviceInvocation`, to make both eng & sci team easier to access & work with these data, add crossFile related attributes to `codewhisperer_userDecision` & `codewhisperer_userTriggerDecision` as well
- `codewhispererSupplementalContextTimeout`
- `codewhispererSupplementalContextIsUtg`
- `codewhispererSupplementalContextLength`




## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
