### PR TITLE
Add credentialType to toolkit_featureState

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -6586,6 +6586,10 @@
                     "required": false
                 },
                 {
+                    "type": "credentialType",
+                    "required": false
+                },
+                {
                     "type": "enabled",
                     "required": true
                 },


### PR DESCRIPTION

This change is a follow-up to #835, to add a "credential type" field to the `toolkit_featureState` metric. This allows us to differentiate whether credentials profiles coming from shared credentials are sso based or regular access key/secret key profiles.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
