### PR TITLE
telemetry(amazonq): add field to track auth type to metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2841,6 +2841,10 @@
                 {
                     "type": "codeTransformSessionId",
                     "required": true
+                },
+                {
+                    "type": "enabledAuthConnections",
+                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2843,7 +2843,7 @@
                     "required": true
                 },
                 {
-                    "type": "enabledAuthConnections",
+                    "type": "credentialSourceId",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem

Want a field to track if user is authenticated with BuilderId or IdC for QCT.

## Solution

Use an existing auth-related field and add it to an existing metric which will be emitted when /transform is invoked.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
