### PR TITLE
refactor(vscode): remove telemetry.foo.record

### DIFF
--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -402,6 +402,7 @@ function generateFile(telemetryJson: MetricDefinitionRoot, dest: string) {
         name: 'Span',
         isExported: true,
         typeParameters: [{ name: 'T' }],
+        docs: ['Represents a telemetry span for tracking and recording metric data.'],
         methods: [
             {
                 name: 'record',

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -285,15 +285,6 @@ function generateMetricRecorder(metadataType: TypeAliasDeclarationStructure): In
         ],
         methods: [
             {
-                docs: ['Adds data to the metric which is preserved for the remainder of the execution context'],
-                name: 'record',
-                returnType: 'void',
-                parameters: [{
-                        name: 'data',
-                        type: `${metadataType.name}<T>`,
-                }],
-            },
-            {
                 docs: ['Sends the metric to the telemetry service'],
                 name: 'emit',
                 returnType: 'void',
@@ -310,7 +301,7 @@ function generateMetricRecorder(metadataType: TypeAliasDeclarationStructure): In
                 returnType: 'U',
                 parameters: [{
                         name: 'fn',
-                        type: `(span: this) => U`,
+                        type: `(span: Span<T>) => U`,
                 }],
             }
         ],
@@ -406,10 +397,30 @@ function generateFile(telemetryJson: MetricDefinitionRoot, dest: string) {
         kind: StructureKind.TypeAlias,
     }
 
+    const span: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: 'Span',
+        isExported: true,
+        typeParameters: [{ name: 'T' }],
+        methods: [
+            {
+                name: 'record',
+                parameters: [
+                    {
+                        name: 'data',
+                        type: 'Partial<T>',
+                    },
+                ],
+                returnType: 'this',
+            }
+        ],
+    }
+
     const definitions = generateDefinitions(telemetryJson.metrics)
     const recorder = generateMetricRecorder(metadataType)
     file.addVariableStatement(definitions)
     file.addTypeAlias(metadataType)
+    file.addInterface(span)
     file.addInterface(recorder)
     file.addClass(generateTelemetryHelper(recorder, telemetryJson.metrics))
 

--- a/telemetry/vscode/test/resources/generatorOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOutput.ts
@@ -125,14 +125,16 @@ export const definitions: Record<string, MetricDefinition> = {
 
 export type Metadata<T extends MetricBase> = Partial<Omit<T, keyof MetricBase> | Partial<Pick<MetricBase, 'awsRegion'>>>
 
+export interface Span<T> {
+    record(data: Partial<T>): this
+}
+
 export interface Metric<T extends MetricBase = MetricBase> {
     readonly name: string
-    /** Adds data to the metric which is preserved for the remainder of the execution context */
-    record(data: Metadata<T>): void
     /** Sends the metric to the telemetry service */
     emit(data?: T): void
     /** Executes a callback, automatically sending the metric after completion */
-    run<U>(fn: (span: this) => U): U
+    run<U>(fn: (span: Span<T>) => U): U
 }
 
 export abstract class TelemetryBase {

--- a/telemetry/vscode/test/resources/generatorOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOutput.ts
@@ -125,6 +125,7 @@ export const definitions: Record<string, MetricDefinition> = {
 
 export type Metadata<T extends MetricBase> = Partial<Omit<T, keyof MetricBase> | Partial<Pick<MetricBase, 'awsRegion'>>>
 
+/** Represents a telemetry span for tracking and recording metric data. */
 export interface Span<T> {
     record(data: Partial<T>): this
 }

--- a/telemetry/vscode/test/resources/generatorOverrideOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOverrideOutput.ts
@@ -96,14 +96,16 @@ export const definitions: Record<string, MetricDefinition> = {
 
 export type Metadata<T extends MetricBase> = Partial<Omit<T, keyof MetricBase> | Partial<Pick<MetricBase, 'awsRegion'>>>
 
+export interface Span<T> {
+    record(data: Partial<T>): this
+}
+
 export interface Metric<T extends MetricBase = MetricBase> {
     readonly name: string
-    /** Adds data to the metric which is preserved for the remainder of the execution context */
-    record(data: Metadata<T>): void
     /** Sends the metric to the telemetry service */
     emit(data?: T): void
     /** Executes a callback, automatically sending the metric after completion */
-    run<U>(fn: (span: this) => U): U
+    run<U>(fn: (span: Span<T>) => U): U
 }
 
 export abstract class TelemetryBase {

--- a/telemetry/vscode/test/resources/generatorOverrideOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOverrideOutput.ts
@@ -96,6 +96,7 @@ export const definitions: Record<string, MetricDefinition> = {
 
 export type Metadata<T extends MetricBase> = Partial<Omit<T, keyof MetricBase> | Partial<Pick<MetricBase, 'awsRegion'>>>
 
+/** Represents a telemetry span for tracking and recording metric data. */
 export interface Span<T> {
     record(data: Partial<T>): this
 }


### PR DESCRIPTION
## Problem
In vscode `telemetry.foo.record` is confusing to partner teams and has a couple of misuses in our codebase

## Solution
We're modifying vscodes telemetry generation to only allow records on a span, instead of on `telemetry.foo.record`.

This means the following will be available
```
telemetry.foo.run(span => {
    span.record( {someInformation: 5})
})
```

but `telemetry.foo.record` will not.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
