### PR TITLE
Add new code transform metric fields and metric type for ApplyChanges

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -372,6 +372,11 @@
             "description": "The number of projects selected for transformation"
         },
         {
+            "name": "codeTransformNumberOfTransformedFiles",
+            "type": "int",
+            "description": "The number of files that were transformed during a transformation job"
+        },
+        {
             "name": "codeTransformNumberOfTransformedFilesAccepted",
             "type": "int",
             "description": "The number of transformed files that have been accepted by the user"
@@ -3633,6 +3638,10 @@
                 {
                     "type": "codeTransformJobId",
                     "required": true
+                },
+                {
+                    "type": "codeTransformNumberOfTransformedFiles",
+                    "required": false
                 },
                 {
                     "type": "codeTransformRuntimeError",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -249,9 +249,9 @@
             "description": "Time taken to invoke code scan service APIs in milliseconds"
         },
         {
-            "name": "codeTransformApiErrorMessage",
+            "name": "codeTransformErrorMessage",
             "type": "string",
-            "description": "Any API-specific errors"
+            "description": "The error message (can be local or API-side)"
         },
         {
             "name": "codeTransformApiNames",
@@ -367,9 +367,19 @@
             "description": "A general field for logging metadata associated to Amazon Q transform metrics."
         },
         {
-            "name": "codeTransformNumberOfProjects",
+            "name": "codeTransformNumberOfSelectedFiles",
+            "type": "int",
+            "description": "The number of files selected to apply changes to"
+        },
+        {
+            "name": "codeTransformNumberOfSelectedProjects",
             "type": "int",
             "description": "The number of projects selected for transformation"
+        },
+        {
+            "name": "codeTransformNumberOfSelectedUnits",
+            "type": "int",
+            "description": "The number of buildable units selected to apply changes to"
         },
         {
             "name": "codeTransformPatchViewerCancelSrcComponents",
@@ -3474,6 +3484,24 @@
             "passive": true
         },
         {
+            "name": "codeTransform_applyChanges",
+            "description": "Apply suggested changes to buildable units.",
+            "metadata": [
+                {
+                    "type": "codeTransformSessionId",
+                    "required": true
+                },
+                {
+                    "type": "codeTransformNumberOfSelectedUnits",
+                    "required": false
+                },
+                {
+                    "type": "codeTransformNumberOfSelectedFiles",
+                    "required": true
+                }
+            ]
+        },
+        {
             "name": "codeTransform_dependenciesCopied",
             "description": "Deprecated - use codeTransform_uploadProject (The repo copies over at least one dependency successfully)",
             "metadata": [
@@ -3716,7 +3744,7 @@
                     "required": false
                 },
                 {
-                    "type": "codeTransformNumberOfProjects",
+                    "type": "codeTransformNumberOfSelectedProjects",
                     "required": false
                 },
                 {
@@ -3741,6 +3769,10 @@
                 },
                 {
                     "type": "result",
+                    "required": false
+                },
+                {
+                    "type": "source",
                     "required": false
                 }
             ]
@@ -3816,10 +3848,10 @@
         {
             "name": "codeTransform_logApiError",
             "passive": true,
-            "description": "Deprecated - avoid logging every service call",
+            "description": "An API-side error has occurred.",
             "metadata": [
                 {
-                    "type": "codeTransformApiErrorMessage",
+                    "type": "codeTransformErrorMessage",
                     "required": true
                 },
                 {
@@ -3882,10 +3914,10 @@
         {
             "name": "codeTransform_logGeneralError",
             "passive": true,
-            "description": "Deprecated - avoid logging every service call",
+            "description": "A general error has occurred.",
             "metadata": [
                 {
-                    "type": "codeTransformApiErrorMessage",
+                    "type": "codeTransformErrorMessage",
                     "required": true
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -313,11 +313,6 @@
             "description": "If dependencies are copied into upload artifact."
         },
         {
-            "name": "codeTransformErrorMessage",
-            "type": "string",
-            "description": "The error message (can be local or API-side)"
-        },
-        {
             "name": "codeTransformJavaSourceVersionsAllowed",
             "type": "string",
             "description": "Allowed Java versions to transform from",
@@ -367,7 +362,7 @@
             "description": "A general field for logging metadata associated to Amazon Q transform metrics."
         },
         {
-            "name": "codeTransformNumberOfSelectedProjects",
+            "name": "codeTransformNumberOfProjects",
             "type": "int",
             "description": "The number of projects selected for transformation"
         },
@@ -3640,10 +3635,6 @@
                     "required": true
                 },
                 {
-                    "type": "codeTransformNumberOfTransformedFiles",
-                    "required": false
-                },
-                {
                     "type": "codeTransformRuntimeError",
                     "required": false
                 },
@@ -3756,7 +3747,11 @@
                     "required": false
                 },
                 {
-                    "type": "codeTransformNumberOfSelectedProjects",
+                    "type": "codeTransformNumberOfProjects",
+                    "required": false
+                },
+                {
+                    "type": "codeTransformNumberOfTransformedFiles",
                     "required": false
                 },
                 {
@@ -3860,16 +3855,8 @@
         {
             "name": "codeTransform_logApiError",
             "passive": true,
-            "description": "An API-side error has occurred.",
+            "description": "Deprecated - avoid logging every service call",
             "metadata": [
-                {
-                    "type": "codeTransformApiNames",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformErrorMessage",
-                    "required": true
-                },
                 {
                     "type": "codeTransformJobId",
                     "required": false
@@ -3885,6 +3872,10 @@
                 {
                     "type": "codeTransformTotalByteSize",
                     "required": false
+                },
+                {
+                    "type": "reason",
+                    "required": true
                 }
             ]
         },
@@ -3929,15 +3920,15 @@
             "description": "A general error has occurred.",
             "metadata": [
                 {
-                    "type": "codeTransformErrorMessage",
-                    "required": true
-                },
-                {
                     "type": "codeTransformJobId",
                     "required": false
                 },
                 {
                     "type": "codeTransformSessionId",
+                    "required": true
+                },
+                {
+                    "type": "reason",
                     "required": true
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -249,11 +249,6 @@
             "description": "Time taken to invoke code scan service APIs in milliseconds"
         },
         {
-            "name": "codeTransformErrorMessage",
-            "type": "string",
-            "description": "The error message (can be local or API-side)"
-        },
-        {
             "name": "codeTransformApiNames",
             "type": "string",
             "description": "Deprecated (Names of allowed API calls)",
@@ -316,6 +311,11 @@
             "name": "codeTransformDependenciesCopied",
             "type": "boolean",
             "description": "If dependencies are copied into upload artifact."
+        },
+        {
+            "name": "codeTransformErrorMessage",
+            "type": "string",
+            "description": "The error message (can be local or API-side)"
         },
         {
             "name": "codeTransformJavaSourceVersionsAllowed",
@@ -1525,7 +1525,10 @@
         {
             "name": "saveType",
             "type": "string",
-            "allowedValues": ["MANUAL_SAVE", "AUTO_SAVE"],
+            "allowedValues": [
+                "MANUAL_SAVE",
+                "AUTO_SAVE"
+            ],
             "description": "Type of save executed"
         },
         {
@@ -3488,7 +3491,7 @@
             "description": "Apply suggested changes to buildable units.",
             "metadata": [
                 {
-                    "type": "codeTransformSessionId",
+                    "type": "codeTransformNumberOfSelectedFiles",
                     "required": true
                 },
                 {
@@ -3496,7 +3499,7 @@
                     "required": false
                 },
                 {
-                    "type": "codeTransformNumberOfSelectedFiles",
+                    "type": "codeTransformSessionId",
                     "required": true
                 }
             ]
@@ -3578,7 +3581,7 @@
         {
             "name": "codeTransform_initiateTransform",
             "description": "User initiates code transform from Q Chat Prompt.",
-            "metadata" : [
+            "metadata": [
                 {
                     "type": "codeTransformSessionId",
                     "required": true
@@ -3826,7 +3829,7 @@
         {
             "name": "codeTransform_localBuildProject",
             "description": "Transform initiates local build.",
-            "metadata" : [
+            "metadata": [
                 {
                     "type": "codeTransformBuildCommand",
                     "required": true
@@ -3851,11 +3854,11 @@
             "description": "An API-side error has occurred.",
             "metadata": [
                 {
-                    "type": "codeTransformErrorMessage",
+                    "type": "codeTransformApiNames",
                     "required": true
                 },
                 {
-                    "type": "codeTransformApiNames",
+                    "type": "codeTransformErrorMessage",
                     "required": true
                 },
                 {
@@ -3978,7 +3981,7 @@
         {
             "name": "codeTransform_submitSelection",
             "description": "User provides input to project module and language selection.",
-            "metadata" : [
+            "metadata": [
                 {
                     "type": "codeTransformJavaSourceVersionsAllowed",
                     "required": false
@@ -4048,11 +4051,10 @@
                 }
             ]
         },
-
         {
             "name": "codeTransform_uploadProject",
             "description": "Transform initiates project artifact upload.",
-            "metadata" : [
+            "metadata": [
                 {
                     "type": "codeTransformDependenciesCopied",
                     "required": true
@@ -4082,7 +4084,7 @@
         {
             "name": "codeTransform_validateProject",
             "description": "Transform initiates project language, build tool, and build file validation.",
-            "metadata" : [
+            "metadata": [
                 {
                     "type": "buildSystemVersion",
                     "required": false

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -367,19 +367,19 @@
             "description": "A general field for logging metadata associated to Amazon Q transform metrics."
         },
         {
-            "name": "codeTransformNumberOfSelectedFiles",
-            "type": "int",
-            "description": "The number of files selected to apply changes to"
-        },
-        {
             "name": "codeTransformNumberOfSelectedProjects",
             "type": "int",
             "description": "The number of projects selected for transformation"
         },
         {
-            "name": "codeTransformNumberOfSelectedUnits",
+            "name": "codeTransformNumberOfTransformedFilesAccepted",
             "type": "int",
-            "description": "The number of buildable units selected to apply changes to"
+            "description": "The number of transformed files that have been accepted by the user"
+        },
+        {
+            "name": "codeTransformNumberOfTransformedUnitsAccepted",
+            "type": "int",
+            "description": "The number of transformed buildable units that have been accepted by the user"
         },
         {
             "name": "codeTransformPatchViewerCancelSrcComponents",
@@ -3491,11 +3491,11 @@
             "description": "Apply suggested changes to buildable units.",
             "metadata": [
                 {
-                    "type": "codeTransformNumberOfSelectedFiles",
+                    "type": "codeTransformNumberOfTransformedFilesAccepted",
                     "required": true
                 },
                 {
-                    "type": "codeTransformNumberOfSelectedUnits",
+                    "type": "codeTransformNumberOfTransformedUnitsAccepted",
                     "required": false
                 },
                 {


### PR DESCRIPTION
Updates `commonDefinitions.json` with some new fields used in existing `codeTransform` metric types, as well as a new metric type called `codeTransform_applyChanges` that is emitted whenever a user chooses to apply suggested changes.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
