### PR TITLE
Make sam info a passive metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2047,6 +2047,7 @@
         {
             "name": "sam_info",
             "description": "Called when checking if the SAM executable on the local machine is valid with a valid version",
+            "passive": true,
             "metadata": [
                 { "type": "result" },
                 { "type": "reason", "required": false },


### PR DESCRIPTION
## Problem
The sam_info metric is generating a lot of noise in the data due to multiple invocations
## Solution
Set the metric to passive to reduce generated noise.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
