### PR TITLE
Touch up GitHub Actions CI

### DIFF
--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -1,9 +1,9 @@
 name: Language Server CI
 on:
     push:
-        branches: [main, dev]
+        branches: [main, dev, feature/*]
     pull_request:
-        branches: [main, dev]
+        branches: [main, dev, feature/*]
 
 jobs:
     test:
@@ -48,5 +48,5 @@ jobs:
             - name: Attach binaries
               uses: actions/upload-artifact@v3
               with:
-                  name: langauge-server
-                  path: lsp/bin/awsdocuments-language-server-*
+                  name: langauge-servers
+                  path: lsp/**/bin/*

--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -43,7 +43,7 @@ jobs:
             - name: Create binaries
               run: |
                   cd lsp
-                  npm run package-x64
+                  npm run package
             # TODO : Can we easily create ARM binaries from GitHub?
             - name: Attach binaries
               uses: actions/upload-artifact@v3

--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -49,4 +49,5 @@ jobs:
               uses: actions/upload-artifact@v3
               with:
                   name: langauge-servers
-                  path: lsp/**/bin/*
+                  # Make sure you don't include lsp/node_modules
+                  path: lsp/app/**/bin/*

--- a/buildspec/languageServerTests.yml
+++ b/buildspec/languageServerTests.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
     install:
         runtime-versions:
-            nodejs: 16
+            nodejs: 18
 
     build:
         # Build and package the language server, then run tests.

--- a/buildspec/languageServerTests.yml
+++ b/buildspec/languageServerTests.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
     install:
         runtime-versions:
-            nodejs: 18
+            nodejs: 16
 
     build:
         # Build and package the language server, then run tests.

--- a/lsp/core/aws-lsp-core/package.json
+++ b/lsp/core/aws-lsp-core/package.json
@@ -5,7 +5,7 @@
     "main": "out/index.js",
     "scripts": {
         "compile": "tsc --build",
-        "test": "mocha ./out/**/*.test.js"
+        "test": "mocha './out/**/*.test.js'"
     },
     "dependencies": {
         "vscode-languageserver-textdocument": "^1.0.8",


### PR DESCRIPTION
This change
- runs GitHub Actions based CI on feature branches now
- bundles binaries into the GitHub Actions artifacts
- properly finds and runs all of the tests on non-Windows systems (like CI)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
