### PR TITLE
feat: Update  amazonq_isAcceptedCodeChanges metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -929,6 +929,11 @@
             "description": "Captures the number of files generated as a part of code generation iteration"
         },
         {
+            "name": "amazonqNumberOfFilesRejected",
+            "type": "double",
+            "description": "Captures the number of rejected files as a part of code generation iteration"
+        },
+        {
             "name": "amazonqRepositorySize",
             "type": "double",
             "description": "Captures the size of the source code"
@@ -2864,6 +2869,7 @@
             "metadata": [
                 { "type": "enabled" }, 
                 { "type": "amazonqConversationId" },
+                { "type": "amazonqNumberOfFilesRejected" },
                 { "type": "credentialStartUrl", "required": false }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2869,7 +2869,7 @@
             "metadata": [
                 { "type": "enabled" }, 
                 { "type": "amazonqConversationId" },
-                { "type": "amazonqNumberOfFilesRejected" },
+                { "type": "amazonqNumberOfFilesRejected", "required": false },
                 { "type": "credentialStartUrl", "required": false }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -929,9 +929,9 @@
             "description": "Captures the number of files generated as a part of code generation iteration"
         },
         {
-            "name": "amazonqNumberOfFilesRejected",
+            "name": "amazonqNumberOfFilesAccepted",
             "type": "double",
-            "description": "Captures the number of rejected files as a part of code generation iteration"
+            "description": "Captures the number of accepted files as a part of code generation iteration"
         },
         {
             "name": "amazonqRepositorySize",
@@ -2869,7 +2869,7 @@
             "metadata": [
                 { "type": "enabled" }, 
                 { "type": "amazonqConversationId" },
-                { "type": "amazonqNumberOfFilesRejected", "required": false },
+                { "type": "amazonqNumberOfFilesAccepted"},
                 { "type": "credentialStartUrl", "required": false }
             ]
         },


### PR DESCRIPTION
## Problem

In amazonq we want to be able to capture number of rejected by the customer files, when accepting changes
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
