### PR TITLE
telemetry(jetbrains): fix CI validation issue

### DIFF
--- a/buildspec/kotlinTests.yml
+++ b/buildspec/kotlinTests.yml
@@ -10,4 +10,4 @@ phases:
             - |
                 # TODO - iterate through the subdirectories to have one build script per runtime
                 cd telemetry/jetbrains
-                ./gradlew test
+                ./gradlew build

--- a/telemetry/jetbrains/build.gradle.kts
+++ b/telemetry/jetbrains/build.gradle.kts
@@ -49,7 +49,7 @@ tasks {
 
     val validatePackagedSchema by registering {
         group = "build"
-        description = "Validates that the packaged definition is compatable with the packaged schema"
+        description = "Validates that the packaged definition is compatible with the packaged schema"
         doFirst {
             try {
                 val telemetrySchema = file("src/main/resources/telemetrySchema.json")
@@ -75,6 +75,10 @@ tasks {
         from("..")
         include("*.json", "definitions/*.json")
         into("src/test/resources/")
+    }
+
+    named("sourcesJar").configure {
+        dependsOn(copyTelemetryResources)
     }
 
     compileKotlin {


### PR DESCRIPTION
## Problem
GitHub checks and CI checks did not match

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':sourcesJar' (type 'Jar').
  - Gradle detected a problem with the following location: '/codebuild/output/src3317621939/src/telemetry/jetbrains/src/main/resources'.
    
    Reason: Task ':sourcesJar' uses this output of task ':copyTelemetryResources' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':copyTelemetryResources' as an input of ':sourcesJar'.
      2. Declare an explicit dependency on ':copyTelemetryResources' from ':sourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':copyTelemetryResources' from ':sourcesJar' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.9/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 1m 49s
```
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
