### PR TITLE
feat: add metric to handle extension uninstallation

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2688,6 +2688,11 @@
             ]
         },
         {
+            "name": "aws_extensionUninstalled",
+            "description": "An extension in uninstalled",
+            "metadata": []
+        },
+        {
             "name": "aws_featureConfig",
             "description": "AB Testing Feature response and Cohort Assignments",
             "metadata": [


### PR DESCRIPTION
This PR adds a metric that is emitted when a user uninstall AWS Toolkit or Amazon Q extension.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
