### PR TITLE
fix(gumby): modify metric to track errors

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3541,6 +3541,14 @@
                 {
                     "type": "codeTransformRuntimeError",
                     "required": false
+                },
+                { 
+                    "type": "result", 
+                    "required": true 
+                },
+                { 
+                    "type": "reason", 
+                    "required": true 
                 }
             ]
         },
@@ -3894,6 +3902,14 @@
                 {
                     "type": "codeTransformRuntimeError",
                     "required": true
+                },
+                { 
+                    "type": "result", 
+                    "required": true 
+                },
+                { 
+                    "type": "reason", 
+                    "required": true 
                 }
             ]
         }

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3538,8 +3538,10 @@
                     "type": "codeTransformSessionId",
                     "required": true
                 },
-                { "type": "result", "required": true },
-                { "type": "reason", "required": true }
+                {
+                    "type": "codeTransformRuntimeError",
+                    "required": false
+                }
             ]
         },
         {
@@ -3890,8 +3892,8 @@
                     "required": true
                 },
                 {
-                    "type": "reason",
-                    "required": false
+                    "type": "codeTransformRuntimeError",
+                    "required": true
                 }
             ]
         }


### PR DESCRIPTION
## Problem

We run a `mvn` and `javap` shell command and want to track the error message that results when these commands fail.

## Solution

Add a field to the relevant metrics to keep track of the error message.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
