### PR TITLE
telemetry(IamPolicyChecks) Add new policy check type

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -162,7 +162,8 @@
             "type": "string",
             "allowedValues": [
                 "CheckNoNewAccess",
-                "CheckAccessNotGranted"
+                "CheckAccessNotGranted",
+                "CheckNoPublicAccess"
             ],
             "description": "User inputted check type to denote which custom check to run."
         },


### PR DESCRIPTION
## Problem
A new `CheckNoPublicAccess` policy check type is being added to the existing IamPolicyChecks toolkits integration.

## Solution
Add the new check type to the allowed check type strings for telemetry.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
