### PR TITLE
Add codeTransformProjectId field for one Q CodeTransform Metric.

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -348,6 +348,11 @@
             ]
         },
         {
+            "name": "codeTransformProjectId",
+            "type": "string",
+            "description": "A hash identifying the projects chosen top level build file that is to be transformed."
+        },
+        {
             "name": "codewhispererAcceptedTokens",
             "type": "int",
             "description": "The metrics accepted on suggested CodeWhisperer code"
@@ -2851,6 +2856,10 @@
                 },
                 {
                     "type": "codeTransformSessionId",
+                    "required": true
+                },
+                {
+                    "type": "codeTransformProjectId",
                     "required": true
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -288,6 +288,11 @@
             "description": "The current transformation job's previous status"
         },
         {
+            "name": "codeTransformProjectId",
+            "type": "string",
+            "description": "A hash identifying the projects chosen top level build file that is to be transformed."
+        },
+        {
             "name": "codeTransformRequestId",
             "type": "string",
             "description": "The API request ID"
@@ -346,11 +351,6 @@
                 "treeView",
                 "treeViewHeader"
             ]
-        },
-        {
-            "name": "codeTransformProjectId",
-            "type": "string",
-            "description": "A hash identifying the projects chosen top level build file that is to be transformed."
         },
         {
             "name": "codewhispererAcceptedTokens",
@@ -2855,11 +2855,11 @@
                     "required": true
                 },
                 {
-                    "type": "codeTransformSessionId",
+                    "type": "codeTransformProjectId",
                     "required": true
                 },
                 {
-                    "type": "codeTransformProjectId",
+                    "type": "codeTransformSessionId",
                     "required": true
                 }
             ]


### PR DESCRIPTION
## Problem
It is complicated to track wether failures when running Q CodeTransform on customer machines are due to repeated tries of the same project or for different projects. This complicates for us to understand if errors we see are only for specific projects or for all projects for a specific clientId.
 
## Solution
Emit a projectHash that uniquely identifies the project selected for transform by a user. This allows us to differentiate between repeated submissions of the same project or unique submissions of different projects. Thus allowing us to fix issues faster.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
