### PR TITLE
Add fields for codeTransform_jobStart metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -333,6 +333,11 @@
             ]
         },
         {
+            "name": "codeTransformPlanReceivedCount",
+            "type": "int",
+            "description": "The number of times the transformation plan was received during transformation"
+        },
+        {
             "name": "codeTransformPreValidationError",
             "type": "string",
             "description": "Names of the pre-validation errors that can occur",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3313,6 +3313,20 @@
             ]
         },
         {
+            "name": "codeTransform_jobIsStartedFromSolutionExplorer",
+            "description": "The user initiates a transform job from the Solution Explorer.",
+            "metadata": [
+                {
+                    "type": "codeTransformSessionId",
+                    "required": true
+                },
+                {
+                    "type": "credentialSourceId",
+                    "required": false
+                }
+            ]
+        },
+        {
             "name": "codeTransform_jobStartedCompleteFromPopupDialog",
             "passive": true,
             "description": "After modal validation of inputs, code execution will start and we will fire this event.",
@@ -3333,6 +3347,21 @@
                     "type": "codeTransformSessionId",
                     "required": true
                 }
+            ]
+        },
+        {
+            "name": "codeTransform_buildCompleted",
+            "passive": true,
+            "description": "During the transformation progress, log whether the build succeeded or failed.",
+            "metadata": [
+                {
+                    "type": "buildStatus",
+                    "required": true
+                },
+                {
+                    "type": "codeTransformSessionId",
+                    "required": true
+                },
             ]
         },
         {
@@ -3503,6 +3532,10 @@
                 },
                 {
                     "type": "codeTransformLocalMavenVersion",
+                    "required": false
+                },
+                {
+                    "type": "codeTransformPlanReceivedCount",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -389,11 +389,6 @@
             "description": "Represents the IDE session from which users start the transformation process"
         },
         {
-            "name": "codeTransformSolutionSelected",
-            "type": "boolean",
-            "description": "Indicates whether the solution is the selected transformation target (true if yes, false if no)"
-        },
-        {
             "name": "codeTransformStartSrcComponents",
             "type": "string",
             "description": "Names of components that can start a transformation",
@@ -3347,20 +3342,12 @@
                     "required": true
                 },
                 {
-                    "type": "codeTransformSolutionSelected",
-                    "required": true
-                },
-                {
                     "type": "codeTransformTarget",
                     "required": true
                 },
                 {
                     "type": "credentialSourceId",
                     "required": false
-                },
-                {
-                    "type": "source",
-                    "required": true
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3299,8 +3299,8 @@
             ]
         },
         {
-            "name": "codeTransform_jobIsStartedFromChatPrompt",
-            "description": "The user initiates a transform job from Amazon Q chat prompt.",
+            "name": "codeTransform_jobIsStarted",
+            "description": "The user initiates a transform job from the Amazon Q chat prompt or Solution Explorer.",
             "metadata": [
                 {
                     "type": "codeTransformSessionId",
@@ -3309,20 +3309,14 @@
                 {
                     "type": "credentialSourceId",
                     "required": false
-                }
-            ]
-        },
-        {
-            "name": "codeTransform_jobIsStartedFromSolutionExplorer",
-            "description": "The user initiates a transform job from the Solution Explorer.",
-            "metadata": [
+                },
                 {
-                    "type": "codeTransformSessionId",
+                    "type": "isStartedFrom",
                     "required": true
                 },
                 {
-                    "type": "credentialSourceId",
-                    "required": false
+                    "type": "source",
+                    "required": true
                 }
             ]
         },
@@ -3350,16 +3344,12 @@
             ]
         },
         {
-            "name": "codeTransform_buildCompleted",
+            "name": "codeTransform_build",
             "passive": true,
-            "description": "During the transformation progress, log whether the build succeeded or failed.",
+            "description": "During the transformation progress, log the status of the build.",
             "metadata": [
                 {
-                    "type": "buildStatus",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformSessionId",
+                    "type": "tool",
                     "required": true
                 },
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3311,10 +3311,6 @@
                     "required": false
                 },
                 {
-                    "type": "isStartedFrom",
-                    "required": true
-                },
-                {
                     "type": "source",
                     "required": true
                 }

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -319,6 +319,11 @@
             "description": "A general field for logging metadata associated to Amazon Q transform metrics."
         },
         {
+            "name": "codeTransformNumberOfProjects",
+            "type": "int",
+            "description": "The number of projects selected for transformation"
+        },
+        {
             "name": "codeTransformPatchViewerCancelSrcComponents",
             "type": "string",
             "description": "Names of components that can cancel the diff viewer",
@@ -379,6 +384,11 @@
             "description": "Represents the IDE session from which users start the transformation process"
         },
         {
+            "name": "codeTransformSolutionSelected",
+            "type": "boolean",
+            "description": "Indicates whether the solution is the selected transformation target (true if yes, false if no)"
+        },
+        {
             "name": "codeTransformStartSrcComponents",
             "type": "string",
             "description": "Names of components that can start a transformation",
@@ -392,6 +402,11 @@
             "name": "codeTransformStatus",
             "type": "string",
             "description": "The current transformation job's status"
+        },
+        {
+            "name": "codeTransformTarget",
+            "type": "string",
+            "description": "The target solution or project(s) selected for transformation"
         },
         {
             "name": "codeTransformTotalByteSize",
@@ -3308,7 +3323,19 @@
             "description": "The user initiates a transform job from the Amazon Q chat prompt or Solution Explorer.",
             "metadata": [
                 {
+                    "type": "codeTransformNumberOfProjects",
+                    "required": true
+                },
+                {
                     "type": "codeTransformSessionId",
+                    "required": true
+                },
+                {
+                    "type": "codeTransformSolutionSelected",
+                    "required": true
+                },
+                {
+                    "type": "codeTransformTarget",
                     "required": true
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -158,6 +158,11 @@
             "description": "AWS Region associated with a metric\n- \"n/a\" if not associated with a region.\n- \"not-set\" if metric is associated with a region, but region is unknown."
         },
         {
+            "name": "buildDuration",
+            "type": "int",
+            "description": "The amount of time required for the build to complete (in seconds)."
+        },
+        {
             "name": "causedBy",
             "allowedValues": [
                 "user",
@@ -3299,7 +3304,7 @@
             ]
         },
         {
-            "name": "codeTransform_jobIsStarted",
+            "name": "codeTransform_jobStart",
             "description": "The user initiates a transform job from the Amazon Q chat prompt or Solution Explorer.",
             "metadata": [
                 {
@@ -3340,14 +3345,14 @@
             ]
         },
         {
-            "name": "codeTransform_build",
+            "name": "codeTransform_buildComplete",
             "passive": true,
             "description": "During the transformation progress, log the status of the build.",
             "metadata": [
                 {
-                    "type": "tool",
+                    "type": "buildDuration",
                     "required": true
-                },
+                }
             ]
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3159,6 +3159,17 @@
             "passive": true
         },
         {
+            "name": "codeTransform_buildComplete",
+            "passive": true,
+            "description": "During the transformation progress, log the status of the build.",
+            "metadata": [
+                {
+                    "type": "buildDuration",
+                    "required": true
+                }
+            ]
+        },
+        {
             "name": "codeTransform_dependenciesCopied",
             "description": "The repo copies over at least one dependency successfully.",
             "metadata": [
@@ -3367,17 +3378,6 @@
                 },
                 {
                     "type": "codeTransformSessionId",
-                    "required": true
-                }
-            ]
-        },
-        {
-            "name": "codeTransform_buildComplete",
-            "passive": true,
-            "description": "During the transformation progress, log the status of the build.",
-            "metadata": [
-                {
-                    "type": "buildDuration",
                     "required": true
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3335,7 +3335,7 @@
             "metadata": [
                 {
                     "type": "codeTransformNumberOfProjects",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "codeTransformSessionId",
@@ -3343,7 +3343,7 @@
                 },
                 {
                     "type": "codeTransformTarget",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "credentialSourceId",


### PR DESCRIPTION
Add metric types for Code Transform to be fired when a transformation is started from the Solution Explorer and when a build is completed. Modified existing metric (`codeTransform_jobIsStartedFromChatPrompt` -> `codeTransform_jobStart`) to also record the number of times a transformation plan was received during the transformation process.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
