### PR TITLE
added ComputeEnv as type with dev, local, test, web, cc, cloud9, wsl,…

### DIFF
--- a/telemetry/service/service-model.json
+++ b/telemetry/service/service-model.json
@@ -68,15 +68,17 @@
       "type":"string",
       "enum":[
         "cloud9",
-        "codeCatalyst",
-        "dev",
+        "cloud9-codecatalyst",
+        "cloud9-ec2",
+        "codecatalyst",
         "ec2",
         "local",
         "sagemaker",
         "ssh",
         "test",
         "web",
-        "wsl"
+        "wsl",
+        "other"
       ]
     },
     "Datapoint":{

--- a/telemetry/service/service-model.json
+++ b/telemetry/service/service-model.json
@@ -64,6 +64,21 @@
       "type":"string",
       "max":2000
     },
+    "CommputeEnv":{
+      "type":"string",
+      "enum":[
+        "cloud9",
+        "codeCatalyst",
+        "dev",
+        "ec2",
+        "local",
+        "sagemaker",
+        "ssh",
+        "test",
+        "web",
+        "wsl"
+      ]
+    },
     "Datapoint":{
       "type":"double",
       "min":0
@@ -169,6 +184,7 @@
         "AWSProductVersion":{"shape":"AWSProductVersion"},
         "OS":{"shape":"Value"},
         "OSVersion":{"shape":"Value"},
+        "CommputeEnv": {"shape":"ComputeEnv"},
         "ParentProduct":{"shape":"Value"},
         "ParentProductVersion":{"shape":"Value"},
         "Metadata":{"shape":"Metadata"},
@@ -191,6 +207,7 @@
         "OS":{"shape":"Value"},
         "OSArchitecture":{"shape":"Value"},
         "OSVersion":{"shape":"Value"},
+        "CommputeEnv": {"shape":"ComputeEnv"},
         "ParentProduct":{"shape":"Value"},
         "ParentProductVersion":{"shape":"Value"},
         "MetricData":{"shape":"MetricData"}

--- a/telemetry/vscode/package-lock.json
+++ b/telemetry/vscode/package-lock.json
@@ -1226,9 +1226,9 @@
             }
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.199",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
-            "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==",
+            "version": "4.14.202",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+            "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -1250,9 +1250,9 @@
             "dev": true
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
+            "version": "17.0.32",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+            "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
             "dev": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -5650,9 +5650,9 @@
             }
         },
         "@types/lodash": {
-            "version": "4.14.199",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
-            "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==",
+            "version": "4.14.202",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+            "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
             "dev": true
         },
         "@types/node": {
@@ -5674,9 +5674,9 @@
             "dev": true
         },
         "@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
+            "version": "17.0.32",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+            "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"


### PR DESCRIPTION
## Problem
Problem : Identify the ENV in metrics. Since different env have different user flows, this field becomes helpful in understanding why some metrics are emitted or better understand user flow w.r.t to ENVS

initially adding "ec2", "codecatalyst", "cloud9", "wsl", "test", "vscode-web", "sagemaker", etc.
we can add more later
field name = computeEnv, analogous to the existing computeRegion field
## Solution
For all Toolkits to utilize field, adding ComputeEnv Field in PostMetricsRequest & PostFeedbackRequest
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
