### PR TITLE
telemetry: add `remoteWorkspace` connect type for ec2. 

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1131,7 +1131,8 @@
                 "remoteDesktop",
                 "ssh",
                 "scp",
-                "ssm"
+                "ssm", 
+                "remoteWorkspace"
             ],
             "description": "Ways to connect to an EC2 Instance"
         },


### PR DESCRIPTION
## Problem
Part of the work here: https://github.com/aws/aws-toolkit-vscode/pull/3723
## Solution
See PR above. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
