### PR TITLE
Centralize common tsconfig settings

### DIFF
--- a/lsp/app/aws-lsp-buildspec-binary/tsconfig.json
+++ b/lsp/app/aws-lsp-buildspec-binary/tsconfig.json
@@ -1,18 +1,8 @@
 {
+    "extends": "../../tsconfig.packages.json",
     "compilerOptions": {
-        "module": "UMD",
-        "target": "ES2021",
-        "moduleResolution": "node",
-        "lib": ["ES2021"],
         "rootDir": "./src",
-        "outDir": "./out",
-        "declaration": true,
-        "sourceMap": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "composite": true
+        "outDir": "./out"
     },
-    "include": ["src", "test"],
-    "exclude": ["node_modules"]
+    "include": ["src"]
 }

--- a/lsp/app/aws-lsp-cloudformation-binary/tsconfig.json
+++ b/lsp/app/aws-lsp-cloudformation-binary/tsconfig.json
@@ -1,18 +1,8 @@
 {
+    "extends": "../../tsconfig.packages.json",
     "compilerOptions": {
-        "module": "UMD",
-        "target": "ES2021",
-        "moduleResolution": "node",
-        "lib": ["ES2021"],
         "rootDir": "./src",
-        "outDir": "./out",
-        "declaration": true,
-        "sourceMap": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "composite": true
+        "outDir": "./out"
     },
-    "include": ["src", "test"],
-    "exclude": ["node_modules"]
+    "include": ["src"]
 }

--- a/lsp/core/aws-lsp-core/tsconfig.json
+++ b/lsp/core/aws-lsp-core/tsconfig.json
@@ -1,18 +1,8 @@
 {
+    "extends": "../../tsconfig.packages.json",
     "compilerOptions": {
-        "module": "UMD",
-        "target": "ES2021",
-        "moduleResolution": "node",
-        "lib": ["ES2021"],
         "rootDir": "./src",
-        "outDir": "./out",
-        "declaration": true,
-        "sourceMap": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "composite": true
+        "outDir": "./out"
     },
-    "include": ["src"],
-    "exclude": ["node_modules"]
+    "include": ["src"]
 }

--- a/lsp/core/aws-lsp-json-common/tsconfig.json
+++ b/lsp/core/aws-lsp-json-common/tsconfig.json
@@ -1,18 +1,8 @@
 {
+    "extends": "../../tsconfig.packages.json",
     "compilerOptions": {
-        "module": "UMD",
-        "target": "ES2021",
-        "moduleResolution": "node",
-        "lib": ["ES2021"],
         "rootDir": "./src",
-        "outDir": "./out",
-        "declaration": true,
-        "sourceMap": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "composite": true
+        "outDir": "./out"
     },
-    "include": ["src", "test"],
-    "exclude": ["node_modules"]
+    "include": ["src"]
 }

--- a/lsp/core/aws-lsp-yaml-common/tsconfig.json
+++ b/lsp/core/aws-lsp-yaml-common/tsconfig.json
@@ -1,18 +1,8 @@
 {
+    "extends": "../../tsconfig.packages.json",
     "compilerOptions": {
-        "module": "UMD",
-        "target": "ES2021",
-        "moduleResolution": "node",
-        "lib": ["ES2021"],
         "rootDir": "./src",
-        "outDir": "./out",
-        "declaration": true,
-        "sourceMap": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "composite": true
+        "outDir": "./out"
     },
-    "include": ["src", "test"],
-    "exclude": ["node_modules"]
+    "include": ["src"]
 }

--- a/lsp/server/aws-lsp-buildspec/tsconfig.json
+++ b/lsp/server/aws-lsp-buildspec/tsconfig.json
@@ -1,18 +1,8 @@
 {
+    "extends": "../../tsconfig.packages.json",
     "compilerOptions": {
-        "module": "UMD",
-        "target": "ES2021",
-        "moduleResolution": "node",
-        "lib": ["ES2021"],
         "rootDir": "./src",
-        "outDir": "./out",
-        "declaration": true,
-        "sourceMap": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "composite": true
+        "outDir": "./out"
     },
-    "include": ["src", "test"],
-    "exclude": ["node_modules"]
+    "include": ["src"]
 }

--- a/lsp/server/aws-lsp-cloudformation/tsconfig.json
+++ b/lsp/server/aws-lsp-cloudformation/tsconfig.json
@@ -1,18 +1,8 @@
 {
+    "extends": "../../tsconfig.packages.json",
     "compilerOptions": {
-        "module": "UMD",
-        "target": "ES2021",
-        "moduleResolution": "node",
-        "lib": ["ES2021"],
         "rootDir": "./src",
-        "outDir": "./out",
-        "declaration": true,
-        "sourceMap": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "composite": true
+        "outDir": "./out"
     },
-    "include": ["src", "test"],
-    "exclude": ["node_modules"]
+    "include": ["src"]
 }

--- a/lsp/tsconfig.packages.json
+++ b/lsp/tsconfig.packages.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "UMD",
+        "target": "ES2021",
+        "moduleResolution": "node",
+        "lib": ["ES2021"],
+        "declaration": true,
+        "sourceMap": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "composite": true
+    },
+    "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This change moves common tsconfig settings to a central file (lsp/tsconfig.packages.json), which each project's tsconfig.json can then reference (using the `extends` setting).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
