### PR TITLE
feat(amazonq): add missing metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2651,6 +2651,11 @@
             "metadata": [{ "type": "enabled" }, { "type": "amazonqConversationId" }]
         },
         {
+            "name": "amazonq_isProvideFeedbackForCodeGen",
+            "description": "User asked to regenerate code generation with a comment",
+            "metadata": [{ "type": "enabled" }, { "type": "amazonqConversationId" }]
+        },
+        {
             "name": "amazonq_isReviewedChanges",
             "description": "User reviewed changes",
             "passive": true,

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -901,11 +901,20 @@
             "type": "double",
             "description": "Captures the number of files generated as a part of code generation iteration"
         },
-
         {
             "name": "amazonqRepositorySize",
             "type": "double",
             "description": "Captures  size of the source code"
+        },
+        {
+            "name": "amazonqNumberOfReferences",
+            "type": "double",
+            "description": "Captures the number of references"
+        },
+        {
+            "name": "amazonqEndOfTheConversationLatency",
+            "type": "double",
+            "description": "The time it takes to end amazonq conversation"
         }
     ],
     "metrics": [
@@ -2602,47 +2611,42 @@
             "metadata": [{ "type": "amazonqConversationId" }]
         },
         {
-            "name": "amazonq_approachInvoke",
-            "description": "Emitted when the user started Approach process and captures if the proccess succeeded or failed.",
+            "name": "amazonq_endChat",
+            "description": "Captures end of the conversation with amazonq /dev",
             "metadata": [
                 { "type": "amazonqConversationId" },
-                { "type": "result" },
-                { "type": "reason", "required": false }
+                { "type": "amazonqEndOfTheConversationLatency", "required": false }
             ]
         },
         {
-            "name": "amazonq_approachIteration",
-            "description": "User recieved a result in Approach Iteration stage",
+            "name": "amazonq_approachInvoke",
+            "description": "Captures Approach generation process",
             "metadata": [
                 { "type": "amazonqConversationId" },
                 { "type": "amazonqGenerateApproachIteration" },
-                { "type": "amazonqGenerateApproachLatency" }
+                { "type": "amazonqGenerateApproachLatency" },
+                { "type": "result" },
+                { "type": "reason", "required": false }
             ]
         },
         {
             "name": "amazonq_isApproachAccepted",
-            "description": "User has accepted the approach generated",
-            "metadata": [{ "type": "enabled" }, { "type": "amazonqConversationId" }] 
+            "description": "User has accepted the approach generated,",
+            "metadata": [{ "type": "enabled" }, { "type": "amazonqConversationId" }]
         },
         {
             "name": "amazonq_codeGenerationInvoke",
-            "description": "Emitted when the user started Code Generation process and captures if the proccess succeeded or failed.",
-            "metadata": [
-                { "type": "amazonqConversationId" },
-                { "type": "result" },
-                { "type": "reason", "required": false }
-            ]
-        },
-        {
-            "name": "amazonq_codeGenerationIteration",
-            "description": "User recieved a result in Code Generation Iteration stage",
+            "description": "Captures Code Generation generation process",
             "metadata": [
                 { "type": "amazonqConversationId" },
                 { "type": "amazonqGenerateCodeIteration" },
                 { "type": "amazonqGenerateCodeResponseLatency" },
                 { "type": "amazonqCodeGenerationResult" },
-                { "type": "amazonqNumberOfFilesGenerated" },
-                { "type": "amazonqRepositorySize" }
+                { "type": "amazonqNumberOfFilesGenerated", "required": false },
+                { "type": "amazonqRepositorySize" },
+                { "type": "amazonqNumberOfReferences", "required": false },
+                { "type": "result" },
+                { "type": "reason", "required": false }
             ]
         },
         {
@@ -2651,13 +2655,9 @@
             "metadata": [{ "type": "enabled" }, { "type": "amazonqConversationId" }]
         },
         {
-            "name": "amazonq_isRejectedCodeChanges",
-            "description": "User rejected code changes generated for the task.",
-            "metadata": [{ "type": "enabled" }, { "type": "amazonqConversationId" }]
-        },
-        {
             "name": "amazonq_isReviewedChanges",
             "description": "User reviewed changes",
+            "passive": true,
             "metadata": [{ "type": "enabled" }, { "type": "amazonqConversationId" }]
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2631,7 +2631,7 @@
         },
         {
             "name": "amazonq_isApproachAccepted",
-            "description": "User has accepted the approach generated,",
+            "description": "User has accepted the approach generated",
             "metadata": [{ "type": "enabled" }, { "type": "amazonqConversationId" }]
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -914,7 +914,7 @@
         {
             "name": "amazonqEndOfTheConversationLatency",
             "type": "double",
-            "description": "The time it takes to end amazonq conversation"
+            "description": "Total time from start to end"
         }
     ],
     "metrics": [

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2624,9 +2624,7 @@
             "metadata": [
                 { "type": "amazonqConversationId" },
                 { "type": "amazonqGenerateApproachIteration" },
-                { "type": "amazonqGenerateApproachLatency" },
-                { "type": "result" },
-                { "type": "reason", "required": false }
+                { "type": "amazonqGenerateApproachLatency" }
             ]
         },
         {
@@ -2645,8 +2643,6 @@
                 { "type": "amazonqNumberOfFilesGenerated", "required": false },
                 { "type": "amazonqRepositorySize" },
                 { "type": "amazonqNumberOfReferences", "required": false },
-                { "type": "result" },
-                { "type": "reason", "required": false }
             ]
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2642,7 +2642,7 @@
                 { "type": "amazonqCodeGenerationResult" },
                 { "type": "amazonqNumberOfFilesGenerated", "required": false },
                 { "type": "amazonqRepositorySize" },
-                { "type": "amazonqNumberOfReferences", "required": false },
+                { "type": "amazonqNumberOfReferences", "required": false }
             ]
         },
         {


### PR DESCRIPTION
## Problem
- remove amazonq_approachIteration and amazonq_codeGenerationIteration.
- moved its metrics to  amazonq_approachInvoke and amazonq_codeGenerationInvoke accordingly
- added amazonqEndOfTheConversationLatency and amazonqNumberOfReferences
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
