### PR TITLE
telemtry:(amazonq): Add more metadata fields to capture duration, result, failure reason to amazonq events

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1340,6 +1340,26 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                {
+                    "type": "duration",
+                    "required": false
+                },
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "requestId",
+                    "required": false
+                },
+                {
+                    "type": "requestServiceType",
+                    "required": false
+                },
+                {
+                    "type": "result",
+                    "required": false
                 }
             ]
         },
@@ -1401,6 +1421,26 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                {
+                    "type": "duration",
+                    "required": false
+                },
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "requestId",
+                    "required": false
+                },
+                {
+                    "type": "requestServiceType",
+                    "required": false
+                },
+                {
+                    "type": "result",
+                    "required": false
                 }
             ]
         },
@@ -1449,6 +1489,26 @@
                 },
                 {
                     "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "duration",
+                    "required": false
+                },
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "requestId",
+                    "required": false
+                },
+                {
+                    "type": "requestServiceType",
+                    "required": false
+                },
+                {
+                    "type": "result",
                     "required": false
                 }
             ]
@@ -1548,6 +1608,26 @@
                 },
                 {
                     "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "duration",
+                    "required": false
+                },
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "requestId",
+                    "required": false
+                },
+                {
+                    "type": "requestServiceType",
+                    "required": false
+                },
+                {
+                    "type": "result",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem

We want to track duration, result, failure reason, requestId and requestServiceType fields for startConversationInvoke, approachInvoke, createUpload and codeGenerationInvoke events in JetBrains. 

## Solution

In toolkits, we get those fields added to the telemetry events when we do telemetry.event.run{}, however in JetBrains it isn't supported. Therefore, adding them as metadata fields.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
