### PR TITLE
feat(jetbrains): Add global metadata fields into all metrics for jetbrains telemetry generator

### DIFF
--- a/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
+++ b/telemetry/jetbrains/src/test/kotlin/software/aws/toolkits/telemetry/generator/GeneratorTest.kt
@@ -25,6 +25,11 @@ class GeneratorTest {
     }
 
     @Test
+    fun generateWithGlobalMetadata() {
+        testGenerator(defaultDefinitionsFile = "/testGlobalMetadataInput.json", expectedOutputFile = "/testGlobalMetadataOutput")
+    }
+
+    @Test
     fun generatesWithNormalInput() {
         testGenerator(defaultDefinitionsFile = "/testGeneratorInput.json", expectedOutputFile = "/testGeneratorOutput")
     }

--- a/telemetry/jetbrains/src/test/resources/testGeneratorOutput
+++ b/telemetry/jetbrains/src/test/resources/testGeneratorOutput
@@ -44,6 +44,7 @@ public object LambdaTelemetry {
         project: Project?,
         lambdaRuntime: LambdaRuntime,
         arbitraryString: String,
+        duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -56,6 +57,9 @@ public object LambdaTelemetry {
                 passive(passive)
                 metadata("lambdaRuntime", lambdaRuntime.toString())
                 metadata("arbitraryString", arbitraryString)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -67,6 +71,7 @@ public object LambdaTelemetry {
         connectionSettings: ConnectionSettings? = null,
         lambdaRuntime: LambdaRuntime,
         arbitraryString: String,
+        duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -79,6 +84,9 @@ public object LambdaTelemetry {
                 passive(passive)
                 metadata("lambdaRuntime", lambdaRuntime.toString())
                 metadata("arbitraryString", arbitraryString)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -90,6 +98,7 @@ public object LambdaTelemetry {
         metadata: MetricEventMetadata,
         lambdaRuntime: LambdaRuntime,
         arbitraryString: String,
+        duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -102,6 +111,9 @@ public object LambdaTelemetry {
                 passive(passive)
                 metadata("lambdaRuntime", lambdaRuntime.toString())
                 metadata("arbitraryString", arbitraryString)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -182,6 +194,7 @@ public object LambdaTelemetry {
         project: Project?,
         lambdaRuntime: LambdaRuntime? = null,
         inttype: Int,
+        duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -196,6 +209,9 @@ public object LambdaTelemetry {
                     metadata("lambdaRuntime", lambdaRuntime.toString())
                 }
                 metadata("inttype", inttype.toString())
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -207,6 +223,7 @@ public object LambdaTelemetry {
         connectionSettings: ConnectionSettings? = null,
         lambdaRuntime: LambdaRuntime? = null,
         inttype: Int,
+        duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -221,6 +238,9 @@ public object LambdaTelemetry {
                     metadata("lambdaRuntime", lambdaRuntime.toString())
                 }
                 metadata("inttype", inttype.toString())
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -232,6 +252,7 @@ public object LambdaTelemetry {
         metadata: MetricEventMetadata,
         lambdaRuntime: LambdaRuntime? = null,
         inttype: Int,
+        duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -246,6 +267,9 @@ public object LambdaTelemetry {
                     metadata("lambdaRuntime", lambdaRuntime.toString())
                 }
                 metadata("inttype", inttype.toString())
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -257,6 +281,7 @@ public object NoTelemetry {
      */
     public fun metadata(
         project: Project?,
+        duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -267,6 +292,9 @@ public object NoTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(passive)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -276,6 +304,7 @@ public object NoTelemetry {
      */
     public fun metadata(
         connectionSettings: ConnectionSettings? = null,
+        duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -286,6 +315,9 @@ public object NoTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(passive)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -295,6 +327,7 @@ public object NoTelemetry {
      */
     public fun metadata(
         metadata: MetricEventMetadata,
+        duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -305,6 +338,9 @@ public object NoTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(passive)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -316,6 +352,7 @@ public object PassiveTelemetry {
      */
     public fun passive(
         project: Project?,
+        duration: Double? = null,
         passive: Boolean = true,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -326,6 +363,9 @@ public object PassiveTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(passive)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -335,6 +375,7 @@ public object PassiveTelemetry {
      */
     public fun passive(
         connectionSettings: ConnectionSettings? = null,
+        duration: Double? = null,
         passive: Boolean = true,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -345,6 +386,9 @@ public object PassiveTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(passive)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }
@@ -354,6 +398,7 @@ public object PassiveTelemetry {
      */
     public fun passive(
         metadata: MetricEventMetadata,
+        duration: Double? = null,
         passive: Boolean = true,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -364,6 +409,9 @@ public object PassiveTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(passive)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
             }
         }
     }

--- a/telemetry/jetbrains/src/test/resources/testGlobalMetadataInput.json
+++ b/telemetry/jetbrains/src/test/resources/testGlobalMetadataInput.json
@@ -1,0 +1,50 @@
+{
+  "types": [
+    {
+      "name": "duration",
+      "type": "double",
+      "description": "The duration of the operation in milliseconds"
+    },
+    {
+      "name": "httpStatusCode",
+      "type": "string",
+      "description": "HTTP status code for the request (if any) associated with a metric."
+    },
+    {
+      "name": "reason",
+      "type": "string",
+      "description": "Reason code or name for an event (when result=Succeeded) or error (when result=Failed). Unlike the `reasonDesc` field, this should be a stable/predictable name for a class of events or errors (typically the exception name, e.g. FileIOException)."
+    },
+    {
+      "name": "reasonDesc",
+      "type": "string",
+      "description": "Error message detail. May contain arbitrary message details (unlike the `reason` field), but should be truncated (recommendation: 200 chars)."
+    },
+    {
+      "name": "requestId",
+      "type": "string",
+      "description": "Request ID (if any) associated with a metric. For example, an event with `requestServiceType: s3` means that the request ID is associated with an S3 API call. Events that cover multiple API calls should use the request ID of the most recent call."
+    },
+    {
+      "name": "requestServiceType",
+      "type": "string",
+      "description": "Per-request service identifier. Unlike `serviceType` (which describes the originator of the request), this describes the request itself."
+    },
+    {
+      "name": "result",
+      "allowedValues": [
+        "Succeeded",
+        "Failed",
+        "Cancelled"
+      ],
+      "description": "The result of the operation"
+    }
+  ],
+  "metrics": [
+    {
+      "name": "test_metric",
+      "description": "Testing metric with global metadata fields",
+      "metadata": []
+    }
+  ]
+}

--- a/telemetry/jetbrains/src/test/resources/testGlobalMetadataOutput
+++ b/telemetry/jetbrains/src/test/resources/testGlobalMetadataOutput
@@ -1,0 +1,241 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// THIS FILE IS GENERATED! DO NOT EDIT BY HAND!
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
+
+package software.aws.toolkits.telemetry
+
+import com.intellij.openapi.project.Project
+import java.time.Instant
+import kotlin.Boolean
+import kotlin.Double
+import kotlin.String
+import kotlin.Suppress
+import software.amazon.awssdk.services.toolkittelemetry.model.Unit
+import software.aws.toolkits.core.ConnectionSettings
+import software.aws.toolkits.jetbrains.services.telemetry.MetricEventMetadata
+import software.aws.toolkits.jetbrains.services.telemetry.TelemetryService
+
+/**
+ * The result of the operation
+ */
+public enum class Result(
+    private val `value`: String,
+) {
+    Succeeded("Succeeded"),
+    Failed("Failed"),
+    Cancelled("Cancelled"),
+    Unknown("unknown"),
+    ;
+
+    override fun toString(): String = value
+
+    public companion object {
+        public fun from(type: String): Result = values().firstOrNull { it.value == type } ?: Unknown
+    }
+}
+
+public object TestTelemetry {
+    /**
+     * Testing metric with global metadata fields
+     */
+    public fun metric(
+        project: Project?,
+        duration: Double? = null,
+        httpStatusCode: String? = null,
+        reason: String? = null,
+        reasonDesc: String? = null,
+        requestId: String? = null,
+        requestServiceType: String? = null,
+        result: Result? = null,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now(),
+    ) {
+        TelemetryService.getInstance().record(project) {
+            datum("test_metric") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(passive)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
+                if(httpStatusCode != null) {
+                    metadata("httpStatusCode", httpStatusCode)
+                }
+                if(reason != null) {
+                    metadata("reason", reason)
+                }
+                if(reasonDesc != null) {
+                    metadata("reasonDesc", reasonDesc)
+                }
+                if(requestId != null) {
+                    metadata("requestId", requestId)
+                }
+                if(requestServiceType != null) {
+                    metadata("requestServiceType", requestServiceType)
+                }
+                if(result != null) {
+                    metadata("result", result.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Testing metric with global metadata fields
+     */
+    public fun metric(
+        connectionSettings: ConnectionSettings? = null,
+        duration: Double? = null,
+        httpStatusCode: String? = null,
+        reason: String? = null,
+        reasonDesc: String? = null,
+        requestId: String? = null,
+        requestServiceType: String? = null,
+        result: Result? = null,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now(),
+    ) {
+        TelemetryService.getInstance().record(connectionSettings) {
+            datum("test_metric") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(passive)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
+                if(httpStatusCode != null) {
+                    metadata("httpStatusCode", httpStatusCode)
+                }
+                if(reason != null) {
+                    metadata("reason", reason)
+                }
+                if(reasonDesc != null) {
+                    metadata("reasonDesc", reasonDesc)
+                }
+                if(requestId != null) {
+                    metadata("requestId", requestId)
+                }
+                if(requestServiceType != null) {
+                    metadata("requestServiceType", requestServiceType)
+                }
+                if(result != null) {
+                    metadata("result", result.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Testing metric with global metadata fields
+     */
+    public fun metric(
+        metadata: MetricEventMetadata,
+        duration: Double? = null,
+        httpStatusCode: String? = null,
+        reason: String? = null,
+        reasonDesc: String? = null,
+        requestId: String? = null,
+        requestServiceType: String? = null,
+        result: Result? = null,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now(),
+    ) {
+        TelemetryService.getInstance().record(metadata) {
+            datum("test_metric") {
+                createTime(createTime)
+                unit(Unit.NONE)
+                value(value)
+                passive(passive)
+                if(duration != null) {
+                    metadata("duration", duration.toString())
+                }
+                if(httpStatusCode != null) {
+                    metadata("httpStatusCode", httpStatusCode)
+                }
+                if(reason != null) {
+                    metadata("reason", reason)
+                }
+                if(reasonDesc != null) {
+                    metadata("reasonDesc", reasonDesc)
+                }
+                if(requestId != null) {
+                    metadata("requestId", requestId)
+                }
+                if(requestServiceType != null) {
+                    metadata("requestServiceType", requestServiceType)
+                }
+                if(result != null) {
+                    metadata("result", result.toString())
+                }
+            }
+        }
+    }
+
+    /**
+     * Testing metric with global metadata fields
+     */
+    public fun metric(
+        project: Project? = null,
+        duration: Double? = null,
+        httpStatusCode: String? = null,
+        reason: String? = null,
+        reasonDesc: String? = null,
+        requestId: String? = null,
+        requestServiceType: String? = null,
+        success: Boolean,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now(),
+    ) {
+        metric(project, duration, httpStatusCode, reason, reasonDesc, requestId, requestServiceType,
+                if(success) Result.Succeeded else Result.Failed, passive, value, createTime)
+    }
+
+    /**
+     * Testing metric with global metadata fields
+     */
+    public fun metric(
+        connectionSettings: ConnectionSettings? = null,
+        duration: Double? = null,
+        httpStatusCode: String? = null,
+        reason: String? = null,
+        reasonDesc: String? = null,
+        requestId: String? = null,
+        requestServiceType: String? = null,
+        success: Boolean,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now(),
+    ) {
+        metric(connectionSettings, duration, httpStatusCode, reason, reasonDesc, requestId,
+                requestServiceType, if(success) Result.Succeeded else Result.Failed, passive, value,
+                createTime)
+    }
+
+    /**
+     * Testing metric with global metadata fields
+     */
+    public fun metric(
+        metadata: MetricEventMetadata,
+        duration: Double? = null,
+        httpStatusCode: String? = null,
+        reason: String? = null,
+        reasonDesc: String? = null,
+        requestId: String? = null,
+        requestServiceType: String? = null,
+        success: Boolean,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now(),
+    ) {
+        metric(metadata, duration, httpStatusCode, reason, reasonDesc, requestId,
+                requestServiceType, if(success) Result.Succeeded else Result.Failed, passive, value,
+                createTime)
+    }
+}

--- a/telemetry/jetbrains/src/test/resources/testOverrideOutput
+++ b/telemetry/jetbrains/src/test/resources/testOverrideOutput
@@ -39,6 +39,7 @@ public object MetadataTelemetry {
      */
     public fun hasResult(
         project: Project?,
+        result: Result? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -49,6 +50,9 @@ public object MetadataTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(passive)
+                if(result != null) {
+                    metadata("result", result.toString())
+                }
             }
         }
     }
@@ -58,6 +62,7 @@ public object MetadataTelemetry {
      */
     public fun hasResult(
         connectionSettings: ConnectionSettings? = null,
+        result: Result? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -68,6 +73,9 @@ public object MetadataTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(passive)
+                if(result != null) {
+                    metadata("result", result.toString())
+                }
             }
         }
     }
@@ -77,6 +85,7 @@ public object MetadataTelemetry {
      */
     public fun hasResult(
         metadata: MetricEventMetadata,
+        result: Result? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
         createTime: Instant = Instant.now(),
@@ -87,7 +96,52 @@ public object MetadataTelemetry {
                 unit(Unit.NONE)
                 value(value)
                 passive(passive)
+                if(result != null) {
+                    metadata("result", result.toString())
+                }
             }
         }
+    }
+
+    /**
+     * It does not actually have a result, yep
+     */
+    public fun hasResult(
+        project: Project? = null,
+        success: Boolean,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now(),
+    ) {
+        hasResult(project, if(success) Result.Succeeded else Result.Failed, passive, value,
+                createTime)
+    }
+
+    /**
+     * It does not actually have a result, yep
+     */
+    public fun hasResult(
+        connectionSettings: ConnectionSettings? = null,
+        success: Boolean,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now(),
+    ) {
+        hasResult(connectionSettings, if(success) Result.Succeeded else Result.Failed, passive,
+                value, createTime)
+    }
+
+    /**
+     * It does not actually have a result, yep
+     */
+    public fun hasResult(
+        metadata: MetricEventMetadata,
+        success: Boolean,
+        passive: Boolean = false,
+        `value`: Double = 1.0,
+        createTime: Instant = Instant.now(),
+    ) {
+        hasResult(metadata, if(success) Result.Succeeded else Result.Failed, passive, value,
+                createTime)
     }
 }


### PR DESCRIPTION
## Problem

Jetbrain telemetry definition does not contain global metadata fields.

## Solution

Added global metadata fields into every metrics in telemetry generator

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
