### PR TITLE
Run LSP tests in CI

### DIFF
--- a/buildspec/languageServerTests.yml
+++ b/buildspec/languageServerTests.yml
@@ -13,10 +13,10 @@ phases:
                 cd lsp
                 npm install
                 npm run compile
-                echo todo noop
+                npm run test
 
+# TODO : IDE-10874 : establish a top level packaging command
 #                npm run package-x64
-#                npm run test
 # artifacts:
 #     discard-paths: yes
 #     files:

--- a/lsp/app/aws-lsp-buildspec-binary/package.json
+++ b/lsp/app/aws-lsp-buildspec-binary/package.json
@@ -4,7 +4,7 @@
     "description": "CodeBuild BuildSpec Language Server Binary",
     "main": "out/index.js",
     "bin": {
-        "awsdocuments-language-server": "./out/index.js"
+        "aws-lsp-buildspec-binary": "./out/index.js"
     },
     "scripts": {
         "compile": "tsc --build",

--- a/lsp/app/aws-lsp-cloudformation-binary/package.json
+++ b/lsp/app/aws-lsp-cloudformation-binary/package.json
@@ -4,7 +4,7 @@
     "description": "CodeBuild CloudFormation Language Server Binary",
     "main": "out/index.js",
     "bin": {
-        "awsdocuments-language-server": "./out/index.js"
+        "aws-lsp-cloudformation-binary": "./out/index.js"
     },
     "scripts": {
         "compile": "tsc --build",

--- a/lsp/package-lock.json
+++ b/lsp/package-lock.json
@@ -35,7 +35,7 @@
                 "@lsp-placeholder/aws-lsp-buildspec": "^0.0.1"
             },
             "bin": {
-                "awsdocuments-language-server": "out/index.js"
+                "aws-lsp-buildspec-binary": "out/index.js"
             },
             "devDependencies": {
                 "pkg": "^5.8.1"
@@ -48,7 +48,7 @@
                 "@lsp-placeholder/aws-lsp-cloudformation": "^0.0.1"
             },
             "bin": {
-                "awsdocuments-language-server": "out/index.js"
+                "aws-lsp-cloudformation-binary": "out/index.js"
             },
             "devDependencies": {
                 "pkg": "^5.8.1"


### PR DESCRIPTION

This change runs the LSP unit tests as part of the CI. This builds on a change in #505 that added a `npm run test` command at the monorepo root.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
