### PR TITLE
telemetry(QCT): add jobId to metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3019,7 +3019,7 @@
             "metadata": [
                 {
                     "type": "codeTransformJobId",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "codeTransformLocalJavaVersion",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3036,6 +3036,10 @@
                 {
                     "type": "codeTransformSessionId",
                     "required": true
+                },
+                {
+                    "type": "codeTransformJobId",
+                    "required": true
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3018,6 +3018,10 @@
             "description": "We want to log the total run time in the users experience for the IDE. The total runtime should end when all API's have finished running and the users is prompted for next step actions.",
             "metadata": [
                 {
+                    "type": "codeTransformJobId",
+                    "required": true
+                },
+                {
                     "type": "codeTransformLocalJavaVersion",
                     "required": false
                 },
@@ -3035,10 +3039,6 @@
                 },
                 {
                     "type": "codeTransformSessionId",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformJobId",
                     "required": true
                 }
             ]


### PR DESCRIPTION
## Problem

Need access to jobId for this totalRunTime metric. Sometimes, the job has been cancelled before a jobId is available, so I set required to false.

## Solution

Add jobId field.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
