### PR TITLE
telemetry(amazonq): make fields/metrics more generic to handle Gradle

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -404,8 +404,8 @@
                 "NoJavaProject",
                 "MixedLanguages",
                 "UnsupportedJavaVersion",
-                "ProjectJDKDiffersFromMavenJDK",
-                "NonMavenProject",
+                "ProjectJDKDiffersFromBuildSystemJDK",
+                "UnsupportedBuildSystem",
                 "EmptyProject",
                 "NonSsoLogin",
                 "RemoteRunProject"
@@ -4249,7 +4249,7 @@
                 },
                 {
                     "type": "codeTransformBuildSystem",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "codeTransformLocalJavaVersion",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -4166,7 +4166,7 @@
                 },
                 {
                     "type": "userChoice",
-                    "required": true
+                    "required": false
                 }
             ]
         },
@@ -4383,7 +4383,7 @@
                 },
                 {
                     "type": "userChoice",
-                    "required": true
+                    "required": false
                 }
             ]
         },


### PR DESCRIPTION
## Problem

Some fields/metrics were too Maven-specific, and we have Gradle support incoming.

## Solution

Make said fields/metrics more generic.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
