### PR TITLE
telemetry(JB): Adding reasonDesc to codewhisperer_securityScan event

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3913,6 +3913,10 @@
                     "required": false
                 },
                 {
+                    "type": "reasonDesc",
+                    "required": false
+                },
+                {
                     "type": "result"
                 }
             ]


### PR DESCRIPTION
## Problem
`reasonDesc` parameter is not added to `codewhisperer_securityScan` event.
## Solution
Added `reasonDesc` to `codewhisperer_securityScan` event.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
