### PR TITLE
telemetry(amazonq): source folder modification

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1599,6 +1599,19 @@
             ]
         },
         {
+            "name": "amazonq_modifySourceFolder",
+            "description": "User modified source folder",
+            "metadata": [
+                {
+                    "type": "amazonqConversationId"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
+        },
+        {
             "name": "amazonq_startConversationInvoke",
             "description": "Captures startConversation invocation process",
             "metadata": [


### PR DESCRIPTION
## Problem

The source folder modification was not being tracked, it was evident when a bug was spotted and it was not possible to measure any customer impact. This should make it easier when integrated with the toolkits to measure usage and impact if something goes wrong.

## Solution

Add modifySourceFolder metric.

It was tested in the VSCode toolkit adding the metric in vscodeTelemetry.json file, generating telemetry and then checking it was emitted in kibana.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
