### PR TITLE
build(lsp): use commonjs instead of umd

### DIFF
--- a/lsp/tsconfig.packages.json
+++ b/lsp/tsconfig.packages.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "UMD",
+        "module": "CommonJS",
         "target": "ES2021",
         "moduleResolution": "node",
         "lib": ["ES2021"],


### PR DESCRIPTION
## Problem

lsp cannot be built by web bundlers (e.g. webpack) that don't support UMD out-of-the-box.

## Solution

Use CommonJS instead of UMD.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
