### PR TITLE
vscode: add "source" field to executeCommand metric

### DIFF
--- a/telemetry/definitions/vscodeDefinitions.json
+++ b/telemetry/definitions/vscodeDefinitions.json
@@ -35,6 +35,7 @@
             "passive": true,
             "metadata": [
                 { "type": "command" },
+                { "type": "source" },
                 { "type": "debounceCount" },
                 { "type": "duration" },
                 { "type": "result" },


### PR DESCRIPTION
When a vscode command is executed it can be executed from different places. The 'source' field will help to identify what caused the command to execute.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
