### PR TITLE
Proof of Concept: Reusable JSON and Yaml servers powered by JSON Schemas

### DIFF
--- a/lsp/ARCHITECTURE.md
+++ b/lsp/ARCHITECTURE.md
@@ -1,5 +1,13 @@
 # TODO : IDE-10874 : This page is out of date while working in a feature branch
 
+# WIP
+
+These designs are at the proof of concept level:
+
+`AwsLanguageService` is the interface for the inner-most language processing "component". It closely follows the interfaces exposed by the VS Code language servers (specifically the JSON language server). These are intended to be reusable. Language servers are composed from `AwsLanguageService` implementations.
+
+To support the goal of providing language support in the browser and in client applications, `AwsLanguageService` implementations should inject handling (where necessary) for features not supported by the browser (like file I/O, etc).
+
 # Architecture
 
 The application consists of two components: the language server, and the language services.

--- a/lsp/ARCHITECTURE.md
+++ b/lsp/ARCHITECTURE.md
@@ -4,9 +4,17 @@
 
 These designs are at the proof of concept level:
 
-`AwsLanguageService` is the interface for the inner-most language processing "component". It closely follows the interfaces exposed by the VS Code language servers (specifically the JSON language server). These are intended to be reusable. Language servers are composed from `AwsLanguageService` implementations.
+-   service (interface `AwsLanguageService`)
 
-To support the goal of providing language support in the browser and in client applications, `AwsLanguageService` implementations should inject handling (where necessary) for features not supported by the browser (like file I/O, etc).
+    -   the interface for the inner-most language processing "component"
+    -   closely follows the interfaces exposed by the VS Code language servers (specifically the JSON language server)
+    -   intended to be reusable -- Language servers are composed of `AwsLanguageService` implementations.
+    -   To support the goal of providing language support in the browser and in client applications, `AwsLanguageService` implementations should inject handling (where necessary) for features not supported by the browser (like file I/O, etc).
+
+-   server (language server)
+    -   the functional component that communicates with Language clients
+    -   wraps `AwsLanguageService` implementations
+    -   operates on an LSP connection
 
 # Architecture
 

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -22,6 +22,9 @@ Monorepo
     └── visualStudio/ - Minimal Visual Studio extension to test the language server
     └── vscode/ - Minimal vscode extension to test the language server
 ── core - contains supporting libraries used by app and server packages
+    └── aws-lsp-core - core support code
+    └── aws-lsp-json-common - reusable code related to JSON language service handling
+    └── aws-lsp-yaml-common - reusable code related to YAML language service handling
     └── todo : IDE-10874
 ── server - packages that contain Language Server implementations
     └── todo : IDE-10874

--- a/lsp/core/aws-lsp-core/package.json
+++ b/lsp/core/aws-lsp-core/package.json
@@ -5,5 +5,9 @@
     "main": "out/index.js",
     "scripts": {
         "compile": "tsc --build"
+    },
+    "dependencies": {
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
     }
 }

--- a/lsp/core/aws-lsp-core/src/content/schemaProvider.ts
+++ b/lsp/core/aws-lsp-core/src/content/schemaProvider.ts
@@ -1,0 +1,7 @@
+/**
+ * The schema request service is used to fetch schemas. If successful, returns a resolved promise with the content of the schema.
+ * In case of an error, returns a rejected promise with a displayable error string.
+ */
+export interface SchemaProvider {
+    (uri: string): Promise<string>
+}

--- a/lsp/core/aws-lsp-core/src/index.ts
+++ b/lsp/core/aws-lsp-core/src/index.ts
@@ -1,2 +1,4 @@
 // todo : IDE-10874 : move core support files into this package from pre-monorepo locations
-export interface Foo {}
+export * from './content/schemaProvider'
+export * as completionItemUtils from './util/completionItemUtils'
+export * as textDocumentUtils from './util/textDocumentUtils'

--- a/lsp/core/aws-lsp-core/src/index.ts
+++ b/lsp/core/aws-lsp-core/src/index.ts
@@ -1,4 +1,5 @@
 // todo : IDE-10874 : move core support files into this package from pre-monorepo locations
 export * from './content/schemaProvider'
+export * from './language-service/awsLanguageService'
 export * as completionItemUtils from './util/completionItemUtils'
 export * as textDocumentUtils from './util/textDocumentUtils'

--- a/lsp/core/aws-lsp-core/src/language-service/awsLanguageService.ts
+++ b/lsp/core/aws-lsp-core/src/language-service/awsLanguageService.ts
@@ -1,8 +1,12 @@
 import { Position, Range, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
 import { CompletionList, Diagnostic, FormattingOptions, Hover } from 'vscode-languageserver-types'
 
-// Where possible, this interface should follow the (VS Code) JSON Language Server's interface, which is close
-// to the core (VS Code) language server implementations.
+// Where possible, this interface should follow the (VS Code) JSON Language Server's interface,
+// (https://github.com/microsoft/vscode-json-languageservice/blob/v5.3.5/src/jsonLanguageService.ts#L38)
+// which closely resembles the core (VS Code) language server implementations.
+// We would prefer to leverage truly core types (like those from vscode-languageserver-textdocument),
+// since the JSON Language Service is a specific product and not a generalized interface type,
+// we have an explicit interface here for use in language services (and consumers).
 export interface AwsLanguageService {
     isSupported(document: TextDocument): boolean
     doValidation(textDocument: TextDocument): PromiseLike<Diagnostic[]>

--- a/lsp/core/aws-lsp-core/src/language-service/awsLanguageService.ts
+++ b/lsp/core/aws-lsp-core/src/language-service/awsLanguageService.ts
@@ -1,0 +1,12 @@
+import { Position, Range, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
+import { CompletionList, Diagnostic, FormattingOptions, Hover } from 'vscode-languageserver-types'
+
+// Where possible, this interface should follow the (VS Code) JSON Language Server's interface, which is close
+// to the core (VS Code) language server implementations.
+export interface AwsLanguageService {
+    isSupported(document: TextDocument): boolean
+    doValidation(textDocument: TextDocument): PromiseLike<Diagnostic[]>
+    doComplete(textDocument: TextDocument, position: Position): PromiseLike<CompletionList | null>
+    doHover(textDocument: TextDocument, position: Position): PromiseLike<Hover | null>
+    format(textDocument: TextDocument, range: Range, options: FormattingOptions): TextEdit[]
+}

--- a/lsp/core/aws-lsp-core/src/util/completionItemUtils.ts
+++ b/lsp/core/aws-lsp-core/src/util/completionItemUtils.ts
@@ -1,0 +1,7 @@
+import { CompletionItem } from 'vscode-languageserver-types'
+
+export function prependItemDetail(items: CompletionItem[], text: string): void {
+    for (const item of items) {
+        item.detail = item.detail!! ? `${text}: ${item.detail}` : text
+    }
+}

--- a/lsp/core/aws-lsp-core/src/util/textDocumentUtils.ts
+++ b/lsp/core/aws-lsp-core/src/util/textDocumentUtils.ts
@@ -1,0 +1,14 @@
+import { Range, TextDocument } from 'vscode-languageserver-textdocument'
+
+export const getFullRange = (textDocument: TextDocument): Range => {
+    return {
+        start: {
+            line: 0,
+            character: 0,
+        },
+        end: {
+            line: textDocument.lineCount,
+            character: 0,
+        },
+    }
+}

--- a/lsp/core/aws-lsp-json-common/package.json
+++ b/lsp/core/aws-lsp-json-common/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@lsp-placeholder/aws-lsp-json-common",
+    "version": "0.0.1",
+    "description": "JSON Language Server common code library",
+    "main": "out/index.js",
+    "scripts": {
+        "compile": "tsc --build"
+    },
+    "dependencies": {
+        "@lsp-placeholder/aws-lsp-core": "^0.0.1",
+        "vscode-json-languageservice": "^5.3.5",
+        "vscode-languageserver": "8.0.1",
+        "vscode-languageserver-textdocument": "^1.0.8"
+    }
+}

--- a/lsp/core/aws-lsp-json-common/src/index.ts
+++ b/lsp/core/aws-lsp-json-common/src/index.ts
@@ -1,2 +1,2 @@
-export * from './language-server/jsonLanguageServiceWrapper'
+export * from './language-server/jsonLanguageService'
 export * from './language-server/jsonSchemaServer'

--- a/lsp/core/aws-lsp-json-common/src/index.ts
+++ b/lsp/core/aws-lsp-json-common/src/index.ts
@@ -1,0 +1,2 @@
+export * from './language-server/jsonLanguageServiceWrapper'
+export * from './language-server/jsonSchemaServer'

--- a/lsp/core/aws-lsp-json-common/src/language-server/jsonLanguageService.ts
+++ b/lsp/core/aws-lsp-json-common/src/language-server/jsonLanguageService.ts
@@ -1,21 +1,17 @@
-import { SchemaProvider } from '@lsp-placeholder/aws-lsp-core'
+import { AwsLanguageService, SchemaProvider } from '@lsp-placeholder/aws-lsp-core'
 import { JSONDocument, LanguageService, getLanguageService } from 'vscode-json-languageservice'
 import { CompletionList, Diagnostic, FormattingOptions, Hover, Range } from 'vscode-languageserver'
 import { Position, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
 
-export type JsonLanguageServiceWrapperProps = {
+export type JsonLanguageServiceProps = {
     defaultSchemaUri?: string
     schemaProvider?: SchemaProvider
 }
 
-export class JsonLanguageServiceWrapper {
+export class JsonLanguageService implements AwsLanguageService {
     private jsonService: LanguageService
 
-    public static isLangaugeIdSupported(languageId: string): boolean {
-        return languageId === 'json' || languageId === 'christou-test-json'
-    }
-
-    constructor(private readonly props: JsonLanguageServiceWrapperProps) {
+    constructor(private readonly props: JsonLanguageServiceProps) {
         this.jsonService = getLanguageService({
             schemaRequestService: props.schemaProvider?.bind(this),
         })
@@ -23,6 +19,11 @@ export class JsonLanguageServiceWrapper {
         const schemas = props.defaultSchemaUri ? [{ fileMatch: ['*.json'], uri: props.defaultSchemaUri }] : undefined
 
         this.jsonService.configure({ allowComments: false, schemas })
+    }
+
+    public isSupported(document: TextDocument): boolean {
+        const languageId = document.languageId
+        return languageId === 'json' || languageId === 'christou-test-json'
     }
 
     public doValidation(textDocument: TextDocument): Thenable<Diagnostic[]> {

--- a/lsp/core/aws-lsp-json-common/src/language-server/jsonLanguageService.ts
+++ b/lsp/core/aws-lsp-json-common/src/language-server/jsonLanguageService.ts
@@ -8,6 +8,10 @@ export type JsonLanguageServiceProps = {
     schemaProvider?: SchemaProvider
 }
 
+/**
+ * This is a thin wrapper around the VS Code Json Language Service
+ * https://github.com/microsoft/vscode-json-languageservice/
+ */
 export class JsonLanguageService implements AwsLanguageService {
     private jsonService: LanguageService
 

--- a/lsp/core/aws-lsp-json-common/src/language-server/jsonLanguageServiceWrapper.ts
+++ b/lsp/core/aws-lsp-json-common/src/language-server/jsonLanguageServiceWrapper.ts
@@ -1,0 +1,59 @@
+import { SchemaProvider } from '@lsp-placeholder/aws-lsp-core'
+import { JSONDocument, LanguageService, getLanguageService } from 'vscode-json-languageservice'
+import { CompletionList, Diagnostic, FormattingOptions, Hover, Range } from 'vscode-languageserver'
+import { Position, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
+
+export type JsonLanguageServiceWrapperProps = {
+    defaultSchemaUri?: string
+    schemaProvider?: SchemaProvider
+}
+
+export class JsonLanguageServiceWrapper {
+    private jsonService: LanguageService
+
+    public static isLangaugeIdSupported(languageId: string): boolean {
+        return languageId === 'json' || languageId === 'christou-test-json'
+    }
+
+    constructor(private readonly props: JsonLanguageServiceWrapperProps) {
+        this.jsonService = getLanguageService({
+            schemaRequestService: props.schemaProvider?.bind(this),
+        })
+
+        const schemas = props.defaultSchemaUri ? [{ fileMatch: ['*.json'], uri: props.defaultSchemaUri }] : undefined
+
+        this.jsonService.configure({ allowComments: false, schemas })
+    }
+
+    public doValidation(textDocument: TextDocument): Thenable<Diagnostic[]> {
+        const jsonDocument = this.parse(textDocument)
+
+        return this.jsonService.doValidation(textDocument, jsonDocument)
+    }
+
+    public doComplete(textDocument: TextDocument, position: Position): Thenable<CompletionList | null> {
+        const jsonDocument = this.parse(textDocument)
+
+        return this.jsonService.doComplete(textDocument, position, jsonDocument)
+    }
+
+    public doHover(textDocument: TextDocument, position: Position): Thenable<Hover | null> {
+        const jsonDocument = this.parse(textDocument)
+
+        return this.jsonService.doHover(textDocument, position, jsonDocument)
+    }
+
+    public format(textDocument: TextDocument, range: Range, options: FormattingOptions): TextEdit[] {
+        return this.jsonService.format(textDocument, range, options)
+    }
+
+    private parse(textDocument: TextDocument): JSONDocument {
+        const jsonDocument = this.jsonService.parseJSONDocument(textDocument)
+
+        if (!jsonDocument) {
+            throw new Error(`Unable to parse document with uri: ${textDocument.uri}`)
+        }
+
+        return jsonDocument
+    }
+}

--- a/lsp/core/aws-lsp-json-common/src/language-server/jsonSchemaServer.ts
+++ b/lsp/core/aws-lsp-json-common/src/language-server/jsonSchemaServer.ts
@@ -1,0 +1,130 @@
+import { SchemaProvider, textDocumentUtils } from '@lsp-placeholder/aws-lsp-core'
+import {
+    Connection,
+    InitializeParams,
+    InitializeResult,
+    TextDocumentSyncKind,
+    TextDocuments,
+} from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { JsonLanguageServiceWrapper } from './jsonLanguageServiceWrapper'
+
+export type JsonSchemaServerProps = {
+    connection: Connection
+    defaultSchemaUri?: string
+    schemaProvider?: SchemaProvider
+}
+
+export class JsonSchemaServer {
+    /**
+     * Options, provided by language server to `onInitialize` callback.
+     */
+    // protected options?: InitializeParams;
+    /**
+     * Text documents manager (see https://github.com/microsoft/vscode-languageserver-node/blob/main/server/src/common/textDocuments.ts#L68)
+     */
+    protected documents = new TextDocuments(TextDocument)
+
+    protected jsonService: JsonLanguageServiceWrapper
+
+    protected connection: Connection
+
+    constructor(private readonly props: JsonSchemaServerProps) {
+        this.connection = props.connection
+
+        this.jsonService = new JsonLanguageServiceWrapper(props)
+
+        this.connection.onInitialize((params: InitializeParams) => {
+            // this.options = params;
+            const result: InitializeResult = {
+                // serverInfo: initialisationOptions?.serverInfo,
+                capabilities: {
+                    textDocumentSync: {
+                        openClose: true,
+                        change: TextDocumentSyncKind.Incremental,
+                    },
+                    completionProvider: { resolveProvider: true },
+                    hoverProvider: true,
+                    documentFormattingProvider: true,
+                    // ...(initialisationOptions?.capabilities || {}),
+                },
+            }
+            return result
+        })
+        this.registerHandlers()
+        this.documents.listen(this.connection)
+        this.connection.listen()
+
+        this.connection.console.info('AWS Documents LS started!')
+    }
+
+    getTextDocument(uri: string): TextDocument {
+        const textDocument = this.documents.get(uri)
+
+        if (!textDocument) {
+            throw new Error(`Document with uri ${uri} not found.`)
+        }
+
+        return textDocument
+    }
+
+    async validateDocument(uri: string): Promise<void> {
+        const textDocument = this.getTextDocument(uri)
+
+        if (JsonLanguageServiceWrapper.isLangaugeIdSupported(textDocument.languageId) === false) {
+            return
+        }
+
+        const diagnostics = await this.jsonService.doValidation(textDocument)
+        this.connection.sendDiagnostics({ uri, version: textDocument.version, diagnostics })
+    }
+
+    registerHandlers() {
+        this.documents.onDidOpen(({ document }) => {
+            if (JsonLanguageServiceWrapper.isLangaugeIdSupported(document.languageId) === false) {
+                return
+            }
+
+            this.validateDocument(document.uri)
+        })
+
+        this.documents.onDidChangeContent(({ document }) => {
+            if (JsonLanguageServiceWrapper.isLangaugeIdSupported(document.languageId) === false) {
+                return
+            }
+            this.validateDocument(document.uri)
+        })
+
+        this.connection.onCompletion(async ({ textDocument: requestedDocument, position }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            if (JsonLanguageServiceWrapper.isLangaugeIdSupported(textDocument.languageId) === false) {
+                return
+            }
+
+            return await this.jsonService.doComplete(textDocument, position)
+        })
+
+        this.connection.onCompletionResolve(item => item)
+
+        this.connection.onHover(async ({ textDocument: requestedDocument, position }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            if (JsonLanguageServiceWrapper.isLangaugeIdSupported(textDocument.languageId) === false) {
+                return
+            }
+
+            return await this.jsonService.doHover(textDocument, position)
+        })
+
+        this.connection.onDocumentFormatting(async ({ textDocument: requestedDocument, options }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            if (JsonLanguageServiceWrapper.isLangaugeIdSupported(textDocument.languageId) === false) {
+                return
+            }
+
+            return this.jsonService.format(textDocument, textDocumentUtils.getFullRange(textDocument), options)
+        })
+    }
+}

--- a/lsp/core/aws-lsp-json-common/src/language-server/jsonSchemaServer.ts
+++ b/lsp/core/aws-lsp-json-common/src/language-server/jsonSchemaServer.ts
@@ -15,6 +15,9 @@ export type JsonSchemaServerProps = {
     schemaProvider?: SchemaProvider
 }
 
+/**
+ * Listens to an LSP connection and wraps JsonLanguageService to handle the calls
+ */
 export class JsonSchemaServer {
     /**
      * Options, provided by language server to `onInitialize` callback.

--- a/lsp/core/aws-lsp-json-common/tsconfig.json
+++ b/lsp/core/aws-lsp-json-common/tsconfig.json
@@ -3,23 +3,16 @@
         "module": "UMD",
         "target": "ES2021",
         "moduleResolution": "node",
+        "lib": ["ES2021"],
         "rootDir": "./src",
         "outDir": "./out",
         "declaration": true,
+        "sourceMap": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
-        "strict": true
+        "strict": true,
+        "composite": true
     },
-    "files": [],
-    "references": [
-        {
-            "path": "./core/aws-lsp-core"
-        },
-        {
-            "path": "./core/aws-lsp-json-common"
-        },
-        {
-            "path": "./core/aws-lsp-yaml-common"
-        }
-    ]
+    "include": ["src", "test"],
+    "exclude": ["node_modules"]
 }

--- a/lsp/core/aws-lsp-yaml-common/package.json
+++ b/lsp/core/aws-lsp-yaml-common/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@lsp-placeholder/aws-lsp-yaml-common",
+    "version": "0.0.1",
+    "description": "YAML Language Server common code library",
+    "main": "out/index.js",
+    "scripts": {
+        "compile": "tsc --build"
+    },
+    "dependencies": {
+        "@lsp-placeholder/aws-lsp-core": "^0.0.1",
+        "vscode-languageserver": "8.0.1",
+        "yaml-language-server": "^1.13.0"
+    }
+}

--- a/lsp/core/aws-lsp-yaml-common/src/index.ts
+++ b/lsp/core/aws-lsp-yaml-common/src/index.ts
@@ -1,2 +1,2 @@
-export * from './language-server/yamlLanguageServiceWrapper'
+export * from './language-server/yamlLanguageService'
 export * from './language-server/yamlSchemaServer'

--- a/lsp/core/aws-lsp-yaml-common/src/index.ts
+++ b/lsp/core/aws-lsp-yaml-common/src/index.ts
@@ -1,0 +1,2 @@
+export * from './language-server/yamlLanguageServiceWrapper'
+export * from './language-server/yamlSchemaServer'

--- a/lsp/core/aws-lsp-yaml-common/src/language-server/formattingOptions.ts
+++ b/lsp/core/aws-lsp-yaml-common/src/language-server/formattingOptions.ts
@@ -1,0 +1,4 @@
+import { FormattingOptions } from 'vscode-languageserver'
+import { CustomFormatterOptions } from 'yaml-language-server'
+
+export interface YamlFormattingOptions extends FormattingOptions, CustomFormatterOptions {}

--- a/lsp/core/aws-lsp-yaml-common/src/language-server/yamlLanguageService.ts
+++ b/lsp/core/aws-lsp-yaml-common/src/language-server/yamlLanguageService.ts
@@ -10,6 +10,10 @@ export type YamlLanguageServiceProps = {
     schemaProvider: SchemaProvider
 }
 
+/**
+ * This is a thin wrapper around the Redhat Yaml Language Service
+ * https://github.com/redhat-developer/yaml-language-server/
+ */
 export class YamlLanguageService implements AwsLanguageService {
     private yamlService: LanguageService
 

--- a/lsp/core/aws-lsp-yaml-common/src/language-server/yamlLanguageServiceWrapper.ts
+++ b/lsp/core/aws-lsp-yaml-common/src/language-server/yamlLanguageServiceWrapper.ts
@@ -1,0 +1,70 @@
+import { SchemaProvider } from '@lsp-placeholder/aws-lsp-core'
+import { CompletionList, Diagnostic, Hover, Position, TextEdit } from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { CustomFormatterOptions, LanguageService, getLanguageService } from 'yaml-language-server'
+
+export type YamlLanguageServiceWrapperProps = {
+    displayName: string
+    defaultSchemaUri: string
+    schemaProvider: SchemaProvider
+}
+
+export class YamlLanguageServiceWrapper {
+    private yamlService: LanguageService
+
+    public static isLangaugeIdSupported(languageId: string): boolean {
+        return languageId === 'yaml'
+    }
+
+    constructor(private readonly props: YamlLanguageServiceWrapperProps) {
+        const workspaceContext = {
+            resolveRelativePath(relativePath: string, resource: string) {
+                return new URL(relativePath, resource).href
+            },
+        }
+
+        this.yamlService = getLanguageService({
+            schemaRequestService: this.props.schemaProvider,
+            workspaceContext,
+        })
+
+        this.yamlService.configure({ schemas: [{ fileMatch: ['*.yml'], uri: this.props.defaultSchemaUri }] })
+    }
+
+    public doValidation(document: TextDocument): Promise<Diagnostic[]> {
+        this.updateSchemaMapping(document.uri)
+        return this.yamlService.doValidation(document, false)
+    }
+
+    public doComplete(document: TextDocument, position: Position): Promise<CompletionList> {
+        this.updateSchemaMapping(document.uri)
+        return this.yamlService.doComplete(document, position, false)
+    }
+
+    public doHover(document: TextDocument, position: Position): Promise<Hover | null> {
+        this.updateSchemaMapping(document.uri)
+        return this.yamlService.doHover(document, position)
+    }
+
+    public doFormat(document: TextDocument, options: CustomFormatterOptions): TextEdit[] {
+        this.updateSchemaMapping(document.uri)
+        return this.yamlService.doFormat(document, options)
+    }
+
+    private updateSchemaMapping(documentUri: string): void {
+        this.yamlService.configure({
+            hover: true,
+            completion: true,
+            validate: true,
+            customTags: [],
+            schemas: [
+                {
+                    fileMatch: [documentUri],
+                    uri: this.props.defaultSchemaUri,
+                    name: this.props.displayName,
+                    description: 'some description,',
+                },
+            ],
+        })
+    }
+}

--- a/lsp/core/aws-lsp-yaml-common/src/language-server/yamlSchemaServer.ts
+++ b/lsp/core/aws-lsp-yaml-common/src/language-server/yamlSchemaServer.ts
@@ -1,0 +1,150 @@
+import { SchemaProvider, completionItemUtils } from '@lsp-placeholder/aws-lsp-core'
+import {
+    Connection,
+    InitializeParams,
+    InitializeResult,
+    TextDocumentSyncKind,
+    TextDocuments,
+} from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { YamlLanguageServiceWrapper } from './yamlLanguageServiceWrapper'
+
+export type YamlSchemaServerProps = {
+    displayName: string
+    connection: Connection
+    defaultSchemaUri: string
+    schemaProvider: SchemaProvider
+}
+
+export class YamlSchemaServer {
+    /**
+     * Options, provided by language server to `onInitialize` callback.
+     */
+    // protected options?: InitializeParams;
+    /**
+     * Text documents manager (see https://github.com/microsoft/vscode-languageserver-node/blob/main/server/src/common/textDocuments.ts#L68)
+     */
+    protected documents = new TextDocuments(TextDocument)
+
+    protected yamlService: YamlLanguageServiceWrapper
+    protected connection: Connection
+
+    constructor(private readonly props: YamlSchemaServerProps) {
+        this.connection = props.connection
+
+        this.yamlService = new YamlLanguageServiceWrapper(props)
+
+        this.connection.onInitialize((params: InitializeParams) => {
+            // this.options = params;
+            const result: InitializeResult = {
+                // serverInfo: initialisationOptions?.serverInfo,
+                capabilities: {
+                    textDocumentSync: {
+                        openClose: true,
+                        change: TextDocumentSyncKind.Incremental,
+                    },
+
+                    // TODO : when resolveProvider is true, we didn't see documentation field in the VS Code completion UI
+                    // TODO : Does VS do this as well? This could be problematic for implementors who set resolveProvider to true
+                    completionProvider: { resolveProvider: false },
+                    hoverProvider: true,
+                    documentFormattingProvider: true,
+                    // ...(initialisationOptions?.capabilities || {}),
+                },
+            }
+            return result
+        })
+        this.registerHandlers()
+        this.documents.listen(this.connection)
+        this.connection.listen()
+
+        this.connection.console.info('AWS Documents LS started!')
+    }
+
+    getTextDocument(uri: string): TextDocument {
+        const doc = this.documents.get(uri)
+        if (!doc) {
+            throw new Error(`Document with uri ${uri} not found.`)
+        }
+
+        return doc
+    }
+
+    async validateDocument(uri: string): Promise<void> {
+        try {
+            const textDocument = this.getTextDocument(uri)
+
+            if (YamlLanguageServiceWrapper.isLangaugeIdSupported(textDocument.languageId) === false) {
+                return
+            }
+
+            const diagnostics = await this.yamlService.doValidation(textDocument)
+            this.connection.sendDiagnostics({ uri, version: textDocument.version, diagnostics })
+        } catch (error) {
+            this.connection.console.info(`AWS Yaml validation error: ${error}`)
+        }
+    }
+
+    registerHandlers() {
+        this.documents.onDidOpen(({ document }) => {
+            if (YamlLanguageServiceWrapper.isLangaugeIdSupported(document.languageId) === false) {
+                return
+            }
+
+            this.validateDocument(document.uri)
+        })
+
+        this.documents.onDidChangeContent(({ document }) => {
+            if (YamlLanguageServiceWrapper.isLangaugeIdSupported(document.languageId) === false) {
+                return
+            }
+            this.validateDocument(document.uri)
+        })
+
+        this.connection.onCompletion(async ({ textDocument: requestedDocument, position }) => {
+            try {
+                this.connection.console.info('AWS Yaml completion')
+
+                const textDocument = this.getTextDocument(requestedDocument.uri)
+
+                if (YamlLanguageServiceWrapper.isLangaugeIdSupported(textDocument.languageId) === false) {
+                    return
+                }
+
+                const results = await this.yamlService.doComplete(textDocument, position)
+                // this.connection.console.info(JSON.stringify(results.items, null, 4))
+
+                completionItemUtils.prependItemDetail(results.items, this.props.displayName)
+
+                return results
+            } catch (error) {
+                this.connection.console.info(`AWS Yaml completion error: ${error} `)
+            }
+        })
+
+        this.connection.onHover(async ({ textDocument: requestedDocument, position }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            if (YamlLanguageServiceWrapper.isLangaugeIdSupported(textDocument.languageId) === false) {
+                return
+            }
+
+            return await this.yamlService.doHover(textDocument, position)
+        })
+
+        this.connection.onDocumentFormatting(({ textDocument: requestedDocument, options }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            if (YamlLanguageServiceWrapper.isLangaugeIdSupported(textDocument.languageId) === false) {
+                return
+            }
+
+            return this.yamlService.doFormat(textDocument, {})
+        })
+
+        // this.connection.onCompletionResolve(item => {
+        //     this.connection.console.info(JSON.stringify(item, null, 4))
+        //     return item
+        // })
+    }
+}

--- a/lsp/core/aws-lsp-yaml-common/src/language-server/yamlSchemaServer.ts
+++ b/lsp/core/aws-lsp-yaml-common/src/language-server/yamlSchemaServer.ts
@@ -21,6 +21,9 @@ export type YamlSchemaServerProps = {
     schemaProvider: SchemaProvider
 }
 
+/**
+ * Listens to an LSP connection and wraps YamlLanguageService to handle the calls
+ */
 export class YamlSchemaServer {
     /**
      * Options, provided by language server to `onInitialize` callback.

--- a/lsp/core/aws-lsp-yaml-common/tsconfig.json
+++ b/lsp/core/aws-lsp-yaml-common/tsconfig.json
@@ -3,23 +3,16 @@
         "module": "UMD",
         "target": "ES2021",
         "moduleResolution": "node",
+        "lib": ["ES2021"],
         "rootDir": "./src",
         "outDir": "./out",
         "declaration": true,
+        "sourceMap": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
-        "strict": true
+        "strict": true,
+        "composite": true
     },
-    "files": [],
-    "references": [
-        {
-            "path": "./core/aws-lsp-core"
-        },
-        {
-            "path": "./core/aws-lsp-json-common"
-        },
-        {
-            "path": "./core/aws-lsp-yaml-common"
-        }
-    ]
+    "include": ["src", "test"],
+    "exclude": ["node_modules"]
 }

--- a/lsp/package-lock.json
+++ b/lsp/package-lock.json
@@ -30,7 +30,30 @@
         },
         "core/aws-lsp-core": {
             "name": "@lsp-placeholder/aws-lsp-core",
-            "version": "0.0.1"
+            "version": "0.0.1",
+            "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3"
+            }
+        },
+        "core/aws-lsp-json-common": {
+            "name": "@lsp-placeholder/aws-lsp-json-common",
+            "version": "0.0.1",
+            "dependencies": {
+                "@lsp-placeholder/aws-lsp-core": "^0.0.1",
+                "vscode-json-languageservice": "^5.3.5",
+                "vscode-languageserver": "8.0.1",
+                "vscode-languageserver-textdocument": "^1.0.8"
+            }
+        },
+        "core/aws-lsp-yaml-common": {
+            "name": "@lsp-placeholder/aws-lsp-yaml-common",
+            "version": "0.0.1",
+            "dependencies": {
+                "@lsp-placeholder/aws-lsp-core": "^0.0.1",
+                "vscode-languageserver": "8.0.1",
+                "yaml-language-server": "^1.13.0"
+            }
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -160,6 +183,14 @@
         },
         "node_modules/@lsp-placeholder/aws-lsp-core": {
             "resolved": "core/aws-lsp-core",
+            "link": true
+        },
+        "node_modules/@lsp-placeholder/aws-lsp-json-common": {
+            "resolved": "core/aws-lsp-json-common",
+            "link": true
+        },
+        "node_modules/@lsp-placeholder/aws-lsp-yaml-common": {
+            "resolved": "core/aws-lsp-yaml-common",
             "link": true
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -454,6 +485,11 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
+        },
+        "node_modules/@vscode/l10n": {
+            "version": "0.0.13",
+            "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.13.tgz",
+            "integrity": "sha512-A3uY356uOU9nGa+TQIT/i3ziWUgJjVMUrGGXSrtRiTwklyCFjGVWIOHoEIHbJpiyhDkJd9kvIWUOfXK1IkK8XQ=="
         },
         "node_modules/acorn": {
             "version": "8.8.2",
@@ -1011,8 +1047,7 @@
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-glob": {
             "version": "3.2.12",
@@ -1383,6 +1418,11 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
+        "node_modules/jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+        },
         "node_modules/levn": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1407,6 +1447,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -1734,7 +1779,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
             "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1758,6 +1802,19 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/request-light": {
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+            "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -2034,7 +2091,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -2044,6 +2100,71 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true
+        },
+        "node_modules/vscode-json-languageservice": {
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-5.3.5.tgz",
+            "integrity": "sha512-DasT+bKtpaS2rTPEB4VMROnvO1WES2KD8RZZxXbumnk9sk5wco10VdB6sJgTlsKQN14tHQLZDXuHnSoSAlE8LQ==",
+            "dependencies": {
+                "@vscode/l10n": "^0.0.13",
+                "jsonc-parser": "^3.2.0",
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3",
+                "vscode-uri": "^3.0.7"
+            }
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
+            "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageserver": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
+            "integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
+            "dependencies": {
+                "vscode-languageserver-protocol": "3.17.1"
+            },
+            "bin": {
+                "installServerIntoExtension": "bin/installServerIntoExtension"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
+            "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.0.1",
+                "vscode-languageserver-types": "3.17.1"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
+            "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+        },
+        "node_modules/vscode-languageserver-textdocument": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+            "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+        },
+        "node_modules/vscode-nls": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+            "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
+        },
+        "node_modules/vscode-uri": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+            "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -2080,6 +2201,120 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "node_modules/yaml": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+            "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/yaml-language-server": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.13.0.tgz",
+            "integrity": "sha512-CzekVjFOUkiXI6tg3BPuSkxE60keDT4/+LjPLXwnt4gCRzaaWMCjT92NxOHv1derbBLHWoecay48tse/De181Q==",
+            "dependencies": {
+                "ajv": "^8.11.0",
+                "lodash": "4.17.21",
+                "request-light": "^0.5.7",
+                "vscode-json-languageservice": "4.1.8",
+                "vscode-languageserver": "^7.0.0",
+                "vscode-languageserver-textdocument": "^1.0.1",
+                "vscode-languageserver-types": "^3.16.0",
+                "vscode-nls": "^5.0.0",
+                "vscode-uri": "^3.0.2",
+                "yaml": "2.2.2"
+            },
+            "bin": {
+                "yaml-language-server": "bin/yaml-language-server"
+            },
+            "optionalDependencies": {
+                "prettier": "2.8.7"
+            }
+        },
+        "node_modules/yaml-language-server/node_modules/ajv": {
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/yaml-language-server/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "node_modules/yaml-language-server/node_modules/prettier": {
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+            "optional": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/yaml-language-server/node_modules/vscode-json-languageservice": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+            "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+            "dependencies": {
+                "jsonc-parser": "^3.0.0",
+                "vscode-languageserver-textdocument": "^1.0.1",
+                "vscode-languageserver-types": "^3.16.0",
+                "vscode-nls": "^5.0.0",
+                "vscode-uri": "^3.0.2"
+            },
+            "engines": {
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/yaml-language-server/node_modules/vscode-jsonrpc": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+            "engines": {
+                "node": ">=8.0.0 || >=10.0.0"
+            }
+        },
+        "node_modules/yaml-language-server/node_modules/vscode-languageserver": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+            "dependencies": {
+                "vscode-languageserver-protocol": "3.16.0"
+            },
+            "bin": {
+                "installServerIntoExtension": "bin/installServerIntoExtension"
+            }
+        },
+        "node_modules/yaml-language-server/node_modules/vscode-languageserver-protocol": {
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+            "dependencies": {
+                "vscode-jsonrpc": "6.0.0",
+                "vscode-languageserver-types": "3.16.0"
+            }
+        },
+        "node_modules/yaml-language-server/node_modules/vscode-languageserver-types": {
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
         "node_modules/yn": {
             "version": "3.1.1",

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "monorepo-aws-languages",
     "version": "1.0.0",
-    "description": "A monorepo for AWS Language Servers (@christou-lsp-test)",
+    "description": "A monorepo for AWS Language Servers (@lsp-placeholder)",
     "private": true,
     "workspaces": [
         "app/*",


### PR DESCRIPTION

This is part of a series of changes that establishes an LSP monorepo that we can perform experiments on.

This change contains proof of concept implementations of JSON (`JsonSchemaServer`) and Yaml (`YamlSchemaServer`) language servers, that operate on a JSON Schema. The classes can be instantiated with a url to a JSON Schema, and it will provide completion/validation based on that schema. A follow-up change will illustrate how these are leveraged. These servers are not optimized (or de-duplicated) at this time.

To support the proof of concept, code has been added to the core library. The `AwsLanguageService` interface is a concept that will be explored further as we grow out the monorepo. This may provide a boundary that contains a document's (or language)'s domain knowledge, without coupling to the LSP Connection.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
