### PR TITLE
auth: add isReAuth attribute to aws_loginWithBrowser

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1059,6 +1059,11 @@
             "description": "Whether this was an individual point or an aggregation of points."
         },
         {
+            "name": "isReAuth",
+            "type": "boolean",
+            "description": "If this was performed as part of the reauthentication flow."
+        },
+        {
             "name": "lambdaArchitecture",
             "allowedValues": [
                 "x86_64",
@@ -1835,6 +1840,10 @@
                 },
                 {
                     "type": "credentialType",
+                    "required": false
+                },
+                {
+                    "type": "isReAuth",
                     "required": false
                 },
                 {


### PR DESCRIPTION
This attribute indicates if the `aws_loginWithBrowser` process was done for reauthentication, otherwise regular authentication was done if isReauth !== true.

This gives us some extra details so we can separate user triggered authentications vs. system triggered reauthentications

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
