### PR TITLE
telemetry(amazonq): add fields for SQL conversions

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -330,6 +330,23 @@
             ]
         },
         {
+            "name": "codeTransformSQLSourceDBAllowed",
+            "type": "string",
+            "description": "Allowed DBs to transform from",
+            "allowedValues": [
+                "ORACLE"
+            ]
+        },
+        {
+            "name": "codeTransformSQLTargetDBAllowed",
+            "type": "string",
+            "description": "Allowed DBs to transform to",
+            "allowedValues": [
+                "AURORA_POSTGRESQL",
+                "RDS_POSTGRESQL"
+            ]
+        },
+        {
             "name": "codeTransformJobId",
             "type": "string",
             "description": "The ID of the job currently running"
@@ -4041,6 +4058,14 @@
                 },
                 {
                     "type": "codeTransformJavaTargetVersionsAllowed",
+                    "required": false
+                },
+                {
+                    "type": "codeTransformSQLSourceDBAllowed",
+                    "required": false
+                },
+                {
+                    "type": "codeTransformSQLTargetDBAllowed",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -430,23 +430,6 @@
             "description": "Represents the IDE session from which users start the transformation process"
         },
         {
-            "name": "codeTransformSQLSourceDBAllowed",
-            "type": "string",
-            "description": "Allowed DBs to transform from",
-            "allowedValues": [
-                "ORACLE"
-            ]
-        },
-        {
-            "name": "codeTransformSQLTargetDBAllowed",
-            "type": "string",
-            "description": "Allowed DBs to transform to",
-            "allowedValues": [
-                "AURORA_POSTGRESQL",
-                "RDS_POSTGRESQL"
-            ]
-        },
-        {
             "name": "codeTransformStartSrcComponents",
             "type": "string",
             "description": "Names of components that can start a transformation",
@@ -1654,6 +1637,11 @@
             "name": "source",
             "type": "string",
             "description": "The source of the operation"
+        },
+        {
+            "name": "target",
+            "type": "string",
+            "description": "The target of the operation"
         },
         {
             "name": "sourceFacetType",
@@ -4069,20 +4057,20 @@
                     "required": true
                 },
                 {
-                    "type": "codeTransformSQLSourceDBAllowed",
-                    "required": false
-                },
-                {
-                    "type": "codeTransformSQLTargetDBAllowed",
-                    "required": false
-                },
-                {
                     "type": "reason",
                     "required": false
                 },
                 {
                     "type": "result",
                     "required": true
+                },
+                {
+                    "type": "source",
+                    "required": false
+                },
+                {
+                    "type": "target",
+                    "required": false
                 },
                 {
                     "type": "userChoice",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -330,23 +330,6 @@
             ]
         },
         {
-            "name": "codeTransformSQLSourceDBAllowed",
-            "type": "string",
-            "description": "Allowed DBs to transform from",
-            "allowedValues": [
-                "ORACLE"
-            ]
-        },
-        {
-            "name": "codeTransformSQLTargetDBAllowed",
-            "type": "string",
-            "description": "Allowed DBs to transform to",
-            "allowedValues": [
-                "AURORA_POSTGRESQL",
-                "RDS_POSTGRESQL"
-            ]
-        },
-        {
             "name": "codeTransformJobId",
             "type": "string",
             "description": "The ID of the job currently running"
@@ -445,6 +428,23 @@
             "name": "codeTransformSessionId",
             "type": "string",
             "description": "Represents the IDE session from which users start the transformation process"
+        },
+        {
+            "name": "codeTransformSQLSourceDBAllowed",
+            "type": "string",
+            "description": "Allowed DBs to transform from",
+            "allowedValues": [
+                "ORACLE"
+            ]
+        },
+        {
+            "name": "codeTransformSQLTargetDBAllowed",
+            "type": "string",
+            "description": "Allowed DBs to transform to",
+            "allowedValues": [
+                "AURORA_POSTGRESQL",
+                "RDS_POSTGRESQL"
+            ]
         },
         {
             "name": "codeTransformStartSrcComponents",
@@ -4061,20 +4061,20 @@
                     "required": false
                 },
                 {
-                    "type": "codeTransformSQLSourceDBAllowed",
-                    "required": false
-                },
-                {
-                    "type": "codeTransformSQLTargetDBAllowed",
-                    "required": false
-                },
-                {
                     "type": "codeTransformProjectId",
                     "required": false
                 },
                 {
                     "type": "codeTransformSessionId",
                     "required": true
+                },
+                {
+                    "type": "codeTransformSQLSourceDBAllowed",
+                    "required": false
+                },
+                {
+                    "type": "codeTransformSQLTargetDBAllowed",
+                    "required": false
                 },
                 {
                     "type": "reason",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1639,11 +1639,6 @@
             "description": "The source of the operation"
         },
         {
-            "name": "target",
-            "type": "string",
-            "description": "The target of the operation"
-        },
-        {
             "name": "sourceFacetType",
             "type": "string",
             "description": "Resource subtype of connection start"
@@ -1685,6 +1680,11 @@
                 "AllResources",
                 "CodeOnly"
             ]
+        },
+        {
+            "name": "target",
+            "type": "string",
+            "description": "The target of the operation"
         },
         {
             "name": "templateName",


### PR DESCRIPTION
## Problem

Need telemetry for our upcoming feature which performs SQL conversions.

## Solution

Add source and target DBs allowed to an existing `submitSelection` metric.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
