### PR TITLE
Add package command to monorepo root

### DIFF
--- a/buildspec/languageServerTests.yml
+++ b/buildspec/languageServerTests.yml
@@ -7,17 +7,16 @@ phases:
 
     build:
         # Build and package the language server, then run tests.
+        # Packaging takes place before the tests, in case tests mutate the output folder.
         # Packaged binaries will be emitted as CodeBuild artifacts.
         commands:
             - |
                 cd lsp
                 npm install
                 npm run compile
+                npm run package
                 npm run test
-
-# TODO : IDE-10874 : establish a top level packaging command
-#                npm run package-x64
-# artifacts:
-#     discard-paths: yes
-#     files:
-#         - lsp/bin/**
+artifacts:
+    discard-paths: yes
+    files:
+        - lsp/app/**/bin/**

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -17,7 +17,8 @@
         "clean": "ts-node ./script/clean.ts",
         "compile": "tsc --build --verbose",
         "watch": "tsc --build --watch",
-        "test": "npm run test --workspaces --if-present"
+        "test": "npm run test --workspaces --if-present",
+        "package": "npm install && npm run compile && npm run package-x64 --workspaces --if-present"
     },
     "dependencies": {
         "typescript": "^5.0.4"


### PR DESCRIPTION
This change adds an `npm run package` command to the monorepo root, which can be used to produce all of the monorepo's language server binaries.

The CI job has been updated to pick up the binaries as artifacts.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
