### PR TITLE
VSC telemetry updates

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1590,6 +1590,16 @@
             "description": "The type of an SQS Queue"
         },
         {
+            "name": "ssoRegistrationClientId",
+            "type": "string",
+            "description": "The client ID of an SSO registration."
+        },
+        {
+            "name": "ssoRegistrationExpiresAt",
+            "type": "string",
+            "description": "Date/time that an SSO client registration expires."
+        },
+        {
             "name": "successCount",
             "type": "int",
             "description": "The number of successful operations"
@@ -2450,6 +2460,14 @@
                 },
                 {
                     "type": "source"
+                },
+                {
+                    "type": "ssoRegistrationClientId",
+                    "required": false
+                },
+                {
+                    "type": "ssoRegistrationExpiresAt",
+                    "required": false
                 }
             ]
         },
@@ -2525,8 +2543,20 @@
                     "required": true
                 },
                 {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
                     "type": "source",
                     "required": true
+                },
+                {
+                    "type": "ssoRegistrationClientId",
+                    "required": false
+                },
+                {
+                    "type": "ssoRegistrationExpiresAt",
+                    "required": false
                 }
             ],
             "passive": true
@@ -2650,6 +2680,14 @@
                 },
                 {
                     "type": "source"
+                },
+                {
+                    "type": "ssoRegistrationClientId",
+                    "required": false
+                },
+                {
+                    "type": "ssoRegistrationExpiresAt",
+                    "required": false
                 }
             ]
         },
@@ -2721,6 +2759,10 @@
                     "required": false
                 },
                 {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
                     "type": "credentialType",
                     "required": false
                 },
@@ -2741,6 +2783,14 @@
                 },
                 {
                     "type": "sessionDuration",
+                    "required": false
+                },
+                {
+                    "type": "ssoRegistrationClientId",
+                    "required": false
+                },
+                {
+                    "type": "ssoRegistrationExpiresAt",
                     "required": false
                 }
             ]

--- a/telemetry/vscode/test/resources/generatorOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOutput.ts
@@ -114,7 +114,7 @@ export const definitions: Record<string, MetricDefinition> = {
     passive_passive: { unit: 'None', passive: true, requiredMetadata: [] },
 }
 
-export type Metadata<T extends MetricBase> = Partial<Omit<T, keyof MetricBase>>
+export type Metadata<T extends MetricBase> = Partial<Omit<T, keyof MetricBase> | Partial<Pick<MetricBase, 'awsRegion'>>>
 
 export interface Metric<T extends MetricBase = MetricBase> {
     readonly name: string

--- a/telemetry/vscode/test/resources/generatorOverrideOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOverrideOutput.ts
@@ -85,7 +85,7 @@ export const definitions: Record<string, MetricDefinition> = {
     metadata_hasResult: { unit: 'None', passive: false, requiredMetadata: [] },
 }
 
-export type Metadata<T extends MetricBase> = Partial<Omit<T, keyof MetricBase>>
+export type Metadata<T extends MetricBase> = Partial<Omit<T, keyof MetricBase> | Partial<Pick<MetricBase, 'awsRegion'>>>
 
 export interface Metric<T extends MetricBase = MetricBase> {
     readonly name: string


### PR DESCRIPTION
**Do not squash merge** Contains 2 commits: 

- feat: add additional fields to auth metrics

- feat(generation): allow awsRegion to be specified by callers in Metadata

Problem: `awsRegion` is a base metric and does not allow for callers to add it to their metadata when using `record()`. However, this field is often known best by the caller and not the telemetry guessing algorithm.

Solution: Update type generation to allow this base metric to be specified in metadata.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
