### PR TITLE
Update actions/checkout GitHub Actions to v4

### DIFF
--- a/.github/workflows/csharp-ci.yaml
+++ b/.github/workflows/csharp-ci.yaml
@@ -15,7 +15,7 @@ jobs:
         runs-on: windows-latest
         steps:
             - name: Sync Code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Build
               run: |
                   dotnet build -c Release ./telemetry/csharp/AwsToolkit.Telemetry.sln

--- a/.github/workflows/lint-telemetry-definitions.yaml
+++ b/.github/workflows/lint-telemetry-definitions.yaml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Sync Code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Compile the Validation code
               run: |


### PR DESCRIPTION
## Problem

The GitHub actions used by CI have a warning that they are using a deprecated Node.js version.

## Solution

Update the actions to the latest version.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
