### PR TITLE
telemetry(vscode): MetricBase.awsRegion

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -128,6 +128,11 @@
             "description": "Status of the an auth connection."
         },
         {
+            "name": "awsAccount",
+            "type": "string",
+            "description": "AWS account ID associated with a metric. \"n/a\" if credentials are not available. \"not-set\" if credentials are not selected. \"invalid\" if account ID cannot be obtained."
+        },
+        {
             "name": "awsFiletype",
             "type": "string",
             "allowedValues": [
@@ -146,6 +151,11 @@
                 "other"
             ],
             "description": "AWS filetype kind"
+        },
+        {
+            "name": "awsRegion",
+            "type": "string",
+            "description": "AWS Region associated with a metric"
         },
         {
             "name": "causedBy",
@@ -1224,6 +1234,11 @@
             "name": "language",
             "type": "string",
             "description": "Language used for the project."
+        },
+        {
+            "name": "locale",
+            "type": "string",
+            "description": "User locale. Examples: en-US, en-GB, etc."
         },
         {
             "name": "name",

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -121,7 +121,7 @@ function getTypeOrThrow(types: MetadataType[] = [], name: string) {
 }
 
 const baseName = 'MetricBase'
-const commonMetadata = ['result', 'reason', 'reasonDesc', 'duration']
+const commonMetadata = ['result', 'reason', 'reasonDesc', 'duration', 'awsRegion']
 const passive: PropertySignatureStructure = {
     isReadonly: true,
     hasQuestionToken: true,

--- a/telemetry/vscode/test/generator.test.ts
+++ b/telemetry/vscode/test/generator.test.ts
@@ -5,7 +5,32 @@
 
 import { generate } from '../src/generate'
 import { tmpdir } from 'os'
-import { readFile } from 'fs-extra'
+import * as fs from 'fs-extra'
+
+/**
+ * Replaces the "types" field in the given json file with the "types" field
+ * from `commonDefinitions.json`.
+ *
+ * @returns Original contents of `relPath`.
+ */
+async function writeCommonTypesToFile(relPath: string) {
+    const testInputFile = `${__dirname}/${relPath}`
+    const commonDefsStr = await fs.readFile(`${__dirname}/../../definitions/commonDefinitions.json`)
+    const commonDefs = JSON.parse(commonDefsStr.toString())
+    const commonTypes = commonDefs.types
+    const testInputStr = (await fs.readFile(testInputFile)).toString()
+    const testInputJson = JSON.parse(testInputStr)
+    // Use the "types" array from commonDefinitions.json.
+    testInputJson.types = commonTypes
+    await fs.writeFile(testInputFile, JSON.stringify(testInputJson, undefined, 4))
+
+    return testInputStr
+}
+
+async function restoreFile(relPath: string, data: string) {
+    const testInputFile = `${__dirname}/${relPath}`
+    await fs.writeFile(testInputFile, data)
+}
 
 describe('Generator', () => {
     let tempDir: string
@@ -18,22 +43,30 @@ describe('Generator', () => {
     })
 
     test('with normal input', async () => {
-        await testGenerator([`resources/generatorInput.json`], `resources/generatorOutput.ts`)
+        const oldFileContent = await writeCommonTypesToFile('resources/generatorInput.json')
+
+        await testGenerator(['resources/generatorInput.json'], 'resources/generatorOutput.ts')
+
+        restoreFile('resources/generatorInput.json', oldFileContent)
     })
 
     test('overrides', async () => {
+        const oldFileContent = await writeCommonTypesToFile('resources/testOverrideInput.json')
+
         await testGenerator(
             ['resources/testOverrideInput.json', 'resources/testResultInput.json'],
             'resources/generatorOverrideOutput.ts'
         )
+
+        restoreFile('resources/testOverrideInput.json', oldFileContent)
     })
 
     async function testGenerator(inputFiles: string[], expectedOutputFile: string) {
         const output = `${tempDir}/output`
         await generate({ inputFiles: inputFiles.map(item => `${__dirname}/${item}`), outputFile: output })
         // TODO remove spaces and line returns so that it matches more generally? pull in a better matching lib?
-        const actualOutput = await readFile(output, 'utf-8')
-        const expectedOutput = await readFile(`${__dirname}/${expectedOutputFile}`, 'utf-8')
+        const actualOutput = await fs.readFile(output, 'utf-8')
+        const expectedOutput = await fs.readFile(`${__dirname}/${expectedOutputFile}`, 'utf-8')
         expect(actualOutput).toEqual(expectedOutput)
     }
 })

--- a/telemetry/vscode/test/resources/generatorInput.json
+++ b/telemetry/vscode/test/resources/generatorInput.json
@@ -1,64 +1,45 @@
 {
-    "types": [
-        {
-            "name": "lambdaRuntime",
-            "type": "string",
-            "allowedValues": ["dotnetcore2.1", "nodejs12.x"],
-            "description": "The lambda runtime"
-        },
-        {
-            "name": "result",
-            "allowedValues": ["Succeeded"],
-            "description": "The result of the operation"
-        },
-        {
-            "name": "reason",
-            "type": "string",
-            "description": "Reason code or name for an event (when result=Succeeded) or error (when result=Failed). Unlike the `reasonDesc` field, this should be a stable/predictable name for a class of events or errors (typically the exception name, e.g. FileIOException)."
-        },
-        {
-            "name": "reasonDesc",
-            "type": "string",
-            "description": "Error message detail. May contain arbitrary message details (unlike the `reason` field), but should be truncated (recommendation: 200 chars)."
-        },
-        {
-            "name": "duration",
-            "type": "double",
-            "description": "The duration of the operation in miliseconds"
-        },
-        {
-            "name": "inttype",
-            "description": "a test int type",
-            "type": "int"
-        },
-        {
-            "name": "booltype",
-            "description": "a test boolean type",
-            "type": "boolean"
-        },
-        {
-            "name": "arbitraryString",
-            "description": "untyped string type"
-        }
-    ],
+    "types": "will be replaced with `types` from commonDefinitions.json",
     "metrics": [
         {
             "name": "lambda_delete",
             "description": "called when deleting lambdas remotely",
             "unit": "None",
-            "metadata": [{ "type": "duration" }, { "type": "booltype" }]
+            "metadata": [
+                {
+                    "type": "duration"
+                },
+                {
+                    "type": "isRetry"
+                }
+            ]
         },
         {
             "name": "lambda_create",
             "description": "called when creating lambdas remotely",
             "unit": "None",
-            "metadata": [{ "type": "lambdaRuntime" }, { "type": "arbitraryString" }]
+            "metadata": [
+                {
+                    "type": "runtime"
+                },
+                {
+                    "type": "userId"
+                }
+            ]
         },
         {
             "name": "lambda_remoteinvoke",
             "description": "called when invoking lambdas remotely",
             "unit": "None",
-            "metadata": [{ "type": "lambdaRuntime", "required": false }, { "type": "inttype" }]
+            "metadata": [
+                {
+                    "type": "runtime",
+                    "required": false
+                },
+                {
+                    "type": "successCount"
+                }
+            ]
         },
         {
             "name": "no_metadata",

--- a/telemetry/vscode/test/resources/generatorOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOutput.ts
@@ -9,8 +9,10 @@ export interface MetricBase {
     readonly reason?: string
     /** Error message detail. May contain arbitrary message details (unlike the `reason` field), but should be truncated (recommendation: 200 chars). */
     readonly reasonDesc?: string
-    /** The duration of the operation in miliseconds */
+    /** The duration of the operation in milliseconds */
     readonly duration?: number
+    /** AWS Region associated with a metric */
+    readonly awsRegion?: string
     /** A flag indicating that the metric was not caused by the user. */
     readonly passive?: boolean
     /** @deprecated Arbitrary "value" of the metric. */
@@ -18,30 +20,58 @@ export interface MetricBase {
 }
 
 export interface LambdaDelete extends MetricBase {
-    /** a test boolean type */
-    readonly booltype: boolean
+    /** Whether or not the operation was a retry */
+    readonly isRetry: boolean
 }
 
 export interface LambdaCreate extends MetricBase {
     /** The lambda runtime */
-    readonly lambdaRuntime: LambdaRuntime
-    /** untyped string type */
-    readonly arbitraryString: string
+    readonly runtime: Runtime
+    /** Opaque AWS Builder ID identifier */
+    readonly userId: string
 }
 
 export interface LambdaRemoteinvoke extends MetricBase {
     /** The lambda runtime */
-    readonly lambdaRuntime?: LambdaRuntime
-    /** a test int type */
-    readonly inttype: number
+    readonly runtime?: Runtime
+    /** The number of successful operations */
+    readonly successCount: number
 }
 
 export interface NoMetadata extends MetricBase {}
 
 export interface PassivePassive extends MetricBase {}
 
-export type Result = 'Succeeded'
-export type LambdaRuntime = 'dotnetcore2.1' | 'nodejs12.x'
+export type Result = 'Succeeded' | 'Failed' | 'Cancelled'
+export type Runtime =
+    | 'dotnetcore3.1'
+    | 'dotnetcore2.1'
+    | 'dotnet5.0'
+    | 'dotnet6'
+    | 'dotnet7'
+    | 'dotnet8'
+    | 'nodejs20.x'
+    | 'nodejs18.x'
+    | 'nodejs16.x'
+    | 'nodejs14.x'
+    | 'nodejs12.x'
+    | 'nodejs10.x'
+    | 'nodejs8.10'
+    | 'ruby2.5'
+    | 'java8'
+    | 'java8.al2'
+    | 'java11'
+    | 'java17'
+    | 'java21'
+    | 'go1.x'
+    | 'python3.12'
+    | 'python3.11'
+    | 'python3.10'
+    | 'python3.9'
+    | 'python3.8'
+    | 'python3.7'
+    | 'python3.6'
+    | 'python2.7'
 
 export interface MetricDefinition {
     readonly unit: string
@@ -60,9 +90,9 @@ export interface MetricShapes {
 export type MetricName = keyof MetricShapes
 
 export const definitions: Record<string, MetricDefinition> = {
-    lambda_delete: { unit: 'None', passive: false, requiredMetadata: ['booltype'] },
-    lambda_create: { unit: 'None', passive: false, requiredMetadata: ['lambdaRuntime', 'arbitraryString'] },
-    lambda_remoteinvoke: { unit: 'None', passive: false, requiredMetadata: ['inttype'] },
+    lambda_delete: { unit: 'None', passive: false, requiredMetadata: ['isRetry'] },
+    lambda_create: { unit: 'None', passive: false, requiredMetadata: ['runtime', 'userId'] },
+    lambda_remoteinvoke: { unit: 'None', passive: false, requiredMetadata: ['successCount'] },
     no_metadata: { unit: 'None', passive: false, requiredMetadata: [] },
     passive_passive: { unit: 'None', passive: true, requiredMetadata: [] },
 }

--- a/telemetry/vscode/test/resources/generatorOverrideOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOverrideOutput.ts
@@ -9,8 +9,10 @@ export interface MetricBase {
     readonly reason?: string
     /** Error message detail. May contain arbitrary message details (unlike the `reason` field), but should be truncated (recommendation: 200 chars). */
     readonly reasonDesc?: string
-    /** The duration of the operation in miliseconds */
+    /** The duration of the operation in milliseconds */
     readonly duration?: number
+    /** AWS Region associated with a metric */
+    readonly awsRegion?: string
     /** A flag indicating that the metric was not caused by the user. */
     readonly passive?: boolean
     /** @deprecated Arbitrary "value" of the metric. */
@@ -19,8 +21,36 @@ export interface MetricBase {
 
 export interface MetadataHasResult extends MetricBase {}
 
-export type Result = 'Succeeded'
-export type LambdaRuntime = 'dotnetcore2.1' | 'nodejs12.x'
+export type Result = 'Succeeded' | 'Failed' | 'Cancelled'
+export type Runtime =
+    | 'dotnetcore3.1'
+    | 'dotnetcore2.1'
+    | 'dotnet5.0'
+    | 'dotnet6'
+    | 'dotnet7'
+    | 'dotnet8'
+    | 'nodejs20.x'
+    | 'nodejs18.x'
+    | 'nodejs16.x'
+    | 'nodejs14.x'
+    | 'nodejs12.x'
+    | 'nodejs10.x'
+    | 'nodejs8.10'
+    | 'ruby2.5'
+    | 'java8'
+    | 'java8.al2'
+    | 'java11'
+    | 'java17'
+    | 'java21'
+    | 'go1.x'
+    | 'python3.12'
+    | 'python3.11'
+    | 'python3.10'
+    | 'python3.9'
+    | 'python3.8'
+    | 'python3.7'
+    | 'python3.6'
+    | 'python2.7'
 
 export interface MetricDefinition {
     readonly unit: string

--- a/telemetry/vscode/test/resources/testOverrideInput.json
+++ b/telemetry/vscode/test/resources/testOverrideInput.json
@@ -1,26 +1,5 @@
 {
-    "types": [
-        {
-            "name": "result",
-            "allowedValues": ["Succeeded"],
-            "description": "The result of the operation"
-        },
-        {
-            "name": "reason",
-            "type": "string",
-            "description": "Reason code or name for an event (when result=Succeeded) or error (when result=Failed). Unlike the `reasonDesc` field, this should be a stable/predictable name for a class of events or errors (typically the exception name, e.g. FileIOException)."
-        },
-        {
-            "name": "reasonDesc",
-            "type": "string",
-            "description": "Error message detail. May contain arbitrary message details (unlike the `reason` field), but should be truncated (recommendation: 200 chars)."
-        },
-        {
-            "name": "duration",
-            "type": "double",
-            "description": "The duration of the operation in miliseconds"
-        }
-    ],
+    "types": "will be replaced with `types` from commonDefinitions.json",
     "metrics": [
         {
             "name": "metadata_hasResult",


### PR DESCRIPTION
## Problem:
In the generated `telemetry.gen.ts` for vscode toolkit, `MetricBase` does not have various common fields. This adds friction when setting these fields.

## Solution:
- Update the generator to define `MetricBase.awsRegion`.
- Change the 'with normal input' test so that it uses the "types" defined in `commonDefinitions.json`. This increases test coverage while also reducing the boilerplate needed when adding a new field to `MetricBase`.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
