### PR TITLE
add codewhispererUserGroup attribute in critical codewhisperer telemetry events

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -725,6 +725,11 @@
             "description": "The threshold of Classifier trigger."
         },
         {
+            "name": "codewhispererUserGroup",
+            "type": "string",
+            "description": "The user group identifier we assign to the customer and it should be unique identifier across different IDE platforms, i.e. Classifier, CrossFile etc."
+        },
+        {
             "name": "syncedResources",
             "type": "string",
             "description": "Describes which parts of an application (that we know of) were synced to the cloud. \"Code\" resources follow the SAM spec: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-sync.html",
@@ -2425,6 +2430,9 @@
                     "type": "codewhispererTotalTokens"
                 },
                 {
+                    "type": "codewhispererUserGroup"
+                },
+                {
                     "type": "reason",
                     "required": false
                 },
@@ -2571,6 +2579,9 @@
                 {
                     "type": "codewhispererImportRecommendationEnabled",
                     "required": false
+                },
+                {
+                    "type": "codewhispererUserGroup"
                 }
             ]
         },
@@ -2652,6 +2663,9 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                {
+                    "type": "codewhispererUserGroup"
                 }
             ]
         },
@@ -2752,6 +2766,9 @@
                 {
                     "type": "codewhispererClassifierThreshold",
                     "required": false
+                },
+                {
+                    "type": "codewhispererUserGroup"
                 }
             ]
         },
@@ -2792,6 +2809,9 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                {
+                    "type": "codewhispererUserGroup"
                 }
             ]
         },
@@ -2821,6 +2841,9 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                {
+                    "type": "codewhispererUserGroup"
                 }
             ]
         },
@@ -2865,6 +2888,9 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                {
+                    "type": "codewhispererUserGroup"
                 }
             ]
         },


### PR DESCRIPTION
## Problem
By adding these field, both eng & sci team will be easier to work with CodeWhisperer client side A/B testing. 
CodeWhispererUserGroup should be an unique string identifier across different IDE platforms, for example, `Feature_1_Group`, `Feature_2_Group`, `Default_Group` etc. 

Note: CodeWhispererUserGroup will be a `required` field for the following critical CodeWhisperer recommendation metrics
- `codewhisperer_serviceInovcation`
- `codewhisperer_userDecision`
- `codewhisperer_userTriggerDecision`
- `codewhisperer_codePercentage`
- `codewhisperer_userModification`
- `codewhisperer_clientComponentLatency`
- `codewhisperer_perceivedLatency`

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
