### PR TITLE
telemetry(amazonq): add/change metrics for gradle support

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3167,19 +3167,27 @@
             "passive": true
         },
         {
-            "name": "codeTransform_buildComplete",
+            "name": "codeTransform_buildResult",
             "passive": true,
-            "description": "During the transformation progress, log the status of the build.",
+            "description": "The result of the local build.",
             "metadata": [
                 {
-                    "type": "buildDuration",
+                    "type": "codeTransformBuildCommand",
                     "required": true
+                },
+                {
+                    "type": "buildDuration",
+                    "required": false
+                },
+                {
+                    "type": "codeTransformSessionId",
+                    "required": false
                 }
             ]
         },
         {
             "name": "codeTransform_dependenciesCopied",
-            "description": "The repo copies over at least one dependency successfully.",
+            "description": "At least one dependency is copied over successfully.",
             "metadata": [
                 {
                     "type": "codeTransformSessionId",
@@ -3464,24 +3472,6 @@
                 {
                     "type": "codeTransformSessionId",
                     "required": true
-                }
-            ]
-        },
-        {
-            "name": "codeTransform_buildFailed",
-            "description": "The local build failed.",
-            "metadata": [
-                {
-                    "type": "codeTransformBuildCommand",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformSessionId",
-                    "required": true
-                },
-                {
-                    "type": "reason",
-                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -244,9 +244,9 @@
             "description": "Any API-specific errors"
         },
         {
-            "name": "codeTransformApiNames",
+            "name": "codeTransformApiName",
             "type": "string",
-            "description": "Names of allowed API calls",
+            "description": "Name of the API",
             "allowedValues": [
                 "ResumeTransformation",
                 "StartTransformation",
@@ -430,16 +430,6 @@
             "name": "codeTransformUploadId",
             "type": "string",
             "description": "A unique upload ID for S3"
-        },
-        {
-            "name": "codeTransformVCSViewerSrcComponents",
-            "type": "string",
-            "description": "Names of components that can initiate the diff viewer",
-            "allowedValues": [
-                "toastNotification",
-                "treeView",
-                "treeViewHeader"
-            ]
         },
         {
             "name": "codewhispererAcceptedTokens",
@@ -3420,17 +3410,17 @@
             ]
         },
         {
-            "name": "codeTransform_logApiError",
+            "name": "codeTransform_logApiResult",
             "passive": true,
-            "description": "A general logging measure for all client side API errors.",
+            "description": "A general logging measure for all client side API results.",
             "metadata": [
                 {
-                    "type": "codeTransformApiErrorMessage",
+                    "type": "codeTransformApiName",
                     "required": true
                 },
                 {
-                    "type": "codeTransformApiNames",
-                    "required": true
+                    "type": "codeTransformApiErrorMessage",
+                    "required": false
                 },
                 {
                     "type": "codeTransformJobId",
@@ -3442,41 +3432,14 @@
                 },
                 {
                     "type": "codeTransformSessionId",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "codeTransformTotalByteSize",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "codeTransform_logApiLatency",
-            "passive": true,
-            "description": "A general logging measure for all client side API's latency.",
-            "metadata": [
-                {
-                    "type": "codeTransformApiNames",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformJobId",
-                    "required": false
-                },
-                {
-                    "type": "codeTransformRequestId",
                     "required": false
                 },
                 {
                     "type": "codeTransformRunTimeLatency",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformSessionId",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformTotalByteSize",
                     "required": false
                 },
                 {
@@ -3599,32 +3562,6 @@
             ]
         },
         {
-            "name": "codeTransform_vcsViewerCanceled",
-            "description": "An interactivity measured when users cancel a patch view.",
-            "metadata": [
-                {
-                    "type": "codeTransformJobId",
-                    "required": false
-                },
-                {
-                    "type": "codeTransformPatchViewerCancelSrcComponents",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformRuntimeError",
-                    "required": false
-                },
-                {
-                    "type": "codeTransformSessionId",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformStatus",
-                    "required": true
-                }
-            ]
-        },
-        {
             "name": "codeTransform_vcsViewerClicked",
             "description": "An interactivity measured when users click to view diff results.",
             "metadata": [
@@ -3637,26 +3574,8 @@
                     "required": true
                 },
                 {
-                    "type": "codeTransformVCSViewerSrcComponents",
-                    "required": true
-                }
-            ]
-        },
-        {
-            "name": "codeTransform_vcsViewerSubmitted",
-            "description": "An interactivity measured when users submit their patch view results.",
-            "metadata": [
-                {
-                    "type": "codeTransformJobId",
+                    "type": "codeTransformMetadata",
                     "required": false
-                },
-                {
-                    "type": "codeTransformSessionId",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformStatus",
-                    "required": true
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -259,6 +259,30 @@
             ]
         },
         {
+            "name": "codeTransformBuildCommand",
+            "type": "string",
+            "description": "Type of build command",
+            "allowedValues": [
+                "mvnw.cmd",
+                "mvnw",
+                "mvn",
+                "IDEBundledMaven",
+                "gradlew.bat",
+                "gradlew",
+                "gradle",
+                "IDEBundledGradle"
+            ]
+        },
+        {
+            "name": "codeTransformBuildSystem",
+            "type": "string",
+            "description": "Type of build system",
+            "allowedValues": [
+                "Maven",
+                "Gradle"
+            ]
+        },
+        {
             "name": "codeTransformCancelSrcComponents",
             "type": "string",
             "description": "Names of components that can cancel a transformation",
@@ -303,38 +327,9 @@
             "description": "The build system version on the user's machine"
         },
         {
-            "name": "codeTransformBuildCommand",
-            "type": "string",
-            "description": "Type of build command",
-            "allowedValues": [
-                "mvnw.cmd",
-                "mvnw",
-                "mvn",
-                "IDEBundledMaven",
-                "gradlew.bat",
-                "gradlew",
-                "gradle",
-                "IDEBundledGradle"
-            ]
-        },
-        {
-            "name": "codeTransformBuildSystem",
-            "type": "string",
-            "description": "Type of build system",
-            "allowedValues": [
-                "Maven",
-                "Gradle"
-            ]
-        },
-        {
             "name": "codeTransformMetadata",
             "type": "string",
             "description": "A general field for logging metadata associated to Amazon Q transform metrics."
-        },
-        {
-            "name": "codeTransformNumberOfProjects",
-            "type": "int",
-            "description": "The number of projects selected for transformation"
         },
         {
             "name": "codeTransformPatchViewerCancelSrcComponents",
@@ -344,11 +339,6 @@
                 "apiError",
                 "cancelButton"
             ]
-        },
-        {
-            "name": "codeTransformPlanReceivedCount",
-            "type": "int",
-            "description": "The number of times the transformation plan was received during transformation"
         },
         {
             "name": "codeTransformPreValidationError",
@@ -415,11 +405,6 @@
             "name": "codeTransformStatus",
             "type": "string",
             "description": "The current transformation job's status"
-        },
-        {
-            "name": "codeTransformTarget",
-            "type": "string",
-            "description": "The target solution or project(s) selected for transformation"
         },
         {
             "name": "codeTransformTotalByteSize",
@@ -3346,28 +3331,6 @@
             ]
         },
         {
-            "name": "codeTransform_jobStart",
-            "description": "The user initiates a transform job from the Amazon Q chat prompt or Solution Explorer.",
-            "metadata": [
-                {
-                    "type": "codeTransformNumberOfProjects",
-                    "required": false
-                },
-                {
-                    "type": "codeTransformSessionId",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformTarget",
-                    "required": false
-                },
-                {
-                    "type": "credentialSourceId",
-                    "required": false
-                }
-            ]
-        },
-        {
             "name": "codeTransform_jobStartedCompleteFromPopupDialog",
             "passive": true,
             "description": "After modal validation of inputs, code execution will start and we will fire this event.",
@@ -3517,10 +3480,6 @@
                 },
                 {
                     "type": "codeTransformLocalMavenVersion",
-                    "required": false
-                },
-                {
-                    "type": "codeTransformPlanReceivedCount",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -317,14 +317,14 @@
             "description": "The ID of the job currently running"
         },
         {
-            "name": "codeTransformLocalJavaVersion",
-            "type": "string",
-            "description": "The Java version on the user's machine"
-        },
-        {
             "name": "codeTransformLocalBuildSystemVersion",
             "type": "string",
             "description": "The build system version on the user's machine"
+        },
+        {
+            "name": "codeTransformLocalJavaVersion",
+            "type": "string",
+            "description": "The Java version on the user's machine"
         },
         {
             "name": "codeTransformMetadata",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3475,11 +3475,11 @@
                     "required": false
                 },
                 {
-                    "type": "codeTransformLocalJavaVersion",
+                    "type": "codeTransformLocalBuildSystemVersion",
                     "required": false
                 },
                 {
-                    "type": "codeTransformLocalBuildSystemVersion",
+                    "type": "codeTransformLocalJavaVersion",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3479,7 +3479,7 @@
                     "required": false
                 },
                 {
-                    "type": "codeTransformLocalMavenVersion",
+                    "type": "codeTransformLocalBuildSystemVersion",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3172,12 +3172,12 @@
             "description": "The result of the local build.",
             "metadata": [
                 {
-                    "type": "codeTransformBuildCommand",
-                    "required": true
-                },
-                {
                     "type": "buildDuration",
                     "required": false
+                },
+                {
+                    "type": "codeTransformBuildCommand",
+                    "required": true
                 },
                 {
                     "type": "codeTransformSessionId",
@@ -3373,16 +3373,16 @@
             "description": "After modal validation of inputs, code execution will start and we will fire this event.",
             "metadata": [
                 {
+                    "type": "codeTransformBuildSystem",
+                    "required": false
+                },
+                {
                     "type": "codeTransformJavaSourceVersionsAllowed",
                     "required": true
                 },
                 {
                     "type": "codeTransformJavaTargetVersionsAllowed",
                     "required": true
-                },
-                {
-                    "type": "codeTransformBuildSystem",
-                    "required": false
                 },
                 {
                     "type": "codeTransformProjectId",
@@ -3423,12 +3423,12 @@
             "description": "A general logging measure for all client side API results.",
             "metadata": [
                 {
-                    "type": "codeTransformApiName",
-                    "required": true
-                },
-                {
                     "type": "codeTransformApiErrorMessage",
                     "required": false
+                },
+                {
+                    "type": "codeTransformApiName",
+                    "required": true
                 },
                 {
                     "type": "codeTransformJobId",
@@ -3439,15 +3439,15 @@
                     "required": false
                 },
                 {
+                    "type": "codeTransformRunTimeLatency",
+                    "required": false
+                },
+                {
                     "type": "codeTransformSessionId",
                     "required": false
                 },
                 {
                     "type": "codeTransformTotalByteSize",
-                    "required": false
-                },
-                {
-                    "type": "codeTransformRunTimeLatency",
                     "required": false
                 },
                 {
@@ -3562,10 +3562,6 @@
                 {
                     "type": "codeTransformSessionId",
                     "required": true
-                },
-                {
-                    "type": "codeTransformMetadata",
-                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -298,19 +298,32 @@
             "description": "The Java version on the user's machine"
         },
         {
-            "name": "codeTransformLocalMavenVersion",
+            "name": "codeTransformLocalBuildSystemVersion",
             "type": "string",
-            "description": "The Maven version on the user's machine"
+            "description": "The build system version on the user's machine"
         },
         {
-            "name": "codeTransformMavenBuildCommand",
+            "name": "codeTransformBuildCommand",
             "type": "string",
-            "description": "Type of maven command",
+            "description": "Type of build command",
             "allowedValues": [
                 "mvnw.cmd",
                 "mvnw",
                 "mvn",
-                "IDEBundledMaven"
+                "IDEBundledMaven",
+                "gradlew.bat",
+                "gradlew",
+                "gradle",
+                "IDEBundledGradle"
+            ]
+        },
+        {
+            "name": "codeTransformBuildSystem",
+            "type": "string",
+            "description": "Type of build system",
+            "allowedValues": [
+                "Maven",
+                "Gradle"
             ]
         },
         {
@@ -3370,6 +3383,10 @@
                     "required": true
                 },
                 {
+                    "type": "codeTransformBuildSystem",
+                    "required": false
+                },
+                {
                     "type": "codeTransformProjectId",
                     "required": true
                 },
@@ -3488,11 +3505,11 @@
             ]
         },
         {
-            "name": "codeTransform_mvnBuildFailed",
-            "description": "The maven command build failed.",
+            "name": "codeTransform_buildFailed",
+            "description": "The local build failed.",
             "metadata": [
                 {
-                    "type": "codeTransformMavenBuildCommand",
+                    "type": "codeTransformBuildCommand",
                     "required": true
                 },
                 {


### PR DESCRIPTION
## Problem

We're adding Gradle support for /transform and need to make some telemetry changes to reflect this.

## Solution

Make said changes. Also, simplify our telemetry by combining duplicate metrics and removing unneeded ones.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
