### PR TITLE
Add exception handling to C# generator to help identify which definitions are having problems

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/DefinitionsBuilder.cs
@@ -163,11 +163,18 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator
         /// </summary>
         internal void ProcessMetricType(MetricType type, CodeNamespace generatedNamespace)
         {
-            // Handle non-POCO types
-            if (!type.IsAliasedType())
+            try
             {
-                // Generate strongly typed code for types that contain "allowed values"
-                generatedNamespace.Types.Add(GenerateEnumStruct(type));
+                // Handle non-POCO types
+                if (!type.IsAliasedType())
+                {
+                    // Generate strongly typed code for types that contain "allowed values"
+                    generatedNamespace.Types.Add(GenerateEnumStruct(type));
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to generate code for metric type: {type.name}", ex);
             }
         }
 
@@ -253,8 +260,15 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator
         /// </summary>
         private void ProcessMetric(Metric metric, CodeTypeDeclaration telemetryEventsClass, CodeNamespace generatedNamespace)
         {
-            generatedNamespace.Types.Add(CreateMetricDataClass(metric));
-            telemetryEventsClass.Members.Add(CreateRecordMetricMethodByDataClass(metric));
+            try
+            {
+                generatedNamespace.Types.Add(CreateMetricDataClass(metric));
+                telemetryEventsClass.Members.Add(CreateRecordMetricMethodByDataClass(metric));
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to generate code for metric: {metric.name}", ex);
+            }
         }
 
         /// <summary>
@@ -542,7 +556,14 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator
 
         private MetricType GetMetricType(string name)
         {
-            return _types.Single(t => t.name == name);
+            try
+            {
+                return _types.Single(t => t.name == name);
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Unable to find metric type: {name}", e);
+            }
         }
 
         private string SanitizeName(string name)


### PR DESCRIPTION
## Problem

When the telemetry definitions contain a general error, it can be hard to tell where the problem is when looking at the C# generator output.

## Solution

Add exception handling that indicates which entity was being processed.


Example:

![image](https://github.com/aws/aws-toolkit-common/assets/39839589/9760413f-8ca7-4818-8078-979ef17556ba)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
