### PR TITLE
Add reasonDesc to createUpload definition

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1670,7 +1670,7 @@
                 },
                 {
                     "type": "reason",
-                    "required": false
+                    "required": false  
                 },
                 {
                     "type": "requestId",
@@ -1740,6 +1740,10 @@
                 {
                     "type": "reason",
                     "required": false
+                },
+                {
+                    "type": "reasonDesc",
+                    "required": false  
                 },
                 {
                     "type": "requestId",
@@ -1921,7 +1925,7 @@
                 },
                 {
                     "type": "reason",
-                    "required": false
+                    "required": false  
                 },
                 {
                     "type": "requestId",


### PR DESCRIPTION
## Problem

As we emit `createUpload` event, we received multiple cases where the result is Failed but the reason is not enough for us to understand what exactly happened

## Solution

Added `reasonDesc` in `createUpload` definition, so we can add more information to debug customer issues.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
