### PR TITLE
telemetry: codewhispererUsergroup is optional

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -4187,7 +4187,8 @@
                     "type": "codewhispererTriggerType"
                 },
                 {
-                    "type": "codewhispererUserGroup"
+                    "type": "codewhispererUserGroup",
+                    "required": false
                 },
                 {
                     "type": "credentialStartUrl",
@@ -4220,7 +4221,8 @@
                     "type": "codewhispererTotalTokens"
                 },
                 {
-                    "type": "codewhispererUserGroup"
+                    "type": "codewhispererUserGroup",
+                    "required": false
                 },
                 {
                     "type": "credentialStartUrl",
@@ -4365,7 +4367,8 @@
                     "type": "codewhispererTriggerType"
                 },
                 {
-                    "type": "codewhispererUserGroup"
+                    "type": "codewhispererUserGroup",
+                    "required": false
                 },
                 {
                     "type": "credentialStartUrl",
@@ -4517,7 +4520,8 @@
                     "type": "codewhispererTriggerType"
                 },
                 {
-                    "type": "codewhispererUserGroup"
+                    "type": "codewhispererUserGroup",
+                    "required": false
                 },
                 {
                     "type": "credentialStartUrl",
@@ -4601,7 +4605,8 @@
                     "type": "codewhispererTriggerType"
                 },
                 {
-                    "type": "codewhispererUserGroup"
+                    "type": "codewhispererUserGroup",
+                    "required": false
                 },
                 {
                     "type": "credentialStartUrl",
@@ -4650,7 +4655,8 @@
                     "type": "codewhispererTriggerType"
                 },
                 {
-                    "type": "codewhispererUserGroup"
+                    "type": "codewhispererUserGroup",
+                    "required": false
                 },
                 {
                     "type": "credentialStartUrl",
@@ -4777,7 +4783,8 @@
                     "type": "codewhispererTypeaheadLength"
                 },
                 {
-                    "type": "codewhispererUserGroup"
+                    "type": "codewhispererUserGroup",
+                    "required": false
                 },
                 {
                     "type": "credentialStartUrl",


### PR DESCRIPTION
## Problem
As we're pivoting to service A/B, userGroup will not be used in the future, hence making it optional for now.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
