### PR TITLE
CI: group xunit dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,26 +3,33 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/telemetry/vscode"
-    schedule:
-      interval: "daily"
-    groups:
-        jest:
-            dependency-type: 'development'
-            patterns:
-                - '*jest'
-        types:
-            dependency-type: 'development'
-            patterns:
-                - '@types/*'
+    - package-ecosystem: 'npm'
+      directory: '/telemetry/vscode'
+      schedule:
+          interval: 'daily'
+      groups:
+          jest:
+              dependency-type: 'development'
+              patterns:
+                  - '*jest'
+          types:
+              dependency-type: 'development'
+              patterns:
+                  - '@types/*'
 
-  - package-ecosystem: "gradle"
-    directory: "/telemetry/jetbrains"
-    schedule:
-      interval: "daily"
+    - package-ecosystem: 'gradle'
+      directory: '/telemetry/jetbrains'
+      schedule:
+          interval: 'daily'
 
-  - package-ecosystem: "nuget"
-    directory: "/telemetry/csharp"
-    schedule:
-      interval: "daily"
+    - package-ecosystem: 'nuget'
+      directory: '/telemetry/csharp'
+      schedule:
+          interval: 'daily'
+      groups:
+          xunit:
+              dependency-type: 'development'
+              patterns:
+                  - 'xunit*'
+              update-types:
+                  - 'minor'


### PR DESCRIPTION
Problem:
Dependency updates can be noisy. Unmerged dependency updates can block other updates if the max is reached.

Solution:
- Use dependabot "groups" feature: https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/ 
    - Group updates to NuGet "xunit*" packages.

The file was also reformatted due to a git commit hook


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
