### PR TITLE
Adding interactWithMessage telemetry event

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1425,6 +1425,49 @@
             ]
         },
         {
+            "name": "amazonq_interactWithMessage",
+            "description": "When a user interacts with a message in the conversation",
+            "metadata": [
+                {
+                    "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "cwsprChatMessageId"
+                },
+                {
+                    "type": "cwsprChatInteractionType"
+                },
+                {
+                    "type": "cwsprChatInteractionTarget",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatCodeBlockIndex",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatTotalCodeBlocks",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatAcceptedCharactersLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatAcceptedNumberOfLines",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatHasReference",
+                    "required": false
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
+        },
+        {
             "name": "accessanalyzer_iamPolicyChecksValidatePolicy",
             "description": "Execution of Validate Policy in IAM Policy Checks",
             "metadata": [

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,6 +1,62 @@
 {
     "types": [
         {
+            "name": "amazonQChatAcceptedCharactersLength",
+            "type": "int",
+            "description": "Count of code characters copied to the editor"
+        },
+        {
+            "name": "amazonQChatAcceptedNumberOfLines",
+            "type": "int",
+            "description": "Count of lines of code copied to the editor"
+        },
+        {
+            "name": "amazonQChatCodeBlockIndex",
+            "type": "int",
+            "description": "Index of the code block inside a message in the conversation."
+        },
+        {
+            "name": "amazonQChatConversationId",
+            "type": "string",
+            "description": "Unique identifier for each conversation"
+        },
+        {
+            "name": "amazonQChatHasReference",
+            "type": "boolean",
+            "description": "True if the code snippet that user interacts with has a reference."
+        },
+        {
+            "name": "amazonQChatInteractionTarget",
+            "type": "string",
+            "description": "Identifies the entity within the message that user interacts with."
+        },
+        {
+            "name": "amazonQChatInteractionType",
+            "allowedValues": [
+                "insertAtCursor",
+                "copySnippet",
+                "copy",
+                "clickLink",
+                "clickFollowUp",
+                "hoverReference",
+                "upvote",
+                "downvote",
+                "clickBodyLink"
+            ],
+            "type": "string",
+            "description": "Indicates the specific interaction type with a message in a conversation"
+        },
+        {
+            "name": "amazonQChatMessageId",
+            "type": "string",
+            "description": "Unique identifier for each message in an conversation"
+        },
+        {
+            "name": "amazonQChatTotalCodeBlocks",
+            "type": "int",
+            "description": "Total number of code blocks inside a message in the conversation."
+        },
+        {
             "name": "amazonqCodeGenerationResult",
             "type": "string",
             "description": "Captures if code generation result is Complete, Failed, etc."
@@ -1660,40 +1716,40 @@
             "description": "When a user interacts with a message in the conversation",
             "metadata": [
                 {
+                    "type": "amazonqChatAcceptedCharactersLength",
+                    "required": false
+                },
+                {
+                    "type": "amazonqChatAcceptedNumberOfLines",
+                    "required": false
+                },
+                {
+                    "type": "amazonqChatCodeBlockIndex",
+                    "required": false
+                },
+                {
+                    "type": "amazonqChatConversationId"
+                },
+                {
+                    "type": "amazonqChatHasReference",
+                    "required": false
+                },
+                {
+                    "type": "amazonqChatInteractionTarget",
+                    "required": false
+                },
+                {
+                    "type": "amazonqChatInteractionType"
+                },
+                {
+                    "type": "amazonqChatMessageId"
+                },
+                {
+                    "type": "amazonqChatTotalCodeBlocks",
+                    "required": false
+                },
+                {
                     "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatAcceptedCharactersLength",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatAcceptedNumberOfLines",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatCodeBlockIndex",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatConversationId"
-                },
-                {
-                    "type": "cwsprChatHasReference",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatInteractionTarget",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatInteractionType"
-                },
-                {
-                    "type": "cwsprChatMessageId"
-                },
-                {
-                    "type": "cwsprChatTotalCodeBlocks",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -51,17 +51,17 @@
             "description": "Captures if code generation result is Complete, Failed, etc."
         },
         {
-            "name": "amazonQHasReference",
+            "name": "amazonqHasReference",
             "type": "boolean",
             "description": "True if the code snippet that user interacts with has a reference."
         },
         {
-            "name": "amazonQInteractionTarget",
+            "name": "amazonqInteractionTarget",
             "type": "string",
             "description": "Identifies the entity within the message that user interacts with."
         },
         {
-            "name": "amazonQInteractionType",
+            "name": "amazonqInteractionType",
             "allowedValues": [
                 "insertAtCursor",
                 "copySnippet",
@@ -77,7 +77,7 @@
             "description": "Indicates the specific interaction type with a message in a conversation"
         },
         {
-            "name": "amazonQMessageId",
+            "name": "amazonqMessageId",
             "type": "string",
             "description": "Unique identifier for each message in an conversation"
         },
@@ -102,7 +102,7 @@
             "description": "Captures the size of the source code"
         },
         {
-            "name": "amazonQTotalCodeBlocks",
+            "name": "amazonqTotalCodeBlocks",
             "type": "int",
             "description": "Total number of code blocks inside a message in the conversation."
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1750,10 +1750,6 @@
                 {
                     "type": "cwsprChatMessageId",
                     "required": true
-                },
-                {
-                    "type": "cwsprChatMessageId",
-                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -46,7 +46,7 @@
             "description": "The time it takes to generate code generation response"
         },
         {
-            "name": "amazonqGenerationResult",
+            "name": "amazonqCodeGenerationResult",
             "type": "string",
             "description": "Captures if code generation result is Complete, Failed, etc."
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -899,7 +899,7 @@
             "description": "Unique identifier for each message in an conversation"
         },
         {
-            "name": "cwsprChatMessageId",
+            "name": "cwsprChatTotalCodeBlocks",
             "type": "int",
             "description": "Total number of code blocks inside a message in the conversation."
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -16,6 +16,11 @@
             "description": "Index of the code block inside a message in the conversation."
         },
         {
+            "name": "amazonqCodeGenerationResult",
+            "type": "string",
+            "description": "Captures if code generation result is Complete, Failed, etc."
+        },
+        {
             "name": "amazonqConversationId",
             "type": "string",
             "description": "Uniquely identifies a message with which the user interacts."
@@ -44,11 +49,6 @@
             "name": "amazonqGenerateCodeResponseLatency",
             "type": "double",
             "description": "The time it takes to generate code generation response"
-        },
-        {
-            "name": "amazonqCodeGenerationResult",
-            "type": "string",
-            "description": "Captures if code generation result is Complete, Failed, etc."
         },
         {
             "name": "amazonqHasReference",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,65 +1,19 @@
 {
     "types": [
         {
-            "name": "amazonQChatAcceptedCharactersLength",
+            "name": "amazonQAcceptedCharactersLength",
             "type": "int",
             "description": "Count of code characters copied to the editor"
         },
         {
-            "name": "amazonQChatAcceptedNumberOfLines",
+            "name": "amazonQAcceptedNumberOfLines",
             "type": "int",
             "description": "Count of lines of code copied to the editor"
         },
         {
-            "name": "amazonQChatCodeBlockIndex",
+            "name": "amazonQCodeBlockIndex",
             "type": "int",
             "description": "Index of the code block inside a message in the conversation."
-        },
-        {
-            "name": "amazonQChatConversationId",
-            "type": "string",
-            "description": "Unique identifier for each conversation"
-        },
-        {
-            "name": "amazonQChatHasReference",
-            "type": "boolean",
-            "description": "True if the code snippet that user interacts with has a reference."
-        },
-        {
-            "name": "amazonQChatInteractionTarget",
-            "type": "string",
-            "description": "Identifies the entity within the message that user interacts with."
-        },
-        {
-            "name": "amazonQChatInteractionType",
-            "allowedValues": [
-                "insertAtCursor",
-                "copySnippet",
-                "copy",
-                "clickLink",
-                "clickFollowUp",
-                "hoverReference",
-                "upvote",
-                "downvote",
-                "clickBodyLink"
-            ],
-            "type": "string",
-            "description": "Indicates the specific interaction type with a message in a conversation"
-        },
-        {
-            "name": "amazonQChatMessageId",
-            "type": "string",
-            "description": "Unique identifier for each message in an conversation"
-        },
-        {
-            "name": "amazonQChatTotalCodeBlocks",
-            "type": "int",
-            "description": "Total number of code blocks inside a message in the conversation."
-        },
-        {
-            "name": "amazonqCodeGenerationResult",
-            "type": "string",
-            "description": "Captures if code generation result is Complete, Failed, etc."
         },
         {
             "name": "amazonqConversationId",
@@ -92,6 +46,42 @@
             "description": "The time it takes to generate code generation response"
         },
         {
+            "name": "amazonqGenerationResult",
+            "type": "string",
+            "description": "Captures if code generation result is Complete, Failed, etc."
+        },
+        {
+            "name": "amazonQHasReference",
+            "type": "boolean",
+            "description": "True if the code snippet that user interacts with has a reference."
+        },
+        {
+            "name": "amazonQInteractionTarget",
+            "type": "string",
+            "description": "Identifies the entity within the message that user interacts with."
+        },
+        {
+            "name": "amazonQInteractionType",
+            "allowedValues": [
+                "insertAtCursor",
+                "copySnippet",
+                "copy",
+                "clickLink",
+                "clickFollowUp",
+                "hoverReference",
+                "upvote",
+                "downvote",
+                "clickBodyLink"
+            ],
+            "type": "string",
+            "description": "Indicates the specific interaction type with a message in a conversation"
+        },
+        {
+            "name": "amazonQMessageId",
+            "type": "string",
+            "description": "Unique identifier for each message in an conversation"
+        },
+        {
             "name": "amazonqNumberOfFilesAccepted",
             "type": "double",
             "description": "Captures the number of accepted files as a part of code generation iteration"
@@ -110,6 +100,11 @@
             "name": "amazonqRepositorySize",
             "type": "double",
             "description": "Captures the size of the source code"
+        },
+        {
+            "name": "amazonQTotalCodeBlocks",
+            "type": "int",
+            "description": "Total number of code blocks inside a message in the conversation."
         },
         {
             "name": "amazonqUploadIntent",
@@ -1716,39 +1711,39 @@
             "description": "When a user interacts with a message in the conversation",
             "metadata": [
                 {
-                    "type": "amazonqChatAcceptedCharactersLength",
+                    "type": "amazonqAcceptedCharactersLength",
                     "required": false
                 },
                 {
-                    "type": "amazonqChatAcceptedNumberOfLines",
+                    "type": "amazonqAcceptedNumberOfLines",
                     "required": false
                 },
                 {
-                    "type": "amazonqChatCodeBlockIndex",
+                    "type": "amazonqCodeBlockIndex",
                     "required": false
                 },
                 {
-                    "type": "amazonqChatConversationId",
+                    "type": "amazonqConversationId",
                     "required": true
                 },
                 {
-                    "type": "amazonqChatHasReference",
+                    "type": "amazonqHasReference",
                     "required": false
                 },
                 {
-                    "type": "amazonqChatInteractionTarget",
+                    "type": "amazonqInteractionTarget",
                     "required": false
                 },
                 {
-                    "type": "amazonqChatInteractionType",
+                    "type": "amazonqInteractionType",
                     "required": true
                 },
                 {
-                    "type": "amazonqChatMessageId",
+                    "type": "amazonqMessageId",
                     "required": true
                 },
                 {
-                    "type": "amazonqChatTotalCodeBlocks",
+                    "type": "amazonqTotalCodeBlocks",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1425,49 +1425,6 @@
             ]
         },
         {
-            "name": "amazonq_interactWithMessage",
-            "description": "When a user interacts with a message in the conversation",
-            "metadata": [
-                {
-                    "type": "cwsprChatConversationId"
-                },
-                {
-                    "type": "cwsprChatMessageId"
-                },
-                {
-                    "type": "cwsprChatInteractionType"
-                },
-                {
-                    "type": "cwsprChatInteractionTarget",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatCodeBlockIndex",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatTotalCodeBlocks",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatAcceptedCharactersLength",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatAcceptedNumberOfLines",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatHasReference",
-                    "required": false
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                }
-            ]
-        },
-        {
             "name": "accessanalyzer_iamPolicyChecksValidatePolicy",
             "description": "Execution of Validate Policy in IAM Policy Checks",
             "metadata": [
@@ -1694,6 +1651,49 @@
                 },
                 {
                     "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_interactWithMessage",
+            "description": "When a user interacts with a message in the conversation",
+            "metadata": [
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatAcceptedCharactersLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatAcceptedNumberOfLines",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatCodeBlockIndex",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "cwsprChatHasReference",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatInteractionTarget",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatInteractionType"
+                },
+                {
+                    "type": "cwsprChatMessageId"
+                },
+                {
+                    "type": "cwsprChatTotalCodeBlocks",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1728,7 +1728,8 @@
                     "required": false
                 },
                 {
-                    "type": "amazonqChatConversationId"
+                    "type": "amazonqChatConversationId",
+                    "required": true
                 },
                 {
                     "type": "amazonqChatHasReference",
@@ -1739,10 +1740,12 @@
                     "required": false
                 },
                 {
-                    "type": "amazonqChatInteractionType"
+                    "type": "amazonqChatInteractionType",
+                    "required": true
                 },
                 {
-                    "type": "amazonqChatMessageId"
+                    "type": "amazonqChatMessageId",
+                    "required": true
                 },
                 {
                     "type": "amazonqChatTotalCodeBlocks",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,21 +1,6 @@
 {
     "types": [
         {
-            "name": "amazonqAcceptedCharactersLength",
-            "type": "int",
-            "description": "Count of code characters copied to the editor"
-        },
-        {
-            "name": "amazonqAcceptedNumberOfLines",
-            "type": "int",
-            "description": "Count of lines of code copied to the editor"
-        },
-        {
-            "name": "amazonqCodeBlockIndex",
-            "type": "int",
-            "description": "Index of the code block inside a message in the conversation."
-        },
-        {
             "name": "amazonqCodeGenerationResult",
             "type": "string",
             "description": "Captures if code generation result is Complete, Failed, etc."
@@ -51,37 +36,6 @@
             "description": "The time it takes to generate code generation response"
         },
         {
-            "name": "amazonqHasReference",
-            "type": "boolean",
-            "description": "True if the code snippet that user interacts with has a reference."
-        },
-        {
-            "name": "amazonqInteractionTarget",
-            "type": "string",
-            "description": "Identifies the entity within the message that user interacts with."
-        },
-        {
-            "name": "amazonqInteractionType",
-            "allowedValues": [
-                "insertAtCursor",
-                "copySnippet",
-                "copy",
-                "clickLink",
-                "clickFollowUp",
-                "hoverReference",
-                "upvote",
-                "downvote",
-                "clickBodyLink"
-            ],
-            "type": "string",
-            "description": "Indicates the specific interaction type with a message in a conversation"
-        },
-        {
-            "name": "amazonqMessageId",
-            "type": "string",
-            "description": "Unique identifier for each message in an conversation"
-        },
-        {
             "name": "amazonqNumberOfFilesAccepted",
             "type": "double",
             "description": "Captures the number of accepted files as a part of code generation iteration"
@@ -100,11 +54,6 @@
             "name": "amazonqRepositorySize",
             "type": "double",
             "description": "Captures the size of the source code"
-        },
-        {
-            "name": "amazonqTotalCodeBlocks",
-            "type": "int",
-            "description": "Total number of code blocks inside a message in the conversation."
         },
         {
             "name": "amazonqUploadIntent",
@@ -897,6 +846,62 @@
                 "bearerToken",
                 "other"
             ]
+        },
+        {
+            "name": "cwsprChatAcceptedCharactersLength",
+            "type": "int",
+            "description": "Count of code characters copied to the editor"
+        },
+        {
+            "name": "cwsprChatAcceptedNumberOfLines",
+            "type": "int",
+            "description": "Count of lines of code copied to the editor"
+        },
+        {
+            "name": "cwsprChatCodeBlockIndex",
+            "type": "int",
+            "description": "Index of the code block inside a message in the conversation."
+        },
+        {
+            "name": "cwsprChatConversationId",
+            "type": "string",
+            "description": "Uniquely identifies a message with which the user interacts."
+        },
+        {
+            "name": "cwsprChatHasReference",
+            "type": "boolean",
+            "description": "True if the code snippet that user interacts with has a reference."
+        },
+        {
+            "name": "cwsprChatInteractionTarget",
+            "type": "string",
+            "description": "Identifies the entity within the message that user interacts with."
+        },
+        {
+            "name": "cwsprChatInteractionType",
+            "allowedValues": [
+                "insertAtCursor",
+                "copySnippet",
+                "copy",
+                "clickLink",
+                "clickFollowUp",
+                "hoverReference",
+                "upvote",
+                "downvote",
+                "clickBodyLink"
+            ],
+            "type": "string",
+            "description": "Indicates the specific interaction type with a message in a conversation"
+        },
+        {
+            "name": "cwsprChatMessageId",
+            "type": "string",
+            "description": "Unique identifier for each message in an conversation"
+        },
+        {
+            "name": "cwsprChatMessageId",
+            "type": "int",
+            "description": "Total number of code blocks inside a message in the conversation."
         },
         {
             "name": "databaseCredentials",
@@ -1711,43 +1716,43 @@
             "description": "When a user interacts with a message in the conversation",
             "metadata": [
                 {
-                    "type": "amazonqAcceptedCharactersLength",
-                    "required": false
-                },
-                {
-                    "type": "amazonqAcceptedNumberOfLines",
-                    "required": false
-                },
-                {
-                    "type": "amazonqCodeBlockIndex",
-                    "required": false
-                },
-                {
-                    "type": "amazonqConversationId",
-                    "required": true
-                },
-                {
-                    "type": "amazonqHasReference",
-                    "required": false
-                },
-                {
-                    "type": "amazonqInteractionTarget",
-                    "required": false
-                },
-                {
-                    "type": "amazonqInteractionType",
-                    "required": true
-                },
-                {
-                    "type": "amazonqMessageId",
-                    "required": true
-                },
-                {
-                    "type": "amazonqTotalCodeBlocks",
-                    "required": false
-                },
-                {
                     "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatAcceptedCharactersLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatAcceptedNumberOfLines",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatCodeBlockIndex",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatConversationId",
+                    "required": true
+                },
+                {
+                    "type": "cwsprChatHasReference",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatInteractionTarget",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatInteractionType",
+                    "required": true
+                },
+                {
+                    "type": "cwsprChatMessageId",
+                    "required": true
+                },
+                {
+                    "type": "cwsprChatMessageId",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,17 +1,17 @@
 {
     "types": [
         {
-            "name": "amazonqAcceptedCharactersLength",
+            "name": "amazonQAcceptedCharactersLength",
             "type": "int",
             "description": "Count of code characters copied to the editor"
         },
         {
-            "name": "amazonqAcceptedNumberOfLines",
+            "name": "amazonQAcceptedNumberOfLines",
             "type": "int",
             "description": "Count of lines of code copied to the editor"
         },
         {
-            "name": "amazonqCodeBlockIndex",
+            "name": "amazonQCodeBlockIndex",
             "type": "int",
             "description": "Index of the code block inside a message in the conversation."
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,17 +1,17 @@
 {
     "types": [
         {
-            "name": "amazonQAcceptedCharactersLength",
+            "name": "amazonqAcceptedCharactersLength",
             "type": "int",
             "description": "Count of code characters copied to the editor"
         },
         {
-            "name": "amazonQAcceptedNumberOfLines",
+            "name": "amazonqAcceptedNumberOfLines",
             "type": "int",
             "description": "Count of lines of code copied to the editor"
         },
         {
-            "name": "amazonQCodeBlockIndex",
+            "name": "amazonqCodeBlockIndex",
             "type": "int",
             "description": "Index of the code block inside a message in the conversation."
         },


### PR DESCRIPTION
## Problem
Event for message interaction (`amazonq_interactWithMessage`) was missing from common telemetry definition. Currently IDEs are adding this to their toolkit specific telemetry override file.

## Solution
Add this event to the common definitions json file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
