### PR TITLE
CI/dependabot: avoid PRs in "staging"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@
 version: 2
 updates:
     - package-ecosystem: 'npm'
+      target-branch: 'main' # Avoid updates to "staging".
       directory: '/telemetry/vscode'
       schedule:
           interval: 'daily'
@@ -18,11 +19,13 @@ updates:
                   - '@types/*'
 
     - package-ecosystem: 'gradle'
+      target-branch: 'main' # Avoid updates to "staging".
       directory: '/telemetry/jetbrains'
       schedule:
           interval: 'daily'
 
     - package-ecosystem: 'nuget'
+      target-branch: 'main' # Avoid updates to "staging".
       directory: '/telemetry/csharp'
       schedule:
           interval: 'daily'


### PR DESCRIPTION
Problem:
Dependabot sends PRs to staging repo.

Solution:
Specify "main" branch explicitly.

Related: https://github.com/aws/aws-toolkit-vscode/pull/1706


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
