### PR TITLE
Add authType to loginWithBrowser metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -133,6 +133,17 @@
             "description": "Status of the an auth connection."
         },
         {
+            "name": "authType",
+            "type": "string",
+            "allowedValues": [
+                "PKCE",
+                "DeviceCode",
+                "IAM",
+                "Unknown"
+            ],
+            "description": "The type of auth flow used for signing in"
+        },
+        {
             "name": "awsAccount",
             "type": "string",
             "description": "AWS account ID associated with a metric.\n- \"n/a\" if credentials are not available.\n- \"not-set\" if credentials are not selected.\n- \"invalid\" if account ID cannot be obtained."
@@ -1726,17 +1737,6 @@
             "name": "xrayEnabled",
             "type": "boolean",
             "description": "Whether or not AWS X-Ray is enabled"
-        },
-        {
-            "name": "authType",
-            "type": "string",
-            "allowedValues": [
-                "PKCE",
-                "DeviceCode",
-                "IAM",
-                "Unknown"
-            ],
-            "description": "The type of auth flow used for signing in"
         }
     ],
     "metrics": [
@@ -2825,6 +2825,10 @@
             "description": "Extension navigated the user to a web browser to perform/complete the login process.",
             "metadata": [
                 {
+                    "type": "authType",
+                    "required": false
+                },
+                {
                     "type": "credentialSourceId",
                     "required": false
                 },
@@ -2856,10 +2860,6 @@
                 },
                 {
                     "type": "ssoRegistrationExpiresAt",
-                    "required": false
-                },
-                {
-                    "type": "authType",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1726,6 +1726,17 @@
             "name": "xrayEnabled",
             "type": "boolean",
             "description": "Whether or not AWS X-Ray is enabled"
+        },
+        {
+            "name": "authType",
+            "type": "string",
+            "allowedValues": [
+                "PKCE",
+                "DeviceCode",
+                "IAM",
+                "Unknown"
+            ],
+            "description": "The type of auth flow used for signing in"
         }
     ],
     "metrics": [
@@ -2845,6 +2856,10 @@
                 },
                 {
                     "type": "ssoRegistrationExpiresAt",
+                    "required": false
+                },
+                {
+                    "type": "authType",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem
Users can signin with the device code or PKCE flow
## Solution
This metric adds the type of auth flow/token flow to the aws_loginWithBroswer metric
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
