### PR TITLE
CI: group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,15 @@ updates:
     directory: "/telemetry/vscode"
     schedule:
       interval: "daily"
+    groups:
+        jest:
+            dependency-type: 'development'
+            patterns:
+                - '*jest'
+        types:
+            dependency-type: 'development'
+            patterns:
+                - '@types/*'
 
   - package-ecosystem: "gradle"
     directory: "/telemetry/jetbrains"


### PR DESCRIPTION
Problem:
Dependency updates can be noisy. Unmerged dependency updates can block other updates if the max is reached.

Solution:
- Use dependabot "groups" feature: https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/ 
    - Group updates to "@types/" packages.
    - Group updates to "jest" packages.

ref https://github.com/aws/aws-toolkit-vscode/commit/06507c380c67c5aec7f3cf3f66e90e0f622232ca


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
