### PR TITLE
adding scopes to auth metrics for detailed authStatus

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -103,6 +103,22 @@
             "description": "Current number of authentication connections the user has"
         },
         {
+            "name": "authEnabledConnections",
+            "type": "string",
+            "description": "Comma-delimited list of enabled auths."
+        },
+        {
+            "name": "authScopes",
+            "type": "string",
+            "description": "Comma-delimited list of scopes that users has"
+        },
+        {
+            "name": "authStatus",
+            "type": "string",
+            "allowedValues": ["connected", "notConnected", "expired"],
+            "description": "Status of the an auth connection."
+        },
+        {
             "name": "awsFiletype",
             "type": "string",
             "allowedValues": [
@@ -1816,6 +1832,10 @@
                     "type": "authConnectionsCount"
                 },
                 {
+                    "type": "authScopes",
+                    "required": false
+                },
+                {
                     "type": "enabledAuthConnections"
                 },
                 {
@@ -1847,6 +1867,29 @@
                     "type": "userChoice"
                 }
             ]
+        },
+        {
+            "name": "auth_userState",
+            "description": "The state of the user's authentication.",
+            "metadata": [
+                {
+                    "type": "source",
+                    "required": true
+                },
+                {
+                    "type": "authStatus",
+                    "required": true
+                },
+                {
+                    "type": "authEnabledConnections",
+                    "required": true
+                },
+                {
+                    "type": "authScopes",
+                    "required": false
+                }
+            ],
+            "passive": true
         },
         {
             "name": "aws_copyArn",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -115,7 +115,11 @@
         {
             "name": "authStatus",
             "type": "string",
-            "allowedValues": ["connected", "notConnected", "expired"],
+            "allowedValues": [
+                "connected",
+                "notConnected",
+                "expired"
+            ],
             "description": "Status of the an auth connection."
         },
         {
@@ -1873,20 +1877,20 @@
             "description": "The state of the user's authentication.",
             "metadata": [
                 {
-                    "type": "source",
-                    "required": true
-                },
-                {
-                    "type": "authStatus",
-                    "required": true
-                },
-                {
                     "type": "authEnabledConnections",
                     "required": true
                 },
                 {
                     "type": "authScopes",
                     "required": false
+                },
+                {
+                    "type": "authStatus",
+                    "required": true
+                },
+                {
+                    "type": "source",
+                    "required": true
                 }
             ],
             "passive": true

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1874,7 +1874,7 @@
         },
         {
             "name": "auth_userState",
-            "description": "The state of the user's authentication.",
+            "description": "The state of the user's authentication upon startup.",
             "metadata": [
                 {
                     "type": "authEnabledConnections",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1801,6 +1801,10 @@
                     "required": false
                 },
                 {
+                    "type": "authScopes",
+                    "required": false
+                },
+                {
                     "type": "credentialSourceId"
                 },
                 {
@@ -1834,10 +1838,6 @@
                 },
                 {
                     "type": "authConnectionsCount"
-                },
-                {
-                    "type": "authScopes",
-                    "required": false
                 },
                 {
                     "type": "enabledAuthConnections"


### PR DESCRIPTION
## Problem

Adding auth telemetry for to identify user's auth Status upon start up.


## Solution
auth_userState list scopes upon users loading extension so we know their authStatus upon startup
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
