### PR TITLE
fix: missing dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,48 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Documentation for configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
 
 version: 2
 updates:
     - package-ecosystem: 'npm'
       target-branch: 'main' # Avoid updates to "staging".
+      commit-message:
+          prefix: 'deps'
       directory: '/telemetry/vscode'
       schedule:
           interval: 'daily'
+      allow:
+          - dependency-name: '*'
       groups:
           jest:
-              dependency-type: 'development'
               patterns:
                   - '*jest'
           types:
-              dependency-type: 'development'
               patterns:
                   - '@types/*'
+          # other: # Catch-all to ensure dependabot updates other dependencies...
+          #     patterns:
+          #         - '*'
 
     - package-ecosystem: 'gradle'
       target-branch: 'main' # Avoid updates to "staging".
+      commit-message:
+          prefix: 'deps'
       directory: '/telemetry/jetbrains'
       schedule:
           interval: 'daily'
 
     - package-ecosystem: 'nuget'
       target-branch: 'main' # Avoid updates to "staging".
+      commit-message:
+          prefix: 'deps'
       directory: '/telemetry/csharp'
       schedule:
           interval: 'daily'
+      allow:
+          - dependency-name: '*'
       groups:
           xunit:
-              dependency-type: 'development'
               patterns:
                   - 'xunit'
                   - 'xunit.runner.visualstudio'
@@ -40,3 +50,6 @@ updates:
                   - 'xunit.*'
               update-types:
                   - 'minor'
+          # other: # Catch-all to ensure dependabot updates other dependencies...
+          #     patterns:
+          #         - '*'


### PR DESCRIPTION
# Problem:
Since ebe7d3cea52169c4f3ebdc398517c4a1a469e80d, dependabot does not send updates for packages not matching a group. For example, in the "telemetry/vscode/" directory it will only update `jest` and `@types` dependencies. Other deps won't be updated.

Hint: https://github.com/aws/aws-toolkit-common/pull/533#issuecomment-1886793932

# Solution:
- Review the inscrutable documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
- Reference examples on github via: https://github.com/search?q=path%3Adependabot.yml+groups+all&type=code
- Remove `dependency-type` directive.
- Try `allow: dependency-name: '*'` directive. 
    - If this doesn't work, later try a "catch-all" group. Note that `groups` are evaluated as "first wins".
- Note: intentionally _not_ using ["allow: dependency-type:all" directive](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow); it enables updates for _transitive_ dependencies.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
