### PR TITLE
Added metric for execution of sam info command

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1999,7 +1999,6 @@
             "description": "Called when deploying a SAM application",
             "metadata": [
                 { "type": "result" },
-                { "type": "reason", "required": false },
                 { "type": "version", "required": false }
             ]
         },
@@ -2031,7 +2030,11 @@
         {
             "name": "sam_info",
             "description": "Called when checking if the SAM executable on the local machine is valid with a valid version",
-            "metadata": [{ "type": "result" }, { "type": "version", "required": false }]
+            "metadata": [
+                { "type": "result" },
+                { "type": "reason", "required": false },
+                { "type": "version", "required": false }
+            ]
         },
         {
             "name": "schemas_view",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1997,7 +1997,11 @@
         {
             "name": "sam_deploy",
             "description": "Called when deploying a SAM application",
-            "metadata": [{ "type": "result" }, { "type": "version", "required": false }]
+            "metadata": [
+                { "type": "result" },
+                { "type": "reason", "required": false },
+                { "type": "version", "required": false }
+            ]
         },
         {
             "name": "sam_sync",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2025,6 +2025,11 @@
             ]
         },
         {
+            "name": "sam_info",
+            "description": "Called when checking if the SAM executable on the local machine is valid with a valid version",
+            "metadata": [{ "type": "result" }, { "type": "version", "required": false }]
+        },
+        {
             "name": "schemas_view",
             "description": "Called when selecting an EventBridge schema to view",
             "metadata": [{ "type": "result" }]


### PR DESCRIPTION
This change helps track failures that occur during validation of SAM CLI in a user's local machine. The metric is recorded after the execution of the sam --info command. The sam --info CLI command is used before the execution of all SAM CLI commands in the toolkit to retrieve the version of the SAM CLI executable. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
