### PR TITLE
codewhisperer: track security issues with fixes

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -502,6 +502,11 @@
             "description": "The number of security issues been detected"
         },
         {
+            "name": "codewhispererCodeScanIssuesWithFixes",
+            "type": "int",
+            "description": "The number of security issues detected with suggested fixes"
+        },
+        {
             "name": "codewhispererCompletionType",
             "type": "string",
             "description": "Completion Type of the inference results returned from CodeWhisperer model layer",
@@ -2718,6 +2723,9 @@
                 },
                 {
                     "type": "codewhispererCodeScanTotalIssues"
+                },
+                {
+                    "type": "codewhispererCodeScanIssuesWithFixes"
                 },
                 {
                     "type": "codewhispererLanguage"


### PR DESCRIPTION
## Problem

We want to track the number of security issues generated with at least 1 suggested fix.

## Solution

- Added an extra metadata field `codewhispererCodeScanIssuesWithFixes` for the `codewhisperer_securityScan` metric to represent this data.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
