### PR TITLE
Set toolkit_initModule to passive

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1263,7 +1263,7 @@
         {
             "name": "module",
             "type": "string",
-            "description": "A generic module metadata"
+            "description": "Free-form module name for both high-level features such as \"PublishToAWS\", and lower-level modules such as \"ToolkitContextProvider\". Use \"component\" for UI components, or \"featureId\" for specific feature names."
         },
         {
             "name": "name",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -6018,7 +6018,8 @@
                     "type": "result",
                     "required": true
                 }
-            ]
+            ],
+            "passive": true
         },
         {
             "name": "toolkit_invokeAction",


### PR DESCRIPTION
## Overview 

- new metric added in https://github.com/aws/aws-toolkit-common/pull/778 needs to be passive.

- updates the description field for the "module" metadata to include example usages.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
