### PR TITLE
chore: remove amazonq_startChat duplicate metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2784,12 +2784,6 @@
             "passive": true
         },
         {
-            "name": "amazonq_startChat",
-            "description": "Number of times the user have triggered /dev and started the chat",
-            "unit": "Count",
-            "metadata": [{ "type": "amazonqConversationId" }]
-        },
-        {
             "name": "amazonq_endChat",
             "description": "Captures end of the conversation with amazonq /dev",
             "metadata": [


### PR DESCRIPTION
## Problem
We have amazonq_startConversationInvoke that tracks the information we need. Having duplicate metrics is unnecessary and confusing.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
