### PR TITLE
telemetry: add Q dev bundle file metric definition

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -835,6 +835,11 @@
             "description": "Time taken for context truncation in milliseconds"
         },
         {
+            "name": "count",
+            "type": "int",
+            "description": "Number of occurrences a metric, or some other metric-defined count."
+        },
+        {
             "name": "credentialModification",
             "type": "string",
             "allowedValues": [
@@ -1630,6 +1635,18 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_bundleExtensionIgnored",
+            "description": "File extension was ignored 'count' many times during bundling process",
+            "metadata": [
+                {
+                    "type": "count"
+                },
+                {
+                    "type": "filenameExt"
                 }
             ]
         },
@@ -6006,7 +6023,7 @@
                     "type": "attempts",
                     "required": false
                 },
-                { 
+                {
                     "type": "duration",
                     "required": false
                 },


### PR DESCRIPTION
## Problem

We (feature dev team) want to understand if there are any other relevant code file extension that should be added to the allowlist.

## Solution

To obtain such information, we want to emit telemetry event to see the most common file extensions being ignored while bundling.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
