### PR TITLE
telemetry: add new field for prev status

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -283,6 +283,11 @@
             ]
         },
         {
+            "name": "codeTransformPreviousStatus",
+            "type": "string",
+            "description": "The current transformation job's previous status"
+        },
+        {
             "name": "codeTransformRequestId",
             "type": "string",
             "description": "The API request ID"
@@ -316,11 +321,6 @@
                 "bottomPanelSideNavButton",
                 "chatPrompt"
             ]
-        },
-        {
-            "name": "codeTransformPreviousStatus",
-            "type": "string",
-            "description": "The current transformation job's previous status"
         },
         {
             "name": "codeTransformStatus",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2865,11 +2865,11 @@
                     "required": true
                 },
                 {
-                    "type": "codeTransformSessionId",
+                    "type": "codeTransformPreviousStatus",
                     "required": true
                 },
                 {
-                    "type": "codeTransformPreviousStatus",
+                    "type": "codeTransformSessionId",
                     "required": true
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -318,6 +318,11 @@
             ]
         },
         {
+            "name": "codeTransformPreviousStatus",
+            "type": "string",
+            "description": "The current transformation job's previous status"
+        },
+        {
             "name": "codeTransformStatus",
             "type": "string",
             "description": "The current transformation job's status"

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2869,6 +2869,10 @@
                     "required": true
                 },
                 {
+                    "type": "codeTransformPreviousStatus",
+                    "required": true
+                },
+                {
                     "type": "codeTransformStatus",
                     "required": true
                 }


### PR DESCRIPTION
## Problem

We already have a status field, but also want to be able to track the previous status of a job so that we can see how the status changes over time more easily. Using a new field rather than putting it all in the existing status field because our dashboards and other metrics are already configured to visualize the status with the existing field, so don't want to break that.

## Solution

Add new field to hold job's previous status.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
