### PR TITLE
telemetry(CodeTransform): enhance metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1091,7 +1091,7 @@
             "description": "Type of maven command",
             "allowedValues": [
                 "mvnw.cmd",
-                "./mvnw",
+                "mvnw",
                 "mvn",
                 "IDEBundledMaven"
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -944,7 +944,8 @@
             "description": "Allowed Java versions to transform from",
             "allowedValues": [
                 "JDK_1_8",
-                "JDK_11"
+                "JDK_11",
+                "Other"
             ]
         },
         {
@@ -1077,6 +1078,7 @@
                 "NoJavaProject",
                 "MixedLanguages",
                 "UnsupportedJavaVersion",
+                "ProjectJDKDiffersFromMavenJDK",
                 "NonMavenProject",
                 "EmptyProject",
                 "NonSsoLogin",
@@ -1088,8 +1090,9 @@
             "type": "string",
             "description": "Type of maven command",
             "allowedValues": [
+                "mvnw.cmd",
+                "./mvnw",
                 "mvn",
-                "mvnw",
                 "IDEBundledMaven"
             ]
         }


### PR DESCRIPTION
## Problem

Want telemetry to see how often users select "Other" in Java version selection drop down. Want telemetry to see how often users are shown the input prompt to enter their JAVA_HOME (happens when project JDK differs from Maven JDK). Needed to revise the `CodeTransformMavenBuildCommand` field to be more accurate.

## Solution

Implement the above.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
