### PR TITLE
telemetry(gumby): add Java/Maven version fields

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -980,6 +980,16 @@
             "description": "A general string field to represent the result of the project"
         },
         {
+            "name": "codeTransformLocalJavaVersion",
+            "type": "string",
+            "description": "A string field to represent the Java version on the user's machine"
+        },
+        {
+            "name": "codeTransformLocalMavenVersion",
+            "type": "string",
+            "description": "A string field to represent the Maven version on the user's machine"
+        },
+        {
             "name": "codeTransformRuntimeError",
             "type": "string",
             "description": "A general string field to represent runtime errors in the project."
@@ -3508,6 +3518,14 @@
                 },
                 {
                     "type": "codeTransformResultStatusMessage",
+                    "required": false
+                },
+                {
+                    "type": "codeTransformLocalJavaVersion",
+                    "required": false
+                },
+                {
+                    "type": "codeTransformLocalMavenVersion",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem

We need to track the Java version and Maven version on the user's machine for insight into why a shell command we run is failing.

## Solution

Add those version fields to an existing metric.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
