### PR TITLE
Measure whether CodeWhisperer is enabled or not

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3450,6 +3450,21 @@
             ]
         },
         {
+            "name": "codewhisperer_enabled",
+            "description": "Whether or not CodeWhisperer is enabled",
+            "passive": true,
+            "metadata": [
+                {
+                    "type": "source",
+                    "required": true
+                },
+                {
+                    "type": "enabled",
+                    "required": true
+                }
+            ]
+        },
+        {
             "name": "codecatalyst_createDevEnvironment",
             "description": "Create an Amazon CodeCatalyst Dev Environment",
             "metadata": [


### PR DESCRIPTION
## Problem

We want to understand how often users turn CodeWhisperer on or off.

## Solution

Measure the current state at startup, and when explicitly turned on/off.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
