### PR TITLE
CloudFormation language server and binary

### DIFF
--- a/lsp/.vscode/launch.json
+++ b/lsp/.vscode/launch.json
@@ -14,7 +14,7 @@
             }
         },
         {
-            "name": "Debug BuildSpec Server in VSCode",
+            "name": "BuildSpec Server",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
@@ -26,7 +26,7 @@
             "preLaunchTask": "npm: compile"
         },
         {
-            "name": "Debug CloudFormation Server in VSCode",
+            "name": "CloudFormation Server",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",

--- a/lsp/.vscode/launch.json
+++ b/lsp/.vscode/launch.json
@@ -26,6 +26,18 @@
             "preLaunchTask": "npm: compile"
         },
         {
+            "name": "Debug CloudFormation Server in VSCode",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}/client/vscode"],
+            "outFiles": ["${workspaceFolder}/client/vscode/out/**/*.js"],
+            "env": {
+                "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-cloudformation-binary/out/index.js"
+            },
+            "preLaunchTask": "npm: compile"
+        },
+        {
             "type": "node",
             "request": "launch",
             "preLaunchTask": "watch",

--- a/lsp/app/aws-lsp-cloudformation-binary/package.json
+++ b/lsp/app/aws-lsp-cloudformation-binary/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@lsp-placeholder/aws-lsp-cloudformation-binary",
+    "version": "0.0.1",
+    "description": "CodeBuild CloudFormation Language Server Binary",
+    "main": "out/index.js",
+    "bin": {
+        "awsdocuments-language-server": "./out/index.js"
+    },
+    "scripts": {
+        "compile": "tsc --build",
+        "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --out-path bin --compress GZip ."
+    },
+    "dependencies": {
+        "@lsp-placeholder/aws-lsp-cloudformation": "^0.0.1"
+    },
+    "devDependencies": {
+        "pkg": "^5.8.1"
+    }
+}

--- a/lsp/app/aws-lsp-cloudformation-binary/src/index.ts
+++ b/lsp/app/aws-lsp-cloudformation-binary/src/index.ts
@@ -1,0 +1,43 @@
+import {
+    CloudFormationServer,
+    CloudFormationServerProps,
+    CloudFormationServiceProps,
+    createCloudFormationService,
+    jsonSchemaUrl,
+} from '@lsp-placeholder/aws-lsp-cloudformation'
+import { httpsUtils } from '@lsp-placeholder/aws-lsp-core'
+import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
+
+const connection = createConnection(ProposedFeatures.all)
+
+// simple in-memory 'cache'
+let cfnSchema: string | undefined
+
+const serviceProps: CloudFormationServiceProps = {
+    displayName: CloudFormationServer.serverId,
+    defaultSchemaUri: jsonSchemaUrl,
+    schemaProvider: async (uri: string) => {
+        switch (uri) {
+            case jsonSchemaUrl:
+                if (!cfnSchema) {
+                    cfnSchema = await getFileAsync(uri)
+                }
+                return cfnSchema
+            default:
+                throw new Error(`Unknown schema '${uri}'.`)
+        }
+    },
+}
+
+const cloudformationService = createCloudFormationService(serviceProps)
+
+const props: CloudFormationServerProps = {
+    connection,
+    cloudformationService: cloudformationService,
+}
+
+async function getFileAsync(url: string): Promise<string> {
+    return await httpsUtils.requestContent(url)
+}
+
+export const server = new CloudFormationServer(props)

--- a/lsp/app/aws-lsp-cloudformation-binary/tsconfig.json
+++ b/lsp/app/aws-lsp-cloudformation-binary/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "UMD",
+        "target": "ES2021",
+        "moduleResolution": "node",
+        "lib": ["ES2021"],
+        "rootDir": "./src",
+        "outDir": "./out",
+        "declaration": true,
+        "sourceMap": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "composite": true
+    },
+    "include": ["src", "test"],
+    "exclude": ["node_modules"]
+}

--- a/lsp/package-lock.json
+++ b/lsp/package-lock.json
@@ -296,6 +296,10 @@
             "resolved": "app/aws-lsp-buildspec-binary",
             "link": true
         },
+        "node_modules/@lsp-placeholder/aws-lsp-cloudformation": {
+            "resolved": "server/aws-lsp-cloudformation",
+            "link": true
+        },
         "node_modules/@lsp-placeholder/aws-lsp-core": {
             "resolved": "core/aws-lsp-core",
             "link": true
@@ -3434,6 +3438,17 @@
             "name": "@lsp-placeholder/aws-lsp-buildspec",
             "version": "0.0.1",
             "dependencies": {
+                "@lsp-placeholder/aws-lsp-json-common": "^0.0.1",
+                "@lsp-placeholder/aws-lsp-yaml-common": "^0.0.1",
+                "vscode-languageserver": "^8.0.1",
+                "vscode-languageserver-textdocument": "^1.0.8"
+            }
+        },
+        "server/aws-lsp-cloudformation": {
+            "name": "@lsp-placeholder/aws-lsp-cloudformation",
+            "version": "0.0.1",
+            "dependencies": {
+                "@lsp-placeholder/aws-lsp-core": "^0.0.1",
                 "@lsp-placeholder/aws-lsp-json-common": "^0.0.1",
                 "@lsp-placeholder/aws-lsp-yaml-common": "^0.0.1",
                 "vscode-languageserver": "^8.0.1",

--- a/lsp/package-lock.json
+++ b/lsp/package-lock.json
@@ -41,6 +41,19 @@
                 "pkg": "^5.8.1"
             }
         },
+        "app/aws-lsp-cloudformation-binary": {
+            "name": "@lsp-placeholder/aws-lsp-cloudformation-binary",
+            "version": "0.0.1",
+            "dependencies": {
+                "@lsp-placeholder/aws-lsp-cloudformation": "^0.0.1"
+            },
+            "bin": {
+                "awsdocuments-language-server": "out/index.js"
+            },
+            "devDependencies": {
+                "pkg": "^5.8.1"
+            }
+        },
         "client/vscode": {
             "name": "awsdocuments-ls-client",
             "version": "0.1.0",
@@ -298,6 +311,10 @@
         },
         "node_modules/@lsp-placeholder/aws-lsp-cloudformation": {
             "resolved": "server/aws-lsp-cloudformation",
+            "link": true
+        },
+        "node_modules/@lsp-placeholder/aws-lsp-cloudformation-binary": {
+            "resolved": "app/aws-lsp-cloudformation-binary",
             "link": true
         },
         "node_modules/@lsp-placeholder/aws-lsp-core": {

--- a/lsp/server/aws-lsp-cloudformation/package.json
+++ b/lsp/server/aws-lsp-cloudformation/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@lsp-placeholder/aws-lsp-cloudformation",
+    "version": "0.0.1",
+    "description": "CodeBuild CloudFormation Language Server (YAML and JSON)",
+    "main": "out/index.js",
+    "scripts": {
+        "compile": "tsc --build"
+    },
+    "dependencies": {
+        "@lsp-placeholder/aws-lsp-core": "^0.0.1",
+        "@lsp-placeholder/aws-lsp-json-common": "^0.0.1",
+        "@lsp-placeholder/aws-lsp-yaml-common": "^0.0.1",
+        "vscode-languageserver": "^8.0.1",
+        "vscode-languageserver-textdocument": "^1.0.8"
+    }
+}

--- a/lsp/server/aws-lsp-cloudformation/src/index.ts
+++ b/lsp/server/aws-lsp-cloudformation/src/index.ts
@@ -1,0 +1,3 @@
+export * from './language-server/cloudFormationServer'
+export * from './language-server/cloudFormationService'
+export * from './language-server/urls'

--- a/lsp/server/aws-lsp-cloudformation/src/index.ts
+++ b/lsp/server/aws-lsp-cloudformation/src/index.ts
@@ -1,3 +1,6 @@
 export * from './language-server/cloudFormationServer'
-export * from './language-server/cloudFormationService'
+export {
+    CloudFormationServiceProps,
+    create as createCloudFormationService,
+} from './language-server/cloudFormationService'
 export * from './language-server/urls'

--- a/lsp/server/aws-lsp-cloudformation/src/language-server/cloudFormationServer.ts
+++ b/lsp/server/aws-lsp-cloudformation/src/language-server/cloudFormationServer.ts
@@ -1,0 +1,133 @@
+import { AwsLanguageService, textDocumentUtils } from '@lsp-placeholder/aws-lsp-core'
+import {
+    Connection,
+    InitializeParams,
+    InitializeResult,
+    TextDocumentSyncKind,
+    TextDocuments,
+} from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+
+export type CloudFormationServerProps = {
+    connection: Connection
+    cloudformationService: AwsLanguageService
+}
+
+/**
+ * This is a demonstration language server that handles both JSON and YAML files according to the
+ * CloudFormation JSON Schema.
+ *
+ * This illustrates how we can wrap LSP Connection calls around a provided language service.
+ * In this case, the service is a composition of a JSON processor and a YAML processor.
+ */
+export class CloudFormationServer {
+    public static readonly serverId = 'aws-lsp-cloudformation'
+
+    protected documents = new TextDocuments(TextDocument)
+
+    protected cloudformationService: AwsLanguageService
+
+    protected connection: Connection
+
+    constructor(private readonly props: CloudFormationServerProps) {
+        this.connection = props.connection
+
+        this.cloudformationService = this.props.cloudformationService
+
+        this.connection.onInitialize((params: InitializeParams) => {
+            // this.options = params;
+            const result: InitializeResult = {
+                // serverInfo: initialisationOptions?.serverInfo,
+                capabilities: {
+                    textDocumentSync: {
+                        openClose: true,
+                        change: TextDocumentSyncKind.Incremental,
+                    },
+                    completionProvider: { resolveProvider: true },
+                    hoverProvider: true,
+                    documentFormattingProvider: true,
+                    // ...(initialisationOptions?.capabilities || {}),
+                },
+            }
+            return result
+        })
+        this.registerHandlers()
+        this.documents.listen(this.connection)
+        this.connection.listen()
+
+        this.connection.console.info('AWS CloudFormation (json/yaml) language server started!')
+    }
+
+    getTextDocument(uri: string): TextDocument {
+        const textDocument = this.documents.get(uri)
+
+        if (!textDocument) {
+            throw new Error(`Document with uri ${uri} not found.`)
+        }
+
+        return textDocument
+    }
+
+    async validateDocument(uri: string): Promise<void> {
+        const textDocument = this.getTextDocument(uri)
+
+        this.connection.console.info(`Validating document, languageId: ${textDocument.languageId}, uri: ${uri}...`)
+
+        if (this.cloudformationService.isSupported(textDocument)) {
+            const diagnostics = await this.cloudformationService.doValidation(textDocument)
+            this.connection.sendDiagnostics({ uri, version: textDocument.version, diagnostics })
+        }
+
+        return
+    }
+
+    registerHandlers() {
+        this.documents.onDidOpen(({ document }) => {
+            this.connection.console.info(`Document opened, uri: ${document.uri}...`)
+
+            this.validateDocument(document.uri)
+        })
+
+        this.documents.onDidChangeContent(({ document }) => {
+            this.validateDocument(document.uri)
+        })
+
+        this.connection.onCompletion(async ({ textDocument: requestedDocument, position }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            if (this.cloudformationService.isSupported(textDocument)) {
+                return await this.cloudformationService.doComplete(textDocument, position)
+            }
+
+            return
+        })
+
+        this.connection.onCompletionResolve(item => item)
+
+        this.connection.onHover(async ({ textDocument: requestedDocument, position }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            this.connection.console.info(`Hover, languageId: ${textDocument.languageId}, uri: ${textDocument.uri}...`)
+
+            if (this.cloudformationService.isSupported(textDocument)) {
+                return await this.cloudformationService.doHover(textDocument, position)
+            }
+
+            return
+        })
+
+        this.connection.onDocumentFormatting(async ({ textDocument: requestedDocument, options }) => {
+            const textDocument = this.getTextDocument(requestedDocument.uri)
+
+            if (this.cloudformationService.isSupported(textDocument)) {
+                return this.cloudformationService.format(
+                    textDocument,
+                    textDocumentUtils.getFullRange(textDocument),
+                    options
+                )
+            }
+
+            return
+        })
+    }
+}

--- a/lsp/server/aws-lsp-cloudformation/src/language-server/cloudFormationService.ts
+++ b/lsp/server/aws-lsp-cloudformation/src/language-server/cloudFormationService.ts
@@ -1,0 +1,16 @@
+import { AwsLanguageService, MutuallyExclusiveLanguageService, SchemaProvider } from '@lsp-placeholder/aws-lsp-core'
+import { JsonLanguageService } from '@lsp-placeholder/aws-lsp-json-common'
+import { YamlLanguageService } from '@lsp-placeholder/aws-lsp-yaml-common'
+
+export type CloudFormationServiceProps = {
+    displayName: string
+    defaultSchemaUri: string
+    schemaProvider: SchemaProvider
+}
+
+export function create(props: CloudFormationServiceProps): AwsLanguageService {
+    const jsonService = new JsonLanguageService(props)
+    const yamlService = new YamlLanguageService(props)
+
+    return new MutuallyExclusiveLanguageService([jsonService, yamlService])
+}

--- a/lsp/server/aws-lsp-cloudformation/src/language-server/urls.ts
+++ b/lsp/server/aws-lsp-cloudformation/src/language-server/urls.ts
@@ -1,0 +1,2 @@
+export const jsonSchemaUrl: string =
+    'https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json'

--- a/lsp/server/aws-lsp-cloudformation/tsconfig.json
+++ b/lsp/server/aws-lsp-cloudformation/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "UMD",
+        "target": "ES2021",
+        "moduleResolution": "node",
+        "lib": ["ES2021"],
+        "rootDir": "./src",
+        "outDir": "./out",
+        "declaration": true,
+        "sourceMap": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "composite": true
+    },
+    "include": ["src", "test"],
+    "exclude": ["node_modules"]
+}

--- a/lsp/tsconfig.json
+++ b/lsp/tsconfig.json
@@ -13,12 +13,6 @@
     "files": [],
     "references": [
         {
-            "path": "./app/aws-lsp-buildspec-binary"
-        },
-        {
-            "path": "./app/aws-lsp-cloudformation-binary"
-        },
-        {
             "path": "./client/vscode"
         },
         {
@@ -35,6 +29,12 @@
         },
         {
             "path": "./server/aws-lsp-cloudformation"
+        },
+        {
+            "path": "./app/aws-lsp-buildspec-binary"
+        },
+        {
+            "path": "./app/aws-lsp-cloudformation-binary"
         }
     ]
 }

--- a/lsp/tsconfig.json
+++ b/lsp/tsconfig.json
@@ -16,6 +16,9 @@
             "path": "./app/aws-lsp-buildspec-binary"
         },
         {
+            "path": "./app/aws-lsp-cloudformation-binary"
+        },
+        {
             "path": "./client/vscode"
         },
         {

--- a/lsp/tsconfig.json
+++ b/lsp/tsconfig.json
@@ -29,6 +29,9 @@
         },
         {
             "path": "./server/aws-lsp-buildspec"
+        },
+        {
+            "path": "./server/aws-lsp-cloudformation"
         }
     ]
 }


### PR DESCRIPTION
This is part of a series of changes that establishes an LSP monorepo that we can perform experiments on.

This change provides a second demonstration language server and binary that can be integrated into IDEs. This language server is based on the CloudFormation JSON Schema.

This server's implementation differs from the Buildspec implementation (from https://github.com/aws/aws-toolkit-common/pull/500), for the purpose of comparison. In this instance, the service is injected into the server. This looks like it gives us more design flexibility in reusing and composing the services to suit the needs of where they will be hosted/integrated.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
