### PR TITLE
telemetry: add version metadata to toolkit_initModule

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -6351,6 +6351,10 @@
                 {
                     "type": "result",
                     "required": true
+                },
+                {
+                    "type": "version",
+                    "required": false
                 }
             ],
             "passive": true


### PR DESCRIPTION
Define version metadata on toolkit_initModule metric. This metadata will help us determine the corresponding version number of a user in each of the modules (ex: WebView2 version number in RuntimeInstaller module).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
