### PR TITLE
Add .NET 8 Lambda runtime

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -177,6 +177,7 @@
                 "dotnet5.0",
                 "dotnet6",
                 "dotnet7",
+                "dotnet8",
                 "nodejs18.x",
                 "nodejs16.x",
                 "nodejs14.x",


### PR DESCRIPTION
## Description
Adds .NET 8 as a Lambda runtime.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
