### PR TITLE
Add featureId to auth_userState

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2702,6 +2702,10 @@
                     "required": false
                 },
                 {
+                    "type": "featureId",
+                    "required": false
+                },
+                {
                     "type": "source",
                     "required": true
                 },


### PR DESCRIPTION
This change adds an optional field to auth_userState that indicates which feature is being referred to. This change supports an upcoming change to the VS Toolkit.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
