### PR TITLE
Define toolkit_initModule metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1433,6 +1433,11 @@
             "description": "The type of an SQS Queue"
         },
         {
+            "name": "startUpComponent",
+            "type": "string",
+            "description": "The Toolkit component being initialized."
+        },
+        {
             "name": "successCount",
             "type": "int",
             "description": "The number of successful operations"
@@ -5977,6 +5982,36 @@
                 }
             ],
             "passive": true
+        },
+        {
+            "name": "toolkit_componentInit",
+            "description": "The Toolkit has completed initialization for the specified component.",
+            "metadata": [
+                {
+                    "type": "attempts",
+                    "required": false
+                },
+                { 
+                    "type": "duration",
+                    "required": false
+                },
+                { 
+                    "type": "errorCode",
+                    "required": false
+                },
+                { 
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "result",
+                    "required": true
+                },
+                {
+                    "type": "startUpComponent",
+                    "required": true
+                }
+            ]
         },
         {
             "name": "toolkit_init",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1261,6 +1261,11 @@
             "description": "User locale. Examples: en-US, en-GB, etc."
         },
         {
+            "name": "module",
+            "type": "string",
+            "description": "A generic module metadata"
+        },
+        {
             "name": "name",
             "type": "string",
             "description": "A generic name metadata"
@@ -1431,11 +1436,6 @@
                 "fifo"
             ],
             "description": "The type of an SQS Queue"
-        },
-        {
-            "name": "startUpComponent",
-            "type": "string",
-            "description": "The Toolkit component being initialized."
         },
         {
             "name": "successCount",
@@ -5965,28 +5965,6 @@
             ]
         },
         {
-            "name": "toolkit_componentInit",
-            "description": "The Toolkit has completed initialization for the specified component.",
-            "metadata": [
-                {
-                    "type": "attempts",
-                    "required": false
-                },
-                { 
-                    "type": "duration",
-                    "required": false
-                },
-                {
-                    "type": "result",
-                    "required": true
-                },
-                {
-                    "type": "startUpComponent",
-                    "required": true
-                }
-            ]
-        },
-        {
             "name": "toolkit_getExternalResource",
             "description": "The toolkit tried to retrieve blob data from a url",
             "metadata": [
@@ -6019,6 +5997,28 @@
                 }
             ],
             "passive": true
+        },
+        {
+            "name": "toolkit_initModule",
+            "description": "The Toolkit has completed initialization for the specified module.",
+            "metadata": [
+                {
+                    "type": "attempts",
+                    "required": false
+                },
+                { 
+                    "type": "duration",
+                    "required": false
+                },
+                {
+                    "type": "result",
+                    "required": true
+                },
+                {
+                    "type": "module",
+                    "required": true
+                }
+            ]
         },
         {
             "name": "toolkit_invokeAction",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -5976,14 +5976,6 @@
                     "type": "duration",
                     "required": false
                 },
-                { 
-                    "type": "errorCode",
-                    "required": false
-                },
-                { 
-                    "type": "reason",
-                    "required": false
-                },
                 {
                     "type": "result",
                     "required": true

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -5965,25 +5965,6 @@
             ]
         },
         {
-            "name": "toolkit_getExternalResource",
-            "description": "The toolkit tried to retrieve blob data from a url",
-            "metadata": [
-                {
-                    "type": "reason",
-                    "required": false
-                },
-                {
-                    "type": "result",
-                    "required": true
-                },
-                {
-                    "type": "url",
-                    "required": true
-                }
-            ],
-            "passive": true
-        },
-        {
             "name": "toolkit_componentInit",
             "description": "The Toolkit has completed initialization for the specified component.",
             "metadata": [
@@ -6012,6 +5993,25 @@
                     "required": true
                 }
             ]
+        },
+        {
+            "name": "toolkit_getExternalResource",
+            "description": "The toolkit tried to retrieve blob data from a url",
+            "metadata": [
+                {
+                    "type": "reason",
+                    "required": false
+                },
+                {
+                    "type": "result",
+                    "required": true
+                },
+                {
+                    "type": "url",
+                    "required": true
+                }
+            ],
+            "passive": true
         },
         {
             "name": "toolkit_init",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -6011,11 +6011,11 @@
                     "required": false
                 },
                 {
-                    "type": "result",
+                    "type": "module",
                     "required": true
                 },
                 {
-                    "type": "module",
+                    "type": "result",
                     "required": true
                 }
             ]


### PR DESCRIPTION
Define toolkit_initModule metric. This metric will help us identify issues that arise during each step of the toolkit initialization process.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
