### PR TITLE
telemetry: set projectDetails as passive

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2988,6 +2988,7 @@
         },
         {
             "name": "codeTransform_projectDetails",
+            "passive": true,
             "description": "Transform initiates project validation before user interaction and we want to gather project details then.",
             "metadata": [
                 {


### PR DESCRIPTION
## Problem
Passive metric emitted popup showing for VSCode for non-passive logging.

<img width="288" alt="Screenshot 2024-03-20 at 5 41 20 PM" src="https://github.com/aws/aws-toolkit-common/assets/38665452/5bc80cd7-416e-4693-9592-6af997466294">

## Solution

Add passive attribute 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
