### PR TITLE
telemetry: toolkit_trackScenario

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1897,25 +1897,6 @@
             ]
         },
         {
-            "name": "amazonq_trackScenarioCountUsage",
-            "description": "Count how many times a scenario is reached.",
-            "unit": "Count",
-            "metadata": [
-                {
-                    "type": "amazonqConversationId",
-                    "required": true
-                },
-                {
-                    "type": "scenarioType",
-                    "required": true
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                }
-            ]
-        },
-        {
             "name": "amazonq_codeGenerationThumbsDown",
             "description": "User clicked on the thumbs down button to say that they are unsatisfied",
             "unit": "Count",
@@ -2162,6 +2143,25 @@
                 },
                 {
                     "type": "result",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_trackScenarioCountUsage",
+            "description": "Count how many times a scenario is reached.",
+            "unit": "Count",
+            "metadata": [
+                {
+                    "type": "amazonqConversationId",
+                    "required": true
+                },
+                {
+                    "type": "scenarioType",
+                    "required": true
+                },
+                {
+                    "type": "credentialStartUrl",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -6817,12 +6817,12 @@
                     "type": "amazonqConversationId",
                     "required": true
                 },
+                 {
+                    "type": "count"
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false
-                },
-                 {
-                    "type": "count"
                 },
                 {
                     "type": "scenario",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -6809,7 +6809,7 @@
 
         {
             "name": "toolkit_trackScenario",
-            "description": "Count how many times a scenario is reached.",
+            "description": "Generic metric for tracking arbitrary scenarios that are not yet formalized into a full metric.",
             "unit": "Count",
             "metadata": [
                

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1561,7 +1561,7 @@
             "description": "Type of save executed"
         },
         {
-            "name": "scenarioType",
+            "name": "scenario",
             "type": "string",
             "allowedValues": [
                 "wsOrphanedDocuments"

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1902,10 +1902,12 @@
             "unit": "Count",
             "metadata": [
                 {
-                    "type": "amazonqConversationId"
+                    "type": "amazonqConversationId",
+                    "required": true
                 },
                 {
-                    "type": "scenarioType"
+                    "type": "scenarioType",
+                    "required": true
                 },
                 {
                     "type": "credentialStartUrl",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2157,12 +2157,12 @@
                     "required": true
                 },
                 {
-                    "type": "scenarioType",
-                    "required": true
-                },
-                {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                {
+                    "type": "scenarioType",
+                    "required": true
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1899,6 +1899,7 @@
         {
             "name": "amazonq_trackScenarioCountUsage",
             "description": "Count how many times a scenario is reached.",
+            "unit": "Count",
             "metadata": [
                 {
                     "type": "amazonqConversationId"

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2156,25 +2156,6 @@
             ]
         },
         {
-            "name": "amazonq_trackScenarioCountUsage",
-            "description": "Count how many times a scenario is reached.",
-            "unit": "Count",
-            "metadata": [
-                {
-                    "type": "amazonqConversationId",
-                    "required": true
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "scenarioType",
-                    "required": true
-                }
-            ]
-        },
-        {
             "name": "amazonq_viewChatPanel",
             "description": "Captures if Q chat panel is successfully viewed or not",
             "metadata": [
@@ -6827,6 +6808,29 @@
                 }
             ],
             "passive": true
+        },
+
+        {
+            "name": "toolkit_trackScenario",
+            "description": "Count how many times a scenario is reached.",
+            "unit": "Count",
+            "metadata": [
+                {
+                    "type": "count"
+                },
+                {
+                    "type": "amazonqConversationId",
+                    "required": true
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "scenarioType",
+                    "required": true
+                }
+            ]
         },
         {
             "name": "toolkit_viewLogs",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1563,9 +1563,6 @@
         {
             "name": "scenario",
             "type": "string",
-            "allowedValues": [
-                "wsOrphanedDocuments"
-            ],
             "description": "Scenarios to count in telemetry"
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1897,6 +1897,22 @@
             ]
         },
         {
+            "name": "amazonq_trackScenarioCountUsage",
+            "description": "Count how many times a scenario is reached.",
+            "metadata": [
+                {
+                    "type": "amazonqConversationId"
+                },
+                {
+                    "type": "scenarioType"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
+        },
+        {
             "name": "amazonq_codeGenerationThumbsDown",
             "description": "User clicked on the thumbs down button to say that they are unsatisfied",
             "unit": "Count",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -6815,9 +6815,7 @@
             "description": "Count how many times a scenario is reached.",
             "unit": "Count",
             "metadata": [
-                {
-                    "type": "count"
-                },
+               
                 {
                     "type": "amazonqConversationId",
                     "required": true
@@ -6825,6 +6823,9 @@
                 {
                     "type": "credentialStartUrl",
                     "required": false
+                },
+                 {
+                    "type": "count"
                 },
                 {
                     "type": "scenarioType",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1561,6 +1561,14 @@
             "description": "Type of save executed"
         },
         {
+            "name": "scenarioType",
+            "type": "string",
+            "allowedValues": [
+                "wsOrphanedDocuments"
+            ],
+            "description": "Scenarios to count in telemetry"
+        },
+        {
             "name": "schemaLanguage",
             "type": "string",
             "allowedValues": [

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -6825,7 +6825,7 @@
                     "type": "count"
                 },
                 {
-                    "type": "scenarioType",
+                    "type": "scenario",
                     "required": true
                 }
             ]


### PR DESCRIPTION
## Problem
No generic metric for counting how many times a (potentially temporary) scenario is reached.
Such scenarios may be temporary and thus a dedicated metric is not appropriate.

Example (vscode):
When customer use workspaces to generate files, RTS and LLM cannot decide which folder to deliver the generated file. We want track how many times we reach for accountability and prioritization.

## Solution
Add toolkit_trackScenario.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
