### PR TITLE
Add IDEBundledMaven to the allowedValues of codeTransformMavenBuildCommand

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1057,7 +1057,8 @@
             "description": "Type of maven command",
             "allowedValues": [
                 "mvn",
-                "mvnw"
+                "mvnw",
+                "intelliJBundledMaven"
             ]
         }
     ],

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1058,7 +1058,7 @@
             "allowedValues": [
                 "mvn",
                 "mvnw",
-                "intelliJBundledMaven"
+                "IDEBundledMaven"
             ]
         }
     ],


### PR DESCRIPTION
## Problem
We are going to use IDE bundled maven to run the maven command for Amazon Q Transform in aws-toolkit-jetbrains.
Need to add the telemetry for it.
## Solution
Add IDEBundledMaven to the allowedValues of codeTransformMavenBuildCommand 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
