### PR TITLE
Apply CultureInvariant string conversion to more numeric metadata types

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/AwsToolkit.Telemetry.Events.Tests.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/AwsToolkit.Telemetry.Events.Tests.csproj
@@ -11,6 +11,7 @@
 		<Reference Include="System.Core" />
 	</ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Core/MetricDatumExtensionMethodsTests.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Tests/Core/MetricDatumExtensionMethodsTests.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using Amazon.AwsToolkit.Telemetry.Events.Core;
+﻿using Amazon.AwsToolkit.Telemetry.Events.Core;
+using FluentAssertions;
+using System;
 using Xunit;
 
 namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Core
@@ -13,45 +14,45 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Core
         public void AddMetadata_NonBlankEntries()
         {
             _sut.AddMetadata(Key, "hello");
-            Assert.Equal("hello", _sut.Metadata[Key]);
+            _sut.Metadata[Key].Should().Be("hello");
 
             _sut.AddMetadata(Key, 123);
-            Assert.Equal("123", _sut.Metadata[Key]);
+            _sut.Metadata[Key].Should().Be("123");
 
             _sut.AddMetadata(Key, 123.456);
-            Assert.Equal("123.456", _sut.Metadata[Key]);
+            _sut.Metadata[Key].Should().Be("123.456");
 
             _sut.AddMetadata(Key, 88.88d);
-            Assert.Equal("88.88", _sut.Metadata[Key]);
+            _sut.Metadata[Key].Should().Be("88.88");
 
             _sut.AddMetadata(Key, true);
-            Assert.Equal("true", _sut.Metadata[Key]);
+            _sut.Metadata[Key].Should().Be("true");
 
             _sut.AddMetadata(Key, false);
-            Assert.Equal("false", _sut.Metadata[Key]);
+            _sut.Metadata[Key].Should().Be("false");
         }
 
         [Fact]
         public void AddMetadata_BlankEntries()
         {
             _sut.AddMetadata(Key, (object) null);
-            Assert.False(_sut.Metadata.ContainsKey(Key));
+            _sut.Metadata.Should().NotContainKey(Key);
 
             _sut.AddMetadata(Key, (string) null);
-            Assert.False(_sut.Metadata.ContainsKey(Key));
+            _sut.Metadata.Should().NotContainKey(Key);
 
             _sut.AddMetadata(Key, string.Empty);
-            Assert.False(_sut.Metadata.ContainsKey(Key));
+            _sut.Metadata.Should().NotContainKey(Key);
 
             _sut.AddMetadata(Key, "   ");
-            Assert.False(_sut.Metadata.ContainsKey(Key));
+            _sut.Metadata.Should().NotContainKey(Key);
         }
 
         [Fact]
         public void InvokeTransform_Null()
         {
             var updatedDatum = _sut.InvokeTransform(null);
-            Assert.Equal(_sut, updatedDatum);
+            _sut.Should().BeSameAs(updatedDatum);
         }
 
         [Fact]
@@ -63,7 +64,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Core
             }
 
             var updatedDatum = _sut.InvokeTransform(TransformFunction);
-            Assert.NotNull(updatedDatum);
+            updatedDatum.Should().NotBeNull();
         }
 
         [Fact]
@@ -76,7 +77,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Tests.Core
             }
 
             var updatedDatum = _sut.InvokeTransform(TransformFunction);
-            Assert.Equal("hello", updatedDatum.Metadata[Key]);
+            updatedDatum.Metadata[Key].Should().Be("hello");
         }
     }
 }

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/MetricDatumExtensionMethods.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/MetricDatumExtensionMethods.cs
@@ -22,7 +22,15 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
         }
 
         /// <summary>
-        /// Add metadata to a metric datum, only if the value is non-blank (object overload)
+        /// Add metadata to a metric datum, only if the value is non-blank (object overload).
+        /// 
+        /// The main use-case for this method is the auto-generated code which provides 
+        /// strongly typed telemetry events emission.
+        /// 
+        /// If you are explicitly calling this method and you have objects that could be any type, 
+        /// you should use the overload which accepts 'detectPrimitiveType'. An example of this
+        /// would be to deserialize some JSON content, which contains properties that could be 
+        /// a variety of types, but are handled as type object.
         /// </summary>
         public static void AddMetadata(this MetricDatum metricDatum, string key, object value)
         {
@@ -32,6 +40,49 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
             }
 
             metricDatum.AddMetadata(key, value.ToString());
+        }
+
+        /// <summary>
+        /// Add metadata to a metric datum, only if the value is non-blank (object overload)
+        /// When requested, this overload will route primitive values like numerics to their specific handling, instead of 
+        /// using the default object ToString call. This avoids performing locale specific convertsions.
+        /// </summary>
+        public static void AddMetadata(this MetricDatum metricDatum, string key, object value, bool detectPrimitiveType)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            if (!detectPrimitiveType)
+            {
+                metricDatum.AddMetadata(key, value.ToString());
+            }
+
+            switch (value)
+            {
+                case bool boolValue:
+                    metricDatum.AddMetadata(key, boolValue);
+                    break;
+                case int intValue:
+                    metricDatum.AddMetadata(key, intValue);
+                    break;
+                case double doubleValue:
+                    metricDatum.AddMetadata(key, doubleValue);
+                    break;
+                case long longValue:
+                    metricDatum.AddMetadata(key, longValue);
+                    break;
+                case float floatValue:
+                    metricDatum.AddMetadata(key, floatValue);
+                    break;
+                case decimal decimalValue:
+                    metricDatum.AddMetadata(key, decimalValue);
+                    break;
+                default:
+                    metricDatum.AddMetadata(key, value.ToString());
+                    break;
+            }
         }
 
         /// <summary>
@@ -60,6 +111,30 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
         /// Add metadata to a metric datum, only if the value is non-blank (int overload)
         /// </summary>
         public static void AddMetadata(this MetricDatum metricDatum, string key, int value)
+        {
+            metricDatum.AddMetadata(key, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Add metadata to a metric datum, only if the value is non-blank (long overload)
+        /// </summary>
+        public static void AddMetadata(this MetricDatum metricDatum, string key, long value)
+        {
+            metricDatum.AddMetadata(key, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Add metadata to a metric datum, only if the value is non-blank (float overload)
+        /// </summary>
+        public static void AddMetadata(this MetricDatum metricDatum, string key, float value)
+        {
+            metricDatum.AddMetadata(key, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Add metadata to a metric datum, only if the value is non-blank (decimal overload)
+        /// </summary>
+        public static void AddMetadata(this MetricDatum metricDatum, string key, decimal value)
         {
             metricDatum.AddMetadata(key, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
         }


### PR DESCRIPTION
## Problem

Most metadata is emitted using code that is auto-generated. There are times where we want to emit metadata from a generic source (like a deserialized JSON payload). These fields are treated as generic objects, which means numeric values get converted to strings using the user's locale settings. We have overloaded methods for certain types, which handle culture invariant conversion, but these fields are routed to the `object` overload. We want these to be culture invariant.

## Solution

Add an overload that can be explicitly used, which routes the metadata to their type-specific handler.

This change also converts the one test class assertions to use FluentAssertions.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
