### PR TITLE
telemetry: revert removal of codeTransform_jobIsStartedFromChatPrompt

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3601,6 +3601,20 @@
             ]
         },
         {
+            "name": "codeTransform_jobIsStartedFromChatPrompt",
+            "description": "The user initiates a transform job from the Amazon Q chat prompt.",
+            "metadata": [
+                {
+                    "type": "codeTransformSessionId",
+                    "required": true
+                },
+                {
+                    "type": "credentialSourceId",
+                    "required": false
+                }
+            ]
+        },
+        {
             "name": "codeTransform_jobStart",
             "description": "Transform job started for uploaded project.",
             "metadata": [
@@ -3615,20 +3629,6 @@
                 {
                     "type": "codeTransformTarget",
                     "required": false
-                },
-                {
-                    "type": "credentialSourceId",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "codeTransform_jobIsStartedFromChatPrompt",
-            "description": "The user initiates a transform job from the Amazon Q chat prompt.",
-            "metadata": [
-                {
-                    "type": "codeTransformSessionId",
-                    "required": true
                 },
                 {
                     "type": "credentialSourceId",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3602,7 +3602,7 @@
         },
         {
             "name": "codeTransform_jobStart",
-            "description": "The user initiates a transform job from the Amazon Q chat prompt or Solution Explorer.",
+            "description": "Transform job started for uploaded project.",
             "metadata": [
                 {
                     "type": "codeTransformNumberOfProjects",
@@ -3615,6 +3615,20 @@
                 {
                     "type": "codeTransformTarget",
                     "required": false
+                },
+                {
+                    "type": "credentialSourceId",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "codeTransform_jobIsStartedFromChatPrompt",
+            "description": "The user initiates a transform job from the Amazon Q chat prompt.",
+            "metadata": [
+                {
+                    "type": "codeTransformSessionId",
+                    "required": true
                 },
                 {
                     "type": "credentialSourceId",


### PR DESCRIPTION
## Problem

Metric `codeTransform_jobIsStartedFromChatPrompt` was removed while it was still in used by IntelliJ and VSCode toolkits. Adding it back to maintain backward compatibility. 

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
