### PR TITLE
Metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -289,7 +289,8 @@
                 "gradlew.bat",
                 "gradlew",
                 "gradle",
-                "IDEBundledGradle"
+                "IDEBundledGradle",
+                "Unknown"
             ]
         },
         {
@@ -298,7 +299,8 @@
             "description": "Type of build system",
             "allowedValues": [
                 "Maven",
-                "Gradle"
+                "Gradle",
+                "Unknown"
             ]
         },
         {
@@ -3882,7 +3884,7 @@
         {
             "name": "codeTransform_logGeneralError",
             "passive": true,
-            "description": "Deprecated - avoid logging every service call",
+            "description": "Emit general error that occurred during the transformation.",
             "metadata": [
                 {
                     "type": "codeTransformApiErrorMessage",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -290,7 +290,7 @@
                 "gradlew",
                 "gradle",
                 "IDEBundledGradle",
-                "Unknown"
+                "unknown"
             ]
         },
         {
@@ -300,7 +300,7 @@
             "allowedValues": [
                 "Maven",
                 "Gradle",
-                "Unknown"
+                "unknown"
             ]
         },
         {
@@ -3799,7 +3799,7 @@
             "metadata" : [
                 {
                     "type": "codeTransformBuildCommand",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "codeTransformSessionId",
@@ -4059,7 +4059,7 @@
                 },
                 {
                     "type": "codeTransformBuildSystem",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "codeTransformLocalJavaVersion",


### PR DESCRIPTION
## Problem

When generating types from shared telemetry, IntelliJ automatically adds an additional "Unknown" value to enum types. VSCode does not.

## Solution

- Add "unknown" to `codeTransformBuildSystem` and `codeTranformBuildCommand` explicitly. 
- Make `codeTransformBuildSystem` and `codeTranformBuildCommand` optional in case other IDE wants to emit these metrics without build system and command. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
