### PR TITLE
Add properties that describe credentials to auth_userState

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2679,7 +2679,15 @@
                     "required": true
                 },
                 {
+                    "type": "credentialSourceId",
+                    "required": false
+                },
+                {
                     "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "credentialType",
                     "required": false
                 },
                 {
@@ -6834,18 +6842,16 @@
             ],
             "passive": true
         },
-
         {
             "name": "toolkit_trackScenario",
             "description": "Generic metric for tracking arbitrary scenarios that are not yet formalized into a full metric.",
             "unit": "Count",
             "metadata": [
-               
                 {
                     "type": "amazonqConversationId",
                     "required": true
                 },
-                 {
+                {
                     "type": "count"
                 },
                 {


### PR DESCRIPTION

This change adds optional fields to auth_userState that describe the credential type and backing source. This change supports an upcoming change to the VS Toolkit.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
