### PR TITLE
telemetry(vscode): MetricBase common fields

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -130,7 +130,7 @@
         {
             "name": "awsAccount",
             "type": "string",
-            "description": "AWS account ID associated with a metric. \"n/a\" if credentials are not available. \"not-set\" if credentials are not selected. \"invalid\" if account ID cannot be obtained."
+            "description": "AWS account ID associated with a metric.\n- \"n/a\" if credentials are not available.\n- \"not-set\" if credentials are not selected.\n- \"invalid\" if account ID cannot be obtained."
         },
         {
             "name": "awsFiletype",
@@ -155,7 +155,7 @@
         {
             "name": "awsRegion",
             "type": "string",
-            "description": "AWS Region associated with a metric"
+            "description": "AWS Region associated with a metric\n- \"n/a\" if not associated with a region.\n- \"not-set\" if metric is associated with a region, but region is unknown."
         },
         {
             "name": "causedBy",
@@ -1133,7 +1133,7 @@
         {
             "name": "httpStatusCode",
             "type": "string",
-            "description": "Describes the HTTP status code for request made. The semantics are contextual based off of other fields (e.g. `requestId`)"
+            "description": "HTTP status code for the request (if any) associated with a metric."
         },
         {
             "name": "iamResourceType",
@@ -1303,7 +1303,7 @@
         {
             "name": "requestId",
             "type": "string",
-            "description": "A generic request ID field. The semantics are contextual based off of other fields (e.g. `requestServiceType`). For example, an event with `requestServiceType: s3` means that the request ID is associated with an S3 API call. Events that cover mutliple API calls should use the request ID of the most recent call."
+            "description": "Request ID (if any) associated with a metric. For example, an event with `requestServiceType: s3` means that the request ID is associated with an S3 API call. Events that cover multiple API calls should use the request ID of the most recent call."
         },
         {
             "name": "requestServiceType",

--- a/telemetry/telemetryformat.md
+++ b/telemetry/telemetryformat.md
@@ -48,24 +48,47 @@ These are then used to generate functions that take arguments pertaining to metr
 
 ### Global Arguments
 
-Global arguments that can be appended to any generated telemetry call.
+Global properties that can annotate any telemetry event.
 
-```
+```javascript
 // The time that the event took place
-createTime?: Date
-// Value based on unit and call type
-value?: number
+createTime: Date
+// AWS account ID associated with a metric.
+// - "n/a" if credentials are not available.
+// - "not-set" if credentials are not selected.
+// - "invalid" if account ID cannot be obtained.
+awsAccount: string
+// AWS Region associated with a metric.
+// - "n/a" if not associated with a region.
+// - "not-set" if metric is associated with a region, but region is unknown.
+awsRegion: string
+// The duration of the operation in milliseconds.
+duration: number
+// HTTP status code for the request (if any) associated with a metric.
+httpStatusCode: string
 // The language-related user preference information. Examples: en-US, en-GB, etc.
-string?: locale
-// The AWS account ID associated with a metric
-// If a metric is not associated with credentials: "n/a"
-// If a metric is associated with credentials, but credentials are not selected: "not-set"
-// If a metric is associated with credentials, but an account ID cannot be obtained: "invalid"
-string? awsAccount
-// The AWS Region associated with a metric
-// If a metric is not associated with a region: "n/a"
-// If a metric is associated with a region, but no region is known: "not-set"
-string? awsRegion
+locale: string
+// Reason code or name for an event (when result=Succeeded) or error (when result=Failed).
+// Unlike the `reasonDesc` field, this should be a stable/predictable name for
+// a class of events or errors (typically the exception name, e.g. FileIOException).
+reason: string
+// Error message detail. May contain arbitrary message details (unlike the
+// `reason` field), but should be truncated (recommendation: 200 chars).
+reasonDesc: string
+// Request ID (if any) associated with a metric.
+// For example, an event with `requestServiceType: s3` means that the request ID
+// is associated with an S3 API call. Events that cover mutliple API calls
+// should use the request ID of the most recent call.
+requestId: string
+// Per-request service identifier. Unlike `serviceType` (which describes the
+// originator of the request), this describes the request itself.
+requestServiceType: string
+// The result of the operation.
+result: Result
+// Indicates that the metric was not caused by an explicit user action.
+passive: boolean
+// Value based on unit and call type
+value: number
 ```
 
 If not specified `createTime` defaults to UTC now, `value` defaults to `1.0`.

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -121,7 +121,19 @@ function getTypeOrThrow(types: MetadataType[] = [], name: string) {
 }
 
 const baseName = 'MetricBase'
-const commonMetadata = ['result', 'reason', 'reasonDesc', 'duration', 'awsRegion']
+
+const commonMetadata = [
+  'awsAccount',
+  'awsRegion',
+  'duration',
+  'httpStatusCode',
+  'reason',
+  'reasonDesc',
+  'requestId',
+  'requestServiceType',
+  'result',
+]
+
 const passive: PropertySignatureStructure = {
     isReadonly: true,
     hasQuestionToken: true,

--- a/telemetry/vscode/src/parser.ts
+++ b/telemetry/vscode/src/parser.ts
@@ -49,12 +49,11 @@ export function validateInput(fileText: string, fileName: string): MetricDefinit
         const input = JSON.parse(fileText)
         const valid = jsonValidator(input)
         if (!valid) {
-            console.error('validating schema failed!')
             throw jsonValidator.errors
         }
         return input as MetricDefinitionRoot
     } catch (errors) {
-        console.error(`Error while trying to parse the definitions file ${fileName}: ${JSON.stringify(errors)}`)
-        throw new Error('Failed to parse')
+        const msg = `Failed to parse definitions file ${fileName}: ${JSON.stringify(errors)}`
+        throw new Error(msg)
     }
 }

--- a/telemetry/vscode/test/resources/generatorOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOutput.ts
@@ -3,16 +3,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 export interface MetricBase {
-    /** The result of the operation */
-    readonly result?: Result
+    /**
+     * AWS account ID associated with a metric.
+     * - "n/a" if credentials are not available.
+     * - "not-set" if credentials are not selected.
+     * - "invalid" if account ID cannot be obtained.
+     */
+    readonly awsAccount?: string
+    /**
+     * AWS Region associated with a metric
+     * - "n/a" if not associated with a region.
+     * - "not-set" if metric is associated with a region, but region is unknown.
+     */
+    readonly awsRegion?: string
+    /** The duration of the operation in milliseconds */
+    readonly duration?: number
+    /** HTTP status code for the request (if any) associated with a metric. */
+    readonly httpStatusCode?: string
     /** Reason code or name for an event (when result=Succeeded) or error (when result=Failed). Unlike the `reasonDesc` field, this should be a stable/predictable name for a class of events or errors (typically the exception name, e.g. FileIOException). */
     readonly reason?: string
     /** Error message detail. May contain arbitrary message details (unlike the `reason` field), but should be truncated (recommendation: 200 chars). */
     readonly reasonDesc?: string
-    /** The duration of the operation in milliseconds */
-    readonly duration?: number
-    /** AWS Region associated with a metric */
-    readonly awsRegion?: string
+    /** Request ID (if any) associated with a metric. For example, an event with `requestServiceType: s3` means that the request ID is associated with an S3 API call. Events that cover multiple API calls should use the request ID of the most recent call. */
+    readonly requestId?: string
+    /** Per-request service identifier. Unlike `serviceType` (which describes the originator of the request), this describes the request itself. */
+    readonly requestServiceType?: string
+    /** The result of the operation */
+    readonly result?: Result
     /** A flag indicating that the metric was not caused by the user. */
     readonly passive?: boolean
     /** @deprecated Arbitrary "value" of the metric. */

--- a/telemetry/vscode/test/resources/generatorOverrideOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOverrideOutput.ts
@@ -3,16 +3,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 export interface MetricBase {
-    /** The result of the operation */
-    readonly result?: Result
+    /**
+     * AWS account ID associated with a metric.
+     * - "n/a" if credentials are not available.
+     * - "not-set" if credentials are not selected.
+     * - "invalid" if account ID cannot be obtained.
+     */
+    readonly awsAccount?: string
+    /**
+     * AWS Region associated with a metric
+     * - "n/a" if not associated with a region.
+     * - "not-set" if metric is associated with a region, but region is unknown.
+     */
+    readonly awsRegion?: string
+    /** The duration of the operation in milliseconds */
+    readonly duration?: number
+    /** HTTP status code for the request (if any) associated with a metric. */
+    readonly httpStatusCode?: string
     /** Reason code or name for an event (when result=Succeeded) or error (when result=Failed). Unlike the `reasonDesc` field, this should be a stable/predictable name for a class of events or errors (typically the exception name, e.g. FileIOException). */
     readonly reason?: string
     /** Error message detail. May contain arbitrary message details (unlike the `reason` field), but should be truncated (recommendation: 200 chars). */
     readonly reasonDesc?: string
-    /** The duration of the operation in milliseconds */
-    readonly duration?: number
-    /** AWS Region associated with a metric */
-    readonly awsRegion?: string
+    /** Request ID (if any) associated with a metric. For example, an event with `requestServiceType: s3` means that the request ID is associated with an S3 API call. Events that cover multiple API calls should use the request ID of the most recent call. */
+    readonly requestId?: string
+    /** Per-request service identifier. Unlike `serviceType` (which describes the originator of the request), this describes the request itself. */
+    readonly requestServiceType?: string
+    /** The result of the operation */
+    readonly result?: Result
     /** A flag indicating that the metric was not caused by the user. */
     readonly passive?: boolean
     /** @deprecated Arbitrary "value" of the metric. */


### PR DESCRIPTION
## Problem

In the generated `telemetry.gen.ts` for vscode toolkit, `MetricBase` does not have various common fields. This adds friction when setting these fields.

## Solution
- Align commonMetadata with VS (see `BaseTelemetryEvent.cs`)
  - Except `causedBy` and `errorCode`, because their purpose is still TBD:
    - `errorCode` seems redundant with `reason`
    - `causedBy` is a high-level category which possibly could be decided by `hasFault` in vscode toolkit: https://github.com/aws/aws-toolkit-vscode/blob/6300d520ac347b7596d98c7cec312b67f98ee528/packages/core/src/shared/errors.ts#L519


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
