### PR TITLE
telemetry(gumby): add runtimeError field to existing metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3556,6 +3556,10 @@
                     "type": "codeTransformSessionId",
                     "required": true
                 },
+                {
+                    "type": "codeTransformRuntimeError",
+                    "required": false
+                },
                 { "type": "result", "required": true },
                 { "type": "reason", "required": true }
             ]


### PR DESCRIPTION
## Problem

Need to track runtimeErrors for one of our metrics. Do not want it in the reason field or codeTransformPreValidationError field because we use these between both VS Code in IntelliJ to filter / group in our dashboard, and this error message we want included is not known in advance, so we are putting it in a separate field.

## Solution

Add runtimeError field to existing metric.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
