### PR TITLE
codewhisperer: make issues with fixes optional

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2707,7 +2707,8 @@
                     "type": "codewhispererCodeScanTotalIssues"
                 },
                 {
-                    "type": "codewhispererCodeScanIssuesWithFixes"
+                    "type": "codewhispererCodeScanIssuesWithFixes",
+                    "required": false
                 },
                 {
                     "type": "codewhispererLanguage"


### PR DESCRIPTION
## Problem

Make `codewhispererCodeScanIssuesWithFixes` optional to unblock build 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
