### PR TITLE
Adding a new allowedValues for codewhispererCodeScanScope type

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -542,7 +542,8 @@
             "type": "string",
             "description": "The scope of the security scan being performed",
             "allowedValues": [
-                "FILE",
+                "FILE_AUTO",
+                "FILE_ON_DEMAND",
                 "PROJECT"
             ]
         },


### PR DESCRIPTION
## Problem
Existing allowed values for `codewhispererCodeScanScope` are PROJECT and FILE.
## Solution
As we are planning to add On-Demand File Scan to Amazon Q chat, we can extend `codewhispererCodeScanScope` to PROJECT, FILE_ON_DEMAND and FILE_AUTO.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
