### PR TITLE
telemetry: cwsprChatUserIntent

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2021,6 +2021,10 @@
                 {
                     "type": "cwsprChatMessageId",
                     "required": true
+                },
+                {
+                    "type": "cwsprChatUserIntent",
+                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -990,6 +990,11 @@
             "description": "Unique identifier for each message in an conversation"
         },
         {
+            "name": "cwsprChatTotalCodeBlocks",
+            "type": "int",
+            "description": "Total number of code blocks inside a message in the conversation."
+        },
+        {
             "name": "cwsprChatUserIntent",
             "type": "string",
             "allowedValues": [
@@ -1003,11 +1008,6 @@
                 "generateUnitTests"
             ],
             "description": "Explict user intent associated with a chat message"
-        },
-        {
-            "name": "cwsprChatTotalCodeBlocks",
-            "type": "int",
-            "description": "Total number of code blocks inside a message in the conversation."
         },
         {
             "name": "databaseCredentials",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -990,6 +990,21 @@
             "description": "Unique identifier for each message in an conversation"
         },
         {
+            "name": "cwsprChatUserIntent",
+            "type": "string",
+            "allowedValues": [
+                "suggestAlternateImplementation",
+                "applyCommonBestPractices",
+                "improveCode",
+                "showExample",
+                "citeSources",
+                "explainLineByLine",
+                "explainCodeSelection",
+                "generateUnitTests"
+            ],
+            "description": "Explict user intent associated with a chat message"
+        },
+        {
             "name": "cwsprChatTotalCodeBlocks",
             "type": "int",
             "description": "Total number of code blocks inside a message in the conversation."


### PR DESCRIPTION
## Problem
Plugins telemetry data should now include the user intent as part of message interaction

## Solution
Modify common definition to include user intent

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
