### PR TITLE
Model all `int` as `Long` in JetBrains generation

### DIFF
--- a/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryParser.kt
+++ b/telemetry/jetbrains/src/main/kotlin/software/aws/toolkits/telemetry/generator/TelemetryParser.kt
@@ -18,7 +18,7 @@ enum class MetricMetadataTypes(@get:JsonValue val type: String) {
         override fun kotlinType(): TypeName = com.squareup.kotlinpoet.STRING
     },
     INT("int") {
-        override fun kotlinType(): TypeName = com.squareup.kotlinpoet.INT
+        override fun kotlinType(): TypeName = com.squareup.kotlinpoet.LONG
     },
     DOUBLE("double") {
         override fun kotlinType(): TypeName = com.squareup.kotlinpoet.DOUBLE

--- a/telemetry/jetbrains/src/test/resources/generatesWithNormalInput/output/software/aws/toolkits/telemetry/LambdaTelemetry.kt
+++ b/telemetry/jetbrains/src/test/resources/generatesWithNormalInput/output/software/aws/toolkits/telemetry/LambdaTelemetry.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.project.Project
 import java.time.Instant
 import kotlin.Boolean
 import kotlin.Double
-import kotlin.Int
+import kotlin.Long
 import kotlin.String
 import kotlin.Suppress
 import software.amazon.awssdk.services.toolkittelemetry.model.Unit
@@ -174,7 +174,7 @@ public object LambdaTelemetry {
     public fun remoteinvoke(
         project: Project?,
         lambdaRuntime: LambdaRuntime? = null,
-        inttype: Int,
+        inttype: Long,
         duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
@@ -203,7 +203,7 @@ public object LambdaTelemetry {
     public fun remoteinvoke(
         connectionSettings: ConnectionSettings? = null,
         lambdaRuntime: LambdaRuntime? = null,
-        inttype: Int,
+        inttype: Long,
         duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,
@@ -232,7 +232,7 @@ public object LambdaTelemetry {
     public fun remoteinvoke(
         metadata: MetricEventMetadata,
         lambdaRuntime: LambdaRuntime? = null,
-        inttype: Int,
+        inttype: Long,
         duration: Double? = null,
         passive: Boolean = false,
         `value`: Double = 1.0,


### PR DESCRIPTION
Service allows `int` to be 64-bit, so generate these as `Long` for consistency across products

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
