### PR TITLE
feat(tele): Fix type for amazonq_ metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -903,7 +903,7 @@
         },
         {
             "name": "amazonqCodeGenerationResult",
-            "type": "double",
+            "type": "string",
             "description": "Captures if code generation result is Complete, Failed,etc"
         },
         {


### PR DESCRIPTION
## Problem
amazonqCodeGenerationResult should be a string
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
