### PR TITLE
Add 'memory' as a credential source to aws-toolkit-common

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -241,7 +241,7 @@
             "name": "credentialSourceId",
             "type": "string",
             "description": "Where credentials are stored or retrieved from",
-            "allowedValues": ["sharedCredentials", "sdkStore", "ec2", "ecs", "envVars", "awsId", "iamIdentityCenter", "other"]
+            "allowedValues": ["sharedCredentials", "sdkStore", "ec2", "ecs", "envVars", "awsId", "iamIdentityCenter", "memory", "other"]
         },
         {
             "name": "credentialType",


### PR DESCRIPTION
## Problem
The AWS Toolkit for Visual Studio has a new MemoryCredential source that stores credentials in memory rather than the other mediums currently defined in CredentialSourceId.  

## Solution

After discussing internally, "memory" best fits this source, so adding it here to be available in the toolkit.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
