### PR TITLE
feat: Add amazonqUploadIntent field to amazonq_createUpload

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -929,6 +929,12 @@
             "description": "Captures the size of the source code"
         },
         {
+            "name": "amazonqUploadIntent",
+            "type": "string",
+            "description": "The intent of the upload",
+            "allowedValues": ["TRANSFORMATION", "TASK_ASSIST_PLANNING"]
+        },
+        {
             "name": "amazonqNumberOfReferences",
             "type": "double",
             "description": "Captures the number of references"
@@ -2816,7 +2822,8 @@
             "description": "Captures createUploadUrl invocation process",
             "metadata": [
                 { "type": "amazonqConversationId" },
-                { "type": "amazonqRepositorySize", "required": false }
+                { "type": "amazonqRepositorySize", "required": false },
+                { "type": "amazonqUploadIntent", "required": false }
             ]
         },
         {


### PR DESCRIPTION
## Problem

We have a missing field in our amazonq_createUpload capture, which identifies the intent of the upload.

## Solution

This CR adds that field as optional with possible values of `TRANSFORMATION` or `TASK_ASSIST_PLANNING`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
