### PR TITLE
Add requestId and reasonDesc to refreshCredentials metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2202,6 +2202,14 @@
                     "type": "result"
                 },
                 {
+                    "type": "requestId",
+                    "required": false
+                },
+                {
+                    "type": "reasonDesc",
+                    "required": false
+                },
+                {
                     "type": "sessionDuration",
                     "required": false
                 }

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1199,6 +1199,11 @@
             "description": "The reason for a metric or exception depending on context. It describes a certain theme of errors usually the exception class name eg. FileIOException"
         },
         {
+            "name": "reasonDesc",
+            "type": "string",
+            "description": "Error message detail (truncated). May contain arbitrary message details (as opposed to the 'reason' field, which is intended to have a predictable value for a particular class of failures)."
+        },
+        {
             "name": "referencePolicyType",
             "type": "string",
             "allowedValues": [

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2204,15 +2204,15 @@
                     "required": false
                 },
                 {
-                    "type": "result"
+                    "type": "reasonDesc",
+                    "required": false
                 },
                 {
                     "type": "requestId",
                     "required": false
                 },
                 {
-                    "type": "reasonDesc",
-                    "required": false
+                    "type": "result"
                 },
                 {
                     "type": "sessionDuration",


### PR DESCRIPTION
## Problem
refreshCredentials metric does not have requestId and reason description

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->
Add requestId and reasonDesc to refreshCredentials 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
