### PR TITLE
Feature/getting started telemetry

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -524,11 +524,11 @@
             "type": "string",
             "description": "The task type selected by the user in getting started page",
             "allowedValues": [
-                "AUTO_TRIGGER",
-                "MANUAL_TRIGGER",
-                "COMMENT_AS_PROMPT",
-                "UNIT_TEST",
-                "NAVIGATION"
+                "autoTrigger",
+                "manualTrigger",
+                "commentAsPrompt",
+                "unitTest",
+                "navigation"
             ]
         },
         {
@@ -2938,15 +2938,14 @@
             ]
         },
         {
-            "name": "codewhisperer_onboardingTaskButtonClick",
+            "name": "codewhisperer_onboardingClick",
             "description": "This metric provides the particular language and task type selected by the user in the onboarding page by clicking on the Try Example button.",
             "metadata": [
                 {
                     "type": "codewhispererLanguage"
                 },
                 {
-                    "type": "codewhispererGettingStartedTaskType",
-                    "required": false
+                    "type": "codewhispererGettingStartedTaskType"
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -522,7 +522,7 @@
         {
             "name": "codewhispererGettingStartedTaskType",
             "type": "string",
-            "description": "The type of the getting started task to open the file",
+            "description": "The task type selected by the user in getting started page",
             "allowedValues": [
                 "AUTO_TRIGGER",
                 "MANUAL_TRIGGER",
@@ -2939,7 +2939,7 @@
         },
         {
             "name": "codewhisperer_onboardingTaskButtonClick",
-            "description": "This metric provides the particular language and task type selected by the user in the onboarding page by clicking on the Try Exmaple button.",
+            "description": "This metric provides the particular language and task type selected by the user in the onboarding page by clicking on the Try Example button.",
             "metadata": [
                 {
                     "type": "codewhispererLanguage"

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -524,11 +524,11 @@
             "type": "string",
             "description": "The type of the getting started task to open the file",
             "allowedValues": [
-                "Automatic",
-                "Manual",
-                "Comments",
-                "TestCase",
-                "Navigattion"
+                "AUTO_TRIGGER",
+                "MANUAL_TRIGGER",
+                "COMMENT_AS_PROMPT",
+                "UNIT_TEST",
+                "NAVIGATION"
             ]
         },
         {
@@ -2751,6 +2751,10 @@
                     "type": "codewhispererLanguage"
                 },
                 {
+                    "type": "codewhispererGettingStartedTaskType",
+                    "required": false
+                },
+                {
                     "type": "codewhispererPaginationProgress",
                     "required": false
                 },
@@ -2852,6 +2856,10 @@
                     "type": "codewhispererLanguage"
                 },
                 {
+                    "type": "codewhispererGettingStartedTaskType",
+                    "required": false
+                },
+                {
                     "type": "codewhispererTriggerType"
                 },
                 {
@@ -2926,6 +2934,19 @@
                 },
                 {
                     "type": "codewhispererUserGroup"
+                }
+            ]
+        },
+        {
+            "name": "codewhisperer_onboardingTaskButtonClick",
+            "description": "This metric provides the particular language and task type selected by the user in the onboarding page by clicking on the Try Exmaple button.",
+            "metadata": [
+                {
+                    "type": "codewhispererLanguage"
+                },
+                {
+                    "type": "codewhispererGettingStartedTaskType",
+                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -520,7 +520,7 @@
                 "c", "cpp", "go", "kotlin", "php", "ruby", "rust", "scala", "shell", "sql"]
         },
         {
-            "name": "codewhispererGettingStartedTaskType",
+            "name": "codewhispererGettingStartedTask",
             "type": "string",
             "description": "The task type selected by the user in getting started page",
             "allowedValues": [
@@ -2646,7 +2646,7 @@
                     "type": "codewhispererLanguage"
                 },
                 {
-                    "type": "codewhispererGettingStartedTaskType",
+                    "type": "codewhispererGettingStartedTask",
                     "required": false
                 },
                 {
@@ -2751,7 +2751,7 @@
                     "type": "codewhispererLanguage"
                 },
                 {
-                    "type": "codewhispererGettingStartedTaskType",
+                    "type": "codewhispererGettingStartedTask",
                     "required": false
                 },
                 {
@@ -2856,7 +2856,7 @@
                     "type": "codewhispererLanguage"
                 },
                 {
-                    "type": "codewhispererGettingStartedTaskType",
+                    "type": "codewhispererGettingStartedTask",
                     "required": false
                 },
                 {
@@ -2945,7 +2945,7 @@
                     "type": "codewhispererLanguage"
                 },
                 {
-                    "type": "codewhispererGettingStartedTaskType"
+                    "type": "codewhispererGettingStartedTask"
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -520,6 +520,18 @@
                 "c", "cpp", "go", "kotlin", "php", "ruby", "rust", "scala", "shell", "sql"]
         },
         {
+            "name": "codewhispererGettingStartedTaskType",
+            "type": "string",
+            "description": "The type of the getting started task to open the file",
+            "allowedValues": [
+                "Automatic",
+                "Manual",
+                "Comments",
+                "TestCase",
+                "Navigattion"
+            ]
+        },
+        {
             "name": "codewhispererLastSuggestionIndex",
             "type": "int",
             "description": "The last index of recommendation from a particular response"
@@ -2632,6 +2644,10 @@
                 },
                 {
                     "type": "codewhispererLanguage"
+                },
+                {
+                    "type": "codewhispererGettingStartedTaskType",
+                    "required": false
                 },
                 {
                     "type": "codewhispererLastSuggestionIndex",


### PR DESCRIPTION
## Problem
Telemetry for CodeWhisperer Getting Started Page.

## Solution
- Added CodeWhispererGettingStartedTaskType for CodeWhispererSerivceInvocation, CodeWhispererUserTriggerDecision,CodeWhispererUserDecision.
- Added a new Event "codewhisperer_onboardingTaskButtonClick" - This metric provides the particular language and task type selected by the user in the onboarding page by clicking on the Try Example button. 
- Changed allowed values for CodeWhispererGettingStartedTaskType.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
