### PR TITLE
feat(awsq_ telemetry): Add additional metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2630,7 +2630,7 @@
         },
         {
             "name": "aws_approachFlow",
-            "description": "A metric to see if Code Genration flow succeeded",
+            "description": "A metric to see if Approach flow succeeded",
             "metadata": [
                 { "type": "result" },
                 { "type": "reason", "required": false }

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2621,8 +2621,8 @@
             "unit": "Count"
         },
         {
-            "name": "aws_codeGenerationFlow",
-            "description": "A metric to see if Code Genration flow succeeded",
+            "name": "aws_codeGeneration",
+            "description": "Emitted when the user started Code Generation process",
             "metadata": [
                 { "type": "result" },
                 { "type": "reason", "required": false }
@@ -2630,7 +2630,7 @@
         },
         {
             "name": "aws_approachFlow",
-            "description": "A metric to see if Approach flow succeeded",
+            "description": "Emitted when the user started Approach process",
             "metadata": [
                 { "type": "result" },
                 { "type": "reason", "required": false }

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2601,14 +2601,40 @@
             "unit": "Count"
         },
         {
-            "name": "awsq_thumbsUp",
+            "name": "awsq_codeGenerationthumbsUp",
             "description": "User clicked on the thumbs up button, to mention that they are satisfied",
             "unit": "Count"
         },
         {
-            "name": "awsq_thumbsDown",
+            "name": "awsq_codeGenerationthumbsDown",
             "description": "User clicked on the thumbs down button to say that they are unsatisfied",
             "unit": "Count"
+        },
+        {
+            "name": "awsq_approachthumbsUp",
+            "description": "User clicked on the thumbs up button, to mention that they are satisfied",
+            "unit": "Count"
+        },
+        {
+            "name": "awsq_approachthumbsDown",
+            "description": "User clicked on the thumbs down button to say that they are unsatisfied",
+            "unit": "Count"
+        },
+        {
+            "name": "aws_codeGenerationFlow",
+            "description": "A metric to see if Code Genration flow succeeded",
+            "metadata": [
+                { "type": "result" },
+                { "type": "reason", "required": false }
+            ]
+        },
+        {
+            "name": "aws_approachFlow",
+            "description": "A metric to see if Code Genration flow succeeded",
+            "metadata": [
+                { "type": "result" },
+                { "type": "reason", "required": false }
+            ]
         },
         {
             "name": "awsq_isApproachAccepted",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2601,22 +2601,22 @@
             "unit": "Count"
         },
         {
-            "name": "awsq_codeGenerationthumbsUp",
+            "name": "awsq_codeGenerationThumbsUp",
             "description": "User clicked on the thumbs up button, to mention that they are satisfied",
             "unit": "Count"
         },
         {
-            "name": "awsq_codeGenerationthumbsDown",
+            "name": "awsq_codeGenerationThumbsDown",
             "description": "User clicked on the thumbs down button to say that they are unsatisfied",
             "unit": "Count"
         },
         {
-            "name": "awsq_approachthumbsUp",
+            "name": "awsq_approachThumbsUp",
             "description": "User clicked on the thumbs up button, to mention that they are satisfied",
             "unit": "Count"
         },
         {
-            "name": "awsq_approachthumbsDown",
+            "name": "awsq_approachThumbsDown",
             "description": "User clicked on the thumbs down button to say that they are unsatisfied",
             "unit": "Count"
         },


### PR DESCRIPTION
## Problem

added the following needed metrics for awswq_:

- awsq_codeGenerationThumbsUp 
- awsq_codeGenerationThumbsDown
- awsq_approachThumbsUp
- awsq_approachThumbsDown
- aws_codeGenerationFlow
- aws_approachFlow

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
