### PR TITLE
codewhisperer: supplemental context strategy id

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -606,6 +606,11 @@
             "description": "Length of codewhisperer supplemental context extracted from files"
         },
         {
+            "name": "codewhispererSupplementalContextStrategyId",
+            "type": "string",
+            "description": "Name tag or identifier for supplemental context fetching strategy being used for us to easier analyze corresponding acceptance rate"
+        },
+        {
             "name": "codewhispererImportRecommendationEnabled",
             "type": "boolean",
             "description": "Whether Import Recommendation is enabled."
@@ -2893,6 +2898,10 @@
                 },
                 {
                     "type": "codewhispererSupplementalContextLength",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererSupplementalContextStrategyId",
                     "required": false
                 },
                 {


### PR DESCRIPTION
## Problem
We need more granular data when processing supplemental context analysis (CrossFile / UTG)
For example, UTG we have 2 different strategies to resolve the source file given a test file (where the customer trigger)
 - by file name
 - by file content

We would like to compare and know acceptance rate with `by file name` vs. `by file context` thus adding a strategyId field


## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
