### PR TITLE
Fix Kotlin buildspec

### DIFF
--- a/buildspec/kotlinTests.yml
+++ b/buildspec/kotlinTests.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
     install:
         runtime-versions:
-            java: corretto8
+            java: corretto17
 
     build:
         commands:


### PR DESCRIPTION
## Problem

Kotlin CI Jobs are failing, because the build images now use corretto 17 instead of 8

## Solution

Update the build jobs to use corretto 17

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
