### PR TITLE
codewhisperer: add rule id for scan metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -777,6 +777,21 @@
             "description": "The user group identifier we assign to the customer and it should be unique identifier across different IDE platforms, i.e. Classifier, CrossFile etc."
         },
         {
+          "name": "findingId",
+          "type": "string",
+          "description": "The id of a security finding from a code scan"
+        },
+        {
+            "name": "detectorId",
+            "type": "string",
+            "description": "The id of the detector which produced the code scan issue"
+        },
+        {
+            "name": "ruleId",
+            "type": "string",
+            "description": "The id of the rule which produced the code scan issue"
+        },
+        {
             "name": "syncedResources",
             "type": "string",
             "description": "Describes which parts of an application (that we know of) were synced to the cloud. \"Code\" resources follow the SAM spec: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-sync.html",
@@ -2941,6 +2956,26 @@
                     "required": false
                 }
             ]
+        },
+        {
+            "name": "codewhisperer_codeScanIssueHover",
+            "description": "Called when a code scan issue is hovered over",
+            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "ruleId", "required": false }]
+        },
+        {
+            "name": "codewhisperer_codeScanIssueApplyFix",
+            "description": "Called when a code scan issue suggested fix is applied",
+            "metadata": [
+                { "type": "findingId" },
+                { "type": "detectorId" },
+                { "type": "component" },
+                { "type": "ruleId", "required": false }
+            ]
+        },
+        {
+            "name": "codewhisperer_codeScanIssueViewDetails",
+            "description": "Called when a code scan issue webview is opened",
+            "metadata": [{ "type": "findingId" }, { "type": "detectorId" }, { "type": "ruleId", "required": false }]
         },
         {
             "name": "codewhisperer_serviceInvocation",


### PR DESCRIPTION
## Description
- Moved metrics here from vscode repo
- Added `ruleId` field for security scans
- Added `codewhisperer_codeScanIssueViewDetails`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
