### PR TITLE
Remove year from copyright header

### DIFF
--- a/lsp/src/client/vscode/activation.ts
+++ b/lsp/src/client/vscode/activation.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/AwsToolkit.Telemetry.Events.Generator.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/AwsToolkit.Telemetry.Events.Generator.csproj
@@ -8,7 +8,7 @@
     <Authors>Amazon Web Services</Authors>
     <Product>AWS Toolkit Telemetry Events Generator</Product>
     <Description>Code generator that produces Telemetry events for AWS Toolkits</Description>
-    <Copyright>Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
+    <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/aws/aws-toolkit-common</RepositoryUrl>
     <PackageTags>AWS AWSToolkit</PackageTags>

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj
@@ -9,7 +9,7 @@
 		<Company>Amazon Web Services</Company>
 		<Product>AWS Toolkit Telemetry Events</Product>
 		<Description>Telemetry events datatypes and functionality for AWS Toolkits</Description>
-		<Copyright>Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
+		<Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<RepositoryUrl>https://github.com/aws/aws-toolkit-common</RepositoryUrl>

--- a/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.SDK/AwsToolkit.Telemetry.SDK.csproj
@@ -10,7 +10,7 @@
 		<Company>Amazon Web Services</Company>
 		<Product>AWS Toolkit Telemetry</Product>
 		<Version Condition="'$(Version)' == ''">0.0.1</Version>
-		<Copyright>Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
+		<Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
 		<PackageProjectUrl></PackageProjectUrl>
 		<RepositoryUrl>https://github.com/aws/aws-toolkit-common</RepositoryUrl>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/ResourceLoader.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/ResourceLoader.kt
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.telemetry.generator

--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryGenerator.kt
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.telemetry.generator
@@ -52,7 +52,7 @@ fun generateTelemetryFromFiles(
 }
 
 private fun FileSpec.Builder.generateHeader(): FileSpec.Builder {
-    addFileComment("Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.\n")
+    addFileComment("Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n")
     addFileComment("SPDX-License-Identifier: Apache-2.0\n")
     addFileComment("THIS FILE IS GENERATED! DO NOT EDIT BY HAND!")
     addAnnotation(AnnotationSpec.builder(Suppress::class).addMember("\"unused\", \"MemberVisibilityCanBePrivate\"").build())

--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryParser.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryParser.kt
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.telemetry.generator

--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/gradle/GenerateTelemetry.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/gradle/GenerateTelemetry.kt
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.telemetry.generator.gradle

--- a/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
+++ b/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.telemetry.generator

--- a/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/ParserTest.kt
+++ b/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/ParserTest.kt
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package software.aws.toolkits.telemetry.generator

--- a/telemetry/jetbrains/src/test/resources/testGeneratorOutput
+++ b/telemetry/jetbrains/src/test/resources/testGeneratorOutput
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // THIS FILE IS GENERATED! DO NOT EDIT BY HAND!
 @file:Suppress("unused", "MemberVisibilityCanBePrivate")

--- a/telemetry/jetbrains/src/test/resources/testLongEnumOutput
+++ b/telemetry/jetbrains/src/test/resources/testLongEnumOutput
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // THIS FILE IS GENERATED! DO NOT EDIT BY HAND!
 @file:Suppress("unused", "MemberVisibilityCanBePrivate")

--- a/telemetry/jetbrains/src/test/resources/testOverrideOutput
+++ b/telemetry/jetbrains/src/test/resources/testOverrideOutput
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // THIS FILE IS GENERATED! DO NOT EDIT BY HAND!
 @file:Suppress("unused", "MemberVisibilityCanBePrivate")

--- a/telemetry/jetbrains/src/test/resources/testResultOutput
+++ b/telemetry/jetbrains/src/test/resources/testResultOutput
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // THIS FILE IS GENERATED! DO NOT EDIT BY HAND!
 @file:Suppress("unused", "MemberVisibilityCanBePrivate")

--- a/telemetry/vscode/scripts/setUpPackage.ts
+++ b/telemetry/vscode/scripts/setUpPackage.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/telemetry/vscode/scripts/validatePackagedJson.ts
+++ b/telemetry/vscode/scripts/validatePackagedJson.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -158,7 +158,7 @@ const runtimeMetricDefinition: InterfaceDeclarationStructure = {
 
 const header = `
 /*!
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 `.trimStart()

--- a/telemetry/vscode/src/generateTelemetry.ts
+++ b/telemetry/vscode/src/generateTelemetry.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/telemetry/vscode/src/parser.ts
+++ b/telemetry/vscode/src/parser.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/telemetry/vscode/test/generator.test.ts
+++ b/telemetry/vscode/test/generator.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/telemetry/vscode/test/parser.test.ts
+++ b/telemetry/vscode/test/parser.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/telemetry/vscode/test/resources/generatorOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOutput.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 export interface MetricBase {

--- a/telemetry/vscode/test/resources/generatorOverrideOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOverrideOutput.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 export interface MetricBase {


### PR DESCRIPTION
## Problem
The year in the copyright header/attribute is unnecessary. See:
* https://github.com/aws/aws-toolkit-vscode/pull/3544
* https://github.com/aws/aws-toolkit-jetbrains/pull/3715

## Solution
Remove the year from all files

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
