### PR TITLE
add customizationArun field to metrics cwspr_clientComponentLatency, cwspr_perceivedLatency

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3432,6 +3432,10 @@
                     "type": "codewhispererCredentialFetchingLatency"
                 },
                 {
+                    "type": "codewhispererCustomizationArn",
+                    "required": false
+                },
+                {
                     "type": "codewhispererEndToEndLatency"
                 },
                 {
@@ -3611,6 +3615,10 @@
             "metadata": [
                 {
                     "type": "codewhispererCompletionType"
+                },
+                {
+                    "type": "codewhispererCustomizationArn",
+                    "required": false
                 },
                 {
                     "type": "codewhispererLanguage"


### PR DESCRIPTION
## Problem
As service team request, adding customizationArn for the team to analyze code completion runtime performance

## Solution
- add field `customizationArn: string` to the mentioned 2 metrics
- setting required=false as free tier users won't have access to customization

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
