### PR TITLE
feature(QTransform): Add telemetry for 1p dependencies

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1076,6 +1076,11 @@
                 "mvnw",
                 "IDEBundledMaven"
             ]
+        },
+        {
+            "name": "codeTransformHas1pDependency",
+            "type": "boolean",
+            "description": "Project contains at least 1 dependency not available in maven central"
         }
     ],
     "metrics": [
@@ -3892,6 +3897,24 @@
                 {
                     "type": "reason",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "codeTransform_projectContains1pDependencies",
+            "description": "When a project contains dependencies not available on maven central",
+            "metadata": [
+                {
+                    "type": "codeTransformSessionId",
+                    "required": true
+                },
+                {
+                    "type": "codeTransformJobId",
+                    "required": true
+                },
+                {
+                    "type": "codeTransformHas1pDependency",
+                    "required": true
                 }
             ]
         }


### PR DESCRIPTION
## Problem
A large amount of applications submitted through Amazon Q Code Transformation fail at the pre-build stage due to errors in retrieving dependencies, especially when dependencies not available on maven central (1p dependencies) are not able to be fetched and packaged up by Q Transform. This metric gives us visibility into whether a project has dependencies that cannot be found on maven central, and the data will be used (1) for the team to get a better understanding of the percentage of pre-build failures associated with 1p dependencies, and (2) to design and implement future enhancements in the case of Q Transform being unable to fetch certain private dependencies. 

## Solution
Add a new true/false metric for the existence of 1p dependencies in an application. See associated PRs in VSCode and IntelliJ: 
- [VSCode](https://github.com/aws/aws-toolkit-vscode/pull/4308) 
- [IntelliJ](https://github.com/aws/aws-toolkit-jetbrains/pull/4109)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
