### PR TITLE
auth: Add reAuthReason field in aws_loginWithBrowser

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1286,6 +1286,11 @@
             "description": "Error message detail. May contain arbitrary message details (unlike the `reason` field), but should be truncated (recommendation: 200 chars)."
         },
         {
+            "name": "reAuthReason",
+            "type": "string",
+            "description": "Why was the connection/session put in to a state where it needs to be reauthenticated?"
+        },
+        {
             "name": "referencePolicyType",
             "type": "string",
             "allowedValues": [
@@ -2281,6 +2286,10 @@
                 },
                 {
                     "type": "isReAuth",
+                    "required": false
+                },
+                {
+                    "type": "reAuthReason",
                     "required": false
                 },
                 {


### PR DESCRIPTION
When the user logs in with the browser AND it is due to reauth, we want to know why they need to reauth. This will explain why.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
