### PR TITLE
Buildspec servers

### DIFF
--- a/lsp/core/aws-lsp-core/src/index.ts
+++ b/lsp/core/aws-lsp-core/src/index.ts
@@ -1,5 +1,6 @@
 // todo : IDE-10874 : move core support files into this package from pre-monorepo locations
 export * from './content/schemaProvider'
 export * from './language-service/awsLanguageService'
+export * from './language-service/mutuallyExclusiveLanguageService'
 export * as completionItemUtils from './util/completionItemUtils'
 export * as textDocumentUtils from './util/textDocumentUtils'

--- a/lsp/core/aws-lsp-core/src/language-service/emptyLanguageService.ts
+++ b/lsp/core/aws-lsp-core/src/language-service/emptyLanguageService.ts
@@ -1,0 +1,29 @@
+import { Position, Range, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
+import { CompletionList, Diagnostic, FormattingOptions, Hover } from 'vscode-languageserver-types'
+import { AwsLanguageService } from './awsLanguageService'
+
+/**
+ * Provides a stock "no-op" language service, which returns
+ * the "empty" equivalent for each call.
+ */
+export class EmptyLanguageService implements AwsLanguageService {
+    public isSupported(document: TextDocument): boolean {
+        return true
+    }
+
+    public doValidation(textDocument: TextDocument): PromiseLike<Diagnostic[]> {
+        return Promise.resolve([])
+    }
+
+    public doComplete(textDocument: TextDocument, position: Position): PromiseLike<CompletionList | null> {
+        return Promise.resolve(null)
+    }
+
+    public doHover(textDocument: TextDocument, position: Position): PromiseLike<Hover | null> {
+        return Promise.resolve(null)
+    }
+
+    public format(textDocument: TextDocument, range: Range, options: FormattingOptions): TextEdit[] {
+        return []
+    }
+}

--- a/lsp/core/aws-lsp-core/src/language-service/mutuallyExclusiveLanguageService.ts
+++ b/lsp/core/aws-lsp-core/src/language-service/mutuallyExclusiveLanguageService.ts
@@ -1,0 +1,38 @@
+import { Position, Range, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
+import { CompletionList, Diagnostic, FormattingOptions, Hover } from 'vscode-languageserver-types'
+import { AwsLanguageService } from './awsLanguageService'
+import { EmptyLanguageService } from './emptyLanguageService'
+
+/**
+ * This is a language service composed of other services provided through the constructor.
+ * It is expected that no more than one of the services will support a given document.
+ * In cases where no service supports a document, the "empty" service will be used.
+ */
+export class MutuallyExclusiveLanguageService implements AwsLanguageService {
+    private readonly services: AwsLanguageService[]
+
+    constructor(services: AwsLanguageService[]) {
+        // Empty language service assures that we will *always* have a default handler (which does nothing)
+        this.services = [...services, new EmptyLanguageService()]
+    }
+
+    public isSupported(document: TextDocument): boolean {
+        return this.services.some(service => service.isSupported(document))
+    }
+
+    public doValidation(textDocument: TextDocument): PromiseLike<Diagnostic[]> {
+        return this.services.find(service => service.isSupported(textDocument))!.doValidation(textDocument)
+    }
+
+    public doComplete(textDocument: TextDocument, position: Position): PromiseLike<CompletionList | null> {
+        return this.services.find(service => service.isSupported(textDocument))!.doComplete(textDocument, position)
+    }
+
+    public doHover(textDocument: TextDocument, position: Position): PromiseLike<Hover | null> {
+        return this.services.find(service => service.isSupported(textDocument))!.doHover(textDocument, position)
+    }
+
+    public format(textDocument: TextDocument, range: Range, options: FormattingOptions): TextEdit[] {
+        return this.services.find(service => service.isSupported(textDocument))!.format(textDocument, range, options)
+    }
+}

--- a/lsp/package-lock.json
+++ b/lsp/package-lock.json
@@ -181,6 +181,10 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@lsp-placeholder/aws-lsp-buildspec": {
+            "resolved": "server/aws-lsp-buildspec",
+            "link": true
+        },
         "node_modules/@lsp-placeholder/aws-lsp-core": {
             "resolved": "core/aws-lsp-core",
             "link": true
@@ -2335,6 +2339,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "server/aws-lsp-buildspec": {
+            "name": "@lsp-placeholder/aws-lsp-buildspec",
+            "version": "0.0.1",
+            "dependencies": {
+                "@lsp-placeholder/aws-lsp-json-common": "^0.0.1",
+                "@lsp-placeholder/aws-lsp-yaml-common": "^0.0.1",
+                "vscode-languageserver": "^8.0.1",
+                "vscode-languageserver-textdocument": "^1.0.8"
             }
         }
     }

--- a/lsp/server/aws-lsp-buildspec/package.json
+++ b/lsp/server/aws-lsp-buildspec/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@lsp-placeholder/aws-lsp-buildspec",
+    "version": "0.0.1",
+    "description": "CodeBuild BuildSpec Language Server (YAML and JSON)",
+    "main": "out/index.js",
+    "scripts": {
+        "compile": "tsc --build"
+    },
+    "dependencies": {
+        "@lsp-placeholder/aws-lsp-json-common": "^0.0.1",
+        "@lsp-placeholder/aws-lsp-yaml-common": "^0.0.1",
+        "vscode-languageserver": "^8.0.1",
+        "vscode-languageserver-textdocument": "^1.0.8"
+    }
+}

--- a/lsp/server/aws-lsp-buildspec/src/index.ts
+++ b/lsp/server/aws-lsp-buildspec/src/index.ts
@@ -1,0 +1,3 @@
+export * from './language-server/buildSpecJsonServer'
+export * from './language-server/buildSpecServer'
+export * from './language-server/buildSpecYamlServer'

--- a/lsp/server/aws-lsp-buildspec/src/language-server/buildSpecJsonServer.ts
+++ b/lsp/server/aws-lsp-buildspec/src/language-server/buildSpecJsonServer.ts
@@ -1,0 +1,17 @@
+import { JsonSchemaServer, JsonSchemaServerProps } from '@lsp-placeholder/aws-lsp-json-common'
+import { jsonSchemaUrl } from './urls'
+
+export type BuildspecJsonServerProps = Omit<JsonSchemaServerProps, 'defaultSchemaUri'>
+
+/**
+ * This is a demonstration language server that handles JSON files according to the
+ * CodeBuild BuildSpec JSON Schema.
+ */
+export class BuildspecJsonServer extends JsonSchemaServer {
+    constructor(props: BuildspecJsonServerProps) {
+        super({
+            defaultSchemaUri: jsonSchemaUrl,
+            ...props,
+        })
+    }
+}

--- a/lsp/server/aws-lsp-buildspec/src/language-server/buildSpecServer.ts
+++ b/lsp/server/aws-lsp-buildspec/src/language-server/buildSpecServer.ts
@@ -1,0 +1,134 @@
+import {
+    AwsLanguageService,
+    MutuallyExclusiveLanguageService,
+    SchemaProvider,
+    completionItemUtils,
+    textDocumentUtils,
+} from '@lsp-placeholder/aws-lsp-core'
+import { JsonLanguageService } from '@lsp-placeholder/aws-lsp-json-common'
+import { YamlLanguageService } from '@lsp-placeholder/aws-lsp-yaml-common'
+import {
+    Connection,
+    InitializeParams,
+    InitializeResult,
+    TextDocumentSyncKind,
+    TextDocuments,
+} from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+
+export type BuildspecServerProps = {
+    connection: Connection
+    defaultSchemaUri: string
+    schemaProvider: SchemaProvider
+}
+
+/**
+ * This is a demonstration language server that handles both JSON and YAML files according to the
+ * CodeBuild BuildSpec JSON Schema.
+ *
+ * This illustrates how we can wrap LSP Connection calls around a composition of different language services.
+ * In this case, the composition consists of a JSON processor and a YAML processor.
+ */
+export class BuildspecServer {
+    public static readonly serverId = 'aws-lsp-buildspec'
+
+    protected documents = new TextDocuments(TextDocument)
+
+    protected buildSpecService: AwsLanguageService
+
+    protected connection: Connection
+
+    constructor(private readonly props: BuildspecServerProps) {
+        this.connection = props.connection
+
+        this.buildSpecService = new MutuallyExclusiveLanguageService([
+            new JsonLanguageService(props),
+            new YamlLanguageService({
+                displayName: BuildspecServer.serverId,
+                ...props,
+            }),
+        ])
+
+        this.connection.onInitialize((params: InitializeParams) => {
+            // this.options = params;
+            const result: InitializeResult = {
+                // serverInfo: initialisationOptions?.serverInfo,
+                capabilities: {
+                    textDocumentSync: {
+                        openClose: true,
+                        change: TextDocumentSyncKind.Incremental,
+                    },
+                    completionProvider: { resolveProvider: true },
+                    hoverProvider: true,
+                    documentFormattingProvider: true,
+                    // ...(initialisationOptions?.capabilities || {}),
+                },
+            }
+            return result
+        })
+        this.registerHandlers()
+        this.documents.listen(this.connection)
+        this.connection.listen()
+
+        this.connection.console.info('AWS Buildspec (json/yaml) language server started!')
+    }
+
+    getTextDocument(uri: string): TextDocument {
+        const textDocument = this.documents.get(uri)
+
+        if (!textDocument) {
+            throw new Error(`Document with uri ${uri} not found.`)
+        }
+
+        return textDocument
+    }
+
+    async validateDocument(uri: string): Promise<void> {
+        const textDocument = this.getTextDocument(uri)
+
+        this.connection.console.info(`Validating document, languageId: ${textDocument.languageId}, uri: ${uri}...`)
+
+        const diagnostics = await this.buildSpecService.doValidation(textDocument)
+        this.connection.sendDiagnostics({ uri, version: textDocument.version, diagnostics })
+    }
+
+    registerHandlers() {
+        this.documents.onDidOpen(({ document }) => {
+            this.connection.console.info(`Document opened, uri: ${document.uri}...`)
+
+            this.validateDocument(document.uri)
+        })
+
+        this.documents.onDidChangeContent(({ document }) => {
+            this.validateDocument(document.uri)
+        })
+
+        this.connection.onCompletion(async ({ textDocument: requestedDocument, position }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            const results = await this.buildSpecService.doComplete(textDocument, position)
+
+            if (results!!) {
+                completionItemUtils.prependItemDetail(results.items, BuildspecServer.serverId)
+            }
+
+            return results
+        })
+
+        this.connection.onCompletionResolve(item => item)
+
+        this.connection.onHover(async ({ textDocument: requestedDocument, position }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            this.connection.console.info(`Hover, languageId: ${textDocument.languageId}, uri: ${textDocument.uri}...`)
+
+            return await this.buildSpecService.doHover(textDocument, position)
+        })
+
+        this.connection.onDocumentFormatting(async ({ textDocument: requestedDocument, options }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            return this.buildSpecService.format(textDocument, textDocumentUtils.getFullRange(textDocument), options)
+        })
+    }
+}

--- a/lsp/server/aws-lsp-buildspec/src/language-server/buildSpecYamlServer.ts
+++ b/lsp/server/aws-lsp-buildspec/src/language-server/buildSpecYamlServer.ts
@@ -1,0 +1,17 @@
+import { YamlSchemaServer, YamlSchemaServerProps } from '@lsp-placeholder/aws-lsp-yaml-common'
+import { jsonSchemaUrl } from './urls'
+
+export type BuildspecYamlServerProps = Omit<YamlSchemaServerProps, 'defaultSchemaUri'>
+
+/**
+ * This is a demonstration language server that handles YAML files according to the
+ * CodeBuild BuildSpec JSON Schema.
+ */
+export class BuildspecYamlServer extends YamlSchemaServer {
+    constructor(props: BuildspecYamlServerProps) {
+        super({
+            defaultSchemaUri: jsonSchemaUrl,
+            ...props,
+        })
+    }
+}

--- a/lsp/server/aws-lsp-buildspec/src/language-server/urls.ts
+++ b/lsp/server/aws-lsp-buildspec/src/language-server/urls.ts
@@ -1,0 +1,2 @@
+export const jsonSchemaUrl: string =
+    'https://d3rrggjwfhwld2.cloudfront.net/CodeBuild/buildspec/buildspec-standalone.schema.json'

--- a/lsp/server/aws-lsp-buildspec/tsconfig.json
+++ b/lsp/server/aws-lsp-buildspec/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "UMD",
+        "target": "ES2021",
+        "moduleResolution": "node",
+        "lib": ["ES2021"],
+        "rootDir": "./src",
+        "outDir": "./out",
+        "declaration": true,
+        "sourceMap": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "composite": true
+    },
+    "include": ["src", "test"],
+    "exclude": ["node_modules"]
+}

--- a/lsp/tsconfig.json
+++ b/lsp/tsconfig.json
@@ -20,6 +20,9 @@
         },
         {
             "path": "./core/aws-lsp-yaml-common"
+        },
+        {
+            "path": "./server/aws-lsp-buildspec"
         }
     ]
 }


### PR DESCRIPTION

This is part of a series of changes that establishes an LSP monorepo that we can perform experiments on.

This change demonstrates how we can create a language server around a CodeBuild Buildspec JSON Schema, building on the proof of concept reusable components defined in #497 .

Three separate language servers have been created:
- one that applies buildspec logic to JSON files (BuildspecJsonServer)
- one that applies buildspec logic to Yaml files (BuildspecYamlServer)
- one that applies buildspec logic to both JSON and Yaml files (BuildspecServer)

BuildspecJsonServer and BuildspecYamlServer shows how we can leverage something that just knows how to wrap a JSON Schema. We don't know yet if we'd want to host disparate language servers like these in the IDE, which is where BuildspecServer comes in. We don't necessarily want to compose language servers together, because there will be collisions at the lsp connection callback level. BuildspecServer illustrates how one level lower (language services) may be a good reusability layer.

To support this change, MutuallyExclusiveLanguageService (naming is hard) shows how we can compose AwsLanguageService implementations in order to produce something that knows how to handle JSON and YAML files.

In a follow up change, I will restore the sample language clients, which will allow us to run and debug this language server while developing in the repo.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
