### PR TITLE
amazonq: add raw suggestion token count to code percentage event

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -490,7 +490,7 @@
         {
             "name": "codewhispererAcceptedTokens",
             "type": "int",
-            "description": "The metrics accepted on suggested CodeWhisperer code"
+            "description": "The number of tokens that are accepted and not modified by the user"
         },
         {
             "name": "codewhispererAllCompletionsLatency",
@@ -765,6 +765,11 @@
             "name": "codewhispererSessionId",
             "type": "string",
             "description": "The unique identifier for a CodeWhisperer session(which can contain multiple requests)"
+        },
+        {
+            "name": "codewhispererSuggestedTokens",
+            "type": "int",
+            "description": "The number of tokens in the original code suggestions"
         },
         {
             "name": "codewhispererSuggestionCount",
@@ -4327,6 +4332,9 @@
                 },
                 {
                     "type": "codewhispererPercentage"
+                },
+                {
+                    "type": "codewhispererSuggestedTokens"
                 },
                 {
                     "type": "codewhispererTotalTokens"

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -4334,7 +4334,8 @@
                     "type": "codewhispererPercentage"
                 },
                 {
-                    "type": "codewhispererSuggestedTokens"
+                    "type": "codewhispererSuggestedTokens",
+                    "required": false
                 },
                 {
                     "type": "codewhispererTotalTokens"


### PR DESCRIPTION
## Problem
We are need both unmodified and raw chars count for code percentage event
## Solution
Add another field for the raw token count
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
