### PR TITLE
telemetry(CodeTransform): add status field to vcs metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1074,10 +1074,10 @@
             "description": "Names of the pre-validation errors that can occur",
             "allowedValues": [
                 "NoPom",
-                "NoJavaProjects",
+                "NoJavaProject",
                 "MixedLanguages",
                 "UnsupportedJavaVersion",
-                "NoMavenProjects",
+                "NonMavenProject",
                 "EmptyProject",
                 "NonSsoLogin",
                 "RemoteRunProject"


### PR DESCRIPTION
## Problem

We want to be able to know, when a user submits or cancels our proposed changes, was the project status successful or partially successful (at this point in the transformation, it must be one of these two).

## Solution

Add existing status field to two existing metrics.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
