### PR TITLE
telemetry: Adding cwsprChatProgrammingLanguage 

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1022,6 +1022,11 @@
             "description": "Explict user intent associated with a chat message"
         },
         {
+            "name": "cwsprChatProgrammingLanguage",
+            "type": "string",
+            "description": "Programming language associated with the message"
+        },
+        {
             "name": "databaseCredentials",
             "type": "string",
             "allowedValues": [
@@ -2056,6 +2061,10 @@
                 },
                 {
                     "type": "cwsprChatUserIntent",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProgrammingLanguage",
                     "required": false
                 }
             ]


### PR DESCRIPTION

## Problem
- There is existing `cwsprChatProgrammingLanguage` param used in different events with telemetry override in both IDE's but trying to initialize this in common.
## Solution
- Adding `cwsprChatProgrammingLanguage` param to `amazonq_interactWithMessage` event in `commonDefination.json`
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
