### PR TITLE
fix(modifySourceFolder): add result and reason fields

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1608,6 +1608,14 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "result",
+                    "required": false
                 }
             ]
         },


### PR DESCRIPTION
## Problem

The `result` and `reason` fields are being used in VSCode to add more details to the metric. In order to have the same fields in JetBrains these are needed to be specifically added to the metric definition.

## Solution

Add the needed fields to the metric.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
