### PR TITLE
fix: mark aws_extensionUninstalled as passive

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2713,6 +2713,7 @@
         {
             "name": "aws_extensionUninstalled",
             "description": "An extension in uninstalled",
+            "passive": true,
             "metadata": []
         },
         {


### PR DESCRIPTION
mark aws_extensionUninstalled as passive

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
