### PR TITLE
refactor(telemetry): rename to aws_featureConfig

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2696,6 +2696,21 @@
             ]
         },
         {
+            "name": "aws_featureConfig",
+            "description": "AB Testing Feature response and Cohort Assignments",
+            "metadata": [
+                {
+                    "type": "featureValue"
+                },
+                {
+                    "type": "featureVariation"
+                },
+                {
+                    "type": "id"
+                }
+            ]
+        },
+        {
             "name": "aws_help",
             "description": "Open docs for the extension",
             "metadata": [
@@ -5784,21 +5799,6 @@
             "metadata": [
                 {
                     "type": "result"
-                }
-            ]
-        },
-        {
-            "name": "experiment_feature_config",
-            "description": "AB Testing Feature response and Cohort Assignments",
-            "metadata": [
-                {
-                    "type": "featureValue"
-                },
-                {
-                    "type": "featureVariation"
-                },
-                {
-                    "type": "id"
                 }
             ]
         },


### PR DESCRIPTION
Rename `experiment_feature_config` to `aws_featureConfig`
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
