### PR TITLE
Update the C# Telemetry Generator from .NET 6 to .NET 8

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/AwsToolkit.Telemetry.Events.Generator.Tests.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/AwsToolkit.Telemetry.Events.Generator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/AwsToolkit.Telemetry.Events.Generator.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator/AwsToolkit.Telemetry.Events.Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Amazon.AwsToolkit.Telemetry.Events.Generator</RootNamespace>
     <AssemblyName>Amazon.AwsToolkit.Telemetry.Events.Generator</AssemblyName>
     <Authors>Amazon Web Services</Authors>


### PR DESCRIPTION
This change updates the .NET telemetry generator from .NET 6 to .NET 8. The NuGet packages it produces continue to target .NET 4.7.2 (which supports the Visual Studio Toolkit).

A while back, I updated the infrastructure so that .NET 8 is available in the automation and CI jobs.

This change was verified by:
- checking that the test suite passes
- comparing the resultant generated code before and after the change, and ensuring they match

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
