### PR TITLE
Add definitions for a feature's enabled state, and the opening and closing of a module

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1200,7 +1200,9 @@
             "type": "string",
             "description": "The id of the feature the user is interacting in. See also: `component`, `featureId`, `module`, `resourceType`.",
             "allowedValues": [
+                "amazonQ",
                 "awsExplorer",
+                "awsToolkit",
                 "codewhisperer",
                 "codecatalyst"
             ]
@@ -6861,6 +6863,44 @@
             ]
         },
         {
+            "name": "toolkit_closeModule",
+            "description": "The user closed 'something' (specified by 'module'). Examples: a view, feature, resource, ...",
+            "metadata": [
+                {
+                    "type": "module",
+                    "required": true
+                }
+            ],
+            "passive": true
+        },
+        {
+            "name": "toolkit_featureState",
+            "description": "Represents the current enabled state of a feature. Used to track user journey through a feature. Emitted after feature-specific operations of interest in the Toolkit.",
+            "metadata": [
+                {
+                    "type": "authStatus",
+                    "required": false
+                },
+                {
+                    "type": "credentialSourceId",
+                    "required": false
+                },
+                {
+                    "type": "enabled",
+                    "required": true
+                },
+                {
+                    "type": "featureId",
+                    "required": true
+                },
+                {
+                    "type": "source",
+                    "required": true
+                }
+            ],
+            "passive": true
+        },
+        {
             "name": "toolkit_getExternalResource",
             "description": "The toolkit tried to retrieve blob data from a url",
             "metadata": [
@@ -6950,6 +6990,25 @@
                     "required": true
                 }
             ]
+        },
+        {
+            "name": "toolkit_openModule",
+            "description": "The user opened 'something' (specified by 'module'). Examples: a view, feature, resource, ...",
+            "metadata": [
+                {
+                    "type": "module",
+                    "required": true
+                },
+                {
+                    "type": "result",
+                    "required": true
+                },
+                {
+                    "type": "source",
+                    "required": true
+                }
+            ],
+            "passive": true
         },
         {
             "name": "toolkit_showAction",


### PR DESCRIPTION

## Problem

We're revising the VS Toolkit's Getting Started experience to more cleanly enable and disable features. We wish to understand the user's journey through this experience, and identify when/why a feature gets enabled or disabled.

## Solution

A generalized set of metrics that can be applied to any feature:
- `toolkit_featureState` - intended to be emitted at various points in a workflow, to report whether or not a certain feature is enabled. Also emits "why" this state is being emitted (via the "source" field)
- `toolkit_openModule` - intended to be emitted when a feature/view/component of interest is opened/entered/displayed. "What" is being opened is represented by the "module" field, and "Why" it is being opened is represented in "source"
- `toolkit_closeModule` - intended to be emitted when a feature/view/component of interest is closed/exited. "What" is being opened is represented by the "module" field.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
