### PR TITLE
telemetry: Metrics for amazonq unit test generation

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1713,7 +1713,7 @@
         {
             "name": "isSupportedLanguage",
             "type": "boolean",
-            "description": "supported language"
+            "description": "Indicate if the language is supported"
         },
         {
             "name": "syncedResources",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1736,6 +1736,11 @@
             "description": "Date/time that an SSO client registration expires."
         },
         {
+            "name": "step",
+            "type": "string",
+            "description": "Indicates the stage at which a user interface click action was performed." 
+        },
+        {
             "name": "successCount",
             "type": "int",
             "description": "The number of successful operations"

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1433,6 +1433,11 @@
             "description": "The Lambda Package type of the function"
         },
         {
+            "name": "language",
+            "type": "string",
+            "description": "Language used for the project."
+        },
+        {
             "name": "latencyOfClientSideBuild",
             "type": "int",
             "description": "Time from start to end of Client-side build."
@@ -1441,11 +1446,6 @@
             "name": "latencyOfGeneratingTests",
             "type": "int",
             "description": "Time from start to end of Generating unit tests"
-        },
-        {
-            "name": "language",
-            "type": "string",
-            "description": "Language used for the project."
         },
         {
             "name": "linesOfCodeGenerated",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2350,6 +2350,10 @@
                     "required": false
                 },
                 {
+                    "type": "numberOfBuildPassed",
+                    "required": false
+                },
+                {
                     "type": "numberOfUnitTestCasesAccepted",
                     "required": false
                 },
@@ -2362,10 +2366,6 @@
                 },
                 {
                     "type": "testGenerationJobGroupName",
-                    "required": false
-                },
-                {
-                    "type": "numberOfBuildPassed",
                     "required": false
                 },
                 {
@@ -2471,15 +2471,15 @@
                     "required": false
                 },
                 {
-                    "type": "userEnteredPromptMessage"
-                },
-                {
                     "type": "unitTestGenerationBuildPayloadBytes",
                     "required": false
                 },
                 {
                     "type": "unitTestGenerationBuildZipFileBytes",
                     "required": false
+                },
+                {
+                    "type": "userEnteredPromptMessage"
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1513,14 +1513,14 @@
             "description": "Number of build succeeded in unit test generation build loop"
         },
         {
-            "name": "numberOfUnitTestCasesGenerated",
-            "type": "int",
-            "description": "Number of unit test cases generated"
-        },
-        {
             "name": "numberOfUnitTestCasesAccepted",
             "type": "int",
             "description": "Number of unit test cases accepted"
+        },
+        {
+            "name": "numberOfUnitTestCasesGenerated",
+            "type": "int",
+            "description": "Number of unit test cases generated"
         },
         {
             "name": "oldVersion",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -179,6 +179,16 @@
             "description": "The amount of time required for the build to complete (in seconds)."
         },
         {
+            "name": "buildStatus",
+            "type": "string",
+            "allowedValues": [
+                "SUCCESS",
+                "FAILED",
+                "CANCELLED"
+            ],
+            "description": "The amount of time required for the build to complete (in seconds)."
+        },
+        {
             "name": "buildSystemVersion",
             "type": "string",
             "description": "The build system version on the user's machine"
@@ -1413,9 +1423,39 @@
             "description": "The Lambda Package type of the function"
         },
         {
+            "name": "latencyOfClientSideBuild",
+            "type": "int",
+            "description": "Time from start to end of Client-side build."
+        },
+        {
+            "name": "latencyOfGeneratingTests",
+            "type": "int",
+            "description": "Time from start to end of Generating unit tests"
+        },
+        {
             "name": "language",
             "type": "string",
             "description": "Language used for the project."
+        },
+        {
+            "name": "linesOfCodeGenerated",
+            "type": "int",
+            "description": "Number of lines of code generated"
+        },
+        {
+            "name": "linesOfCodeAccepted",
+            "type": "int",
+            "description": "Number of lines of code accepted"
+        },
+        {
+            "name": "charsOfCodeGenerated",
+            "type": "int",
+            "description": "Number of characters of code generated"
+        },
+        {
+            "name": "charsOfCodeAccepted",
+            "type": "int",
+            "description": "Number of characters of code accepted"
         },
         {
             "name": "loadFileTime",
@@ -1456,6 +1496,31 @@
             "name": "numAttempts",
             "type": "int",
             "description": "Number of generations before the user accepted or rejected"
+        },
+        {
+            "name": "numberOfBuildExecuted",
+            "type": "int",
+            "description": "Number of build executed in unit test generation build loop"
+        },
+        {
+            "name": "numberOfBuildFailed",
+            "type": "int",
+            "description": "Number of build failures in unit test generation build loop"
+        },
+        {
+            "name": "numberOfBuildPassed",
+            "type": "int",
+            "description": "Number of build succeeded in unit test generation build loop"
+        },
+        {
+            "name": "numberOfUnitTestCasesGenerated",
+            "type": "int",
+            "description": "Number of unit test cases generated"
+        },
+        {
+            "name": "numberOfUnitTestCasesAccepted",
+            "type": "int",
+            "description": "Number of unit test cases accepted"
         },
         {
             "name": "oldVersion",
@@ -1676,6 +1741,11 @@
             "description": "The number of successful operations"
         },
         {
+            "name": "supportedLanguage",
+            "type": "boolean",
+            "description": "supported language"
+        },
+        {
             "name": "syncedResources",
             "type": "string",
             "description": "Describes which parts of an application (that we know of) were synced to the cloud. \"Code\" resources follow the SAM spec: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-sync.html",
@@ -1693,6 +1763,16 @@
             "name": "templateName",
             "type": "string",
             "description": "Generic name of a template"
+        },
+        {
+            "name": "testGenerationJobGroupName",
+            "type": "string",
+            "description": "Unit test generation job group name"
+        },
+        {
+            "name": "testGenerationJobId",
+            "type": "string",
+            "description": "Unit test generation job id"
         },
         {
             "name": "toolId",
@@ -1731,6 +1811,21 @@
             "name": "userChoice",
             "type": "string",
             "description": "User selection from a predefined menu (not user-provided input). See also `action`."
+        },
+        {
+            "name": "unitTestGenerationBuildPayloadBytes",
+            "type": "int",
+            "description": "The uncompressed payload size in bytes of the source files in customer project context sent for unit test generation"
+        },
+        {
+            "name": "unitTestGenerationBuildZipFileBytes",
+            "type": "int",
+            "description": "The compressed payload size of source files in bytes of customer project context sent for unit test generation"
+        },
+        {
+            "name": "userEnteredPromptMessage",
+            "type": "boolean",
+            "description": "True if user enter prompt message as input else false"
         },
         {
             "name": "userId",
@@ -2211,6 +2306,175 @@
                 {
                     "type": "result",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_unitTestGeneration",
+            "description": "Client side metrics of AmazonQ Unit Test Generation",
+            "metadata": [
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProgrammingLanguage"
+                },
+                {
+                    "type": "supportedLanguage"
+                },
+                {
+                    "type": "userEnteredPromptMessage"
+                },
+               {
+                    "type": "testGenerationJobGroupName",
+                    "required": false
+                },
+                {
+                    "type": "linesOfCodeAccepted",
+                    "required": false
+                },
+                {
+                    "type": "linesOfCodeGenerated",
+                    "required": false
+                },
+                {
+                    "type": "charsOfCodeAccepted",
+                    "required": false
+                },
+                {
+                    "type": "charsOfCodeGenerated",
+                    "required": false
+                },
+                {
+                    "type": "numberOfUnitTestCasesAccepted",
+                    "required": false
+                },
+                {
+                    "type": "numberOfUnitTestCasesGenerated",
+                    "required": false
+                },
+                {
+                    "type": "numberOfBuildExecuted",
+                    "required": false
+                },
+                {
+                    "type": "numberOfBuildFailed",
+                    "required": false
+                },
+                {
+                    "type": "numberOfBuildPassed",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_utg_generateTests",
+            "description": "Client side invocation of the AmazonQ Unit Test Generation",
+            "metadata": [
+                {
+                    "type": "artifactsUploadDuration",
+                    "required": false
+                },
+                {
+                    "type": "charsOfCodeGenerated",
+                    "required": false
+                },
+               {
+                    "type": "charsOfCodeAccepted",
+                    "required": false
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProgrammingLanguage"
+                },
+                {
+                    "type": "latencyOfGeneratingTests",
+                    "required": false
+                },
+                {
+                    "type": "linesOfCodeAccepted",
+                    "required": false
+                },
+                {
+                    "type": "linesOfCodeGenerated",
+                    "required": false
+                },
+                {
+                    "type": "numberOfUnitTestCasesAccepted",
+                    "required": false
+                },
+                {
+                    "type": "numberOfUnitTestCasesGenerated",
+                    "required": false
+                },
+                {
+                    "type": "source",
+                    "required": false
+                },
+                {
+                    "type": "supportedLanguage"
+                },
+                {
+                    "type": "testGenerationJobGroupName",
+                    "required": false
+                },
+                {
+                    "type": "testGenerationJobId", 
+                    "required": false
+                },
+                {
+                    "type": "userEnteredPromptMessage"
+                },
+                {
+                    "type": "unitTestGenerationBuildPayloadBytes",
+                    "required": false
+                },
+                {
+                    "type": "unitTestGenerationBuildZipFileBytes",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_utg_buildLoop",
+            "description": "Client side invocation of the AmazonQ Unit Test Generation build loop",
+            "metadata": [
+                {
+                    "type": "buildStatus",
+                    "required": false
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProgrammingLanguage"
+                },
+                {
+                    "type": "latencyOfClientSideBuild",
+                    "required": false
+                },
+                {
+                    "type": "source",
+                    "required": false
+                },
+                {
+                    "type": "supportedLanguage"
+                },
+                {
+                    "type": "testGenerationJobGroupName",
+                    "required": false
+                },
+                {
+                    "type": "testGenerationJobId",
+                    "required": false
+                },
+                {
+                    "type": "userEnteredPromptMessage"
                 }
             ]
         },
@@ -6997,6 +7261,10 @@
             "metadata": [
                 {
                     "type": "elementId"
+                },
+                {
+                    "type": "step",
+                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -215,16 +215,6 @@
             "description": "Boolean value of whether or not a Cfn parameter file is provided."
         },
         {
-            "name": "charsOfCodeAccepted",
-            "type": "int",
-            "description": "Number of characters of code accepted"
-        },
-        {
-            "name": "charsOfCodeGenerated",
-            "type": "int",
-            "description": "Number of characters of code generated"
-        },
-        {
             "name": "checkType",
             "type": "string",
             "allowedValues": [
@@ -1304,6 +1294,11 @@
             "description": "Application framework being used"
         },
         {
+            "name": "generatedCharactersCount",
+            "type": "int",
+            "description": "Number of characters of code generated"
+        },
+        {
             "name": "generatedCount",
             "type": "int",
             "description": "The number of generated cases"
@@ -1451,16 +1446,6 @@
             "name": "language",
             "type": "string",
             "description": "Language used for the project."
-        },
-        {
-            "name": "latencyOfClientSideBuild",
-            "type": "int",
-            "description": "Time from start to end of Client-side build."
-        },
-        {
-            "name": "latencyOfGeneratingTests",
-            "type": "int",
-            "description": "Time from start to end of Generating unit tests"
         },
         {
             "name": "loadFileTime",
@@ -2283,15 +2268,11 @@
                     "required": false
                 },
                 {
-                    "type": "acceptedLinesCount",
+                    "type": "cwsprChatAcceptedCharactersLength",
                     "required": false
                 },
                 {
-                    "type": "charsOfCodeAccepted",
-                    "required": false
-                },
-                {
-                    "type": "charsOfCodeGenerated",
+                    "type": "cwsprChatAcceptedNumberOfLines",
                     "required": false
                 },
                 {
@@ -2307,6 +2288,10 @@
                 },
                 {
                     "type": "failedCount",
+                    "required": false
+                },
+                {
+                    "type": "generatedCharactersCount",
                     "required": false
                 },
                 {
@@ -2381,10 +2366,6 @@
                     "required": false
                 },
                 {
-                    "type": "acceptedLinesCount",
-                    "required": false
-                },
-                {
                     "type": "artifactsUploadDuration",
                     "required": false
                 },
@@ -2397,14 +2378,6 @@
                     "required": false
                 },
                 {
-                    "type": "charsOfCodeAccepted",
-                    "required": false
-                },
-                {
-                    "type": "charsOfCodeGenerated",
-                    "required": false
-                },
-                {
                     "type": "codewhispererEndToEndLatency",
                     "required": false
                 },
@@ -2413,7 +2386,19 @@
                     "required": false
                 },
                 {
+                    "type": "cwsprChatAcceptedCharactersLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatAcceptedNumberOfLines",
+                    "required": false
+                },
+                {
                     "type": "cwsprChatProgrammingLanguage"
+                },
+                {
+                    "type": "generatedCharactersCount",
+                    "required": false
                 },
                 {
                     "type": "generatedCount",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2337,19 +2337,19 @@
                     "required": false
                 },
                 {
-                    "type": "numberOfUnitTestCasesAccepted",
-                    "required": false
-                },
-                {
-                    "type": "numberOfUnitTestCasesGenerated",
-                    "required": false
-                },
-                {
                     "type": "numberOfBuildExecuted",
                     "required": false
                 },
                 {
                     "type": "numberOfBuildFailed",
+                    "required": false
+                },
+                {
+                    "type": "numberOfUnitTestCasesAccepted",
+                    "required": false
+                },
+                {
+                    "type": "numberOfUnitTestCasesGenerated",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -184,6 +184,16 @@
             "description": "The amount of time required for the build to complete (in seconds)."
         },
         {
+            "name": "buildPayloadBytes",
+            "type": "int",
+            "description": "The uncompressed payload size in bytes of the source files in customer project context"
+        },
+        {
+            "name": "buildZipFileBytes",
+            "type": "int",
+            "description": "The compressed payload size of source files in bytes of customer project context sent"
+        },
+        {
             "name": "buildSystemVersion",
             "type": "string",
             "description": "The build system version on the user's machine"
@@ -1453,16 +1463,6 @@
             "description": "Time from start to end of Generating unit tests"
         },
         {
-            "name": "linesOfCodeAccepted",
-            "type": "int",
-            "description": "Number of lines of code accepted"
-        },
-        {
-            "name": "linesOfCodeGenerated",
-            "type": "int",
-            "description": "Number of lines of code generated"
-        },
-        {
             "name": "loadFileTime",
             "type": "int",
             "description": "Time from opening Composer to loading the file"
@@ -1726,7 +1726,7 @@
             "description": "The number of successful operations"
         },
         {
-            "name": "supportedLanguage",
+            "name": "isSupportedLanguage",
             "type": "boolean",
             "description": "supported language"
         },
@@ -1750,16 +1750,6 @@
             "description": "Generic name of a template"
         },
         {
-            "name": "testGenerationJobGroupName",
-            "type": "string",
-            "description": "Unit test generation job group name"
-        },
-        {
-            "name": "testGenerationJobId",
-            "type": "string",
-            "description": "Unit test generation job id"
-        },
-        {
             "name": "toolId",
             "type": "string",
             "description": "The tool being installed",
@@ -1781,16 +1771,6 @@
             "name": "traceId",
             "type": "string",
             "description": "Unique identifier for the trace (a set of events) this metric belongs to"
-        },
-        {
-            "name": "unitTestGenerationBuildPayloadBytes",
-            "type": "int",
-            "description": "The uncompressed payload size in bytes of the source files in customer project context sent for unit test generation"
-        },
-        {
-            "name": "unitTestGenerationBuildZipFileBytes",
-            "type": "int",
-            "description": "The compressed payload size of source files in bytes of customer project context sent for unit test generation"
         },
         {
             "name": "update",
@@ -2303,6 +2283,10 @@
                     "required": false
                 },
                 {
+                    "type": "acceptedLinesCount",
+                    "required": false
+                },
+                {
                     "type": "charsOfCodeAccepted",
                     "required": false
                 },
@@ -2330,22 +2314,18 @@
                     "required": false
                 },
                 {
-                    "type": "linesOfCodeAccepted",
+                    "type": "generatedLinesCount",
                     "required": false
                 },
                 {
-                    "type": "linesOfCodeGenerated",
+                    "type": "isSupportedLanguage"
+                },
+                {
+                    "type": "jobGroup",
                     "required": false
                 },
                 {
                     "type": "successCount",
-                    "required": false
-                },
-                {
-                    "type": "supportedLanguage"
-                },
-                {
-                    "type": "testGenerationJobGroupName",
                     "required": false
                 },
                 {
@@ -2358,6 +2338,10 @@
             "description": "Client side invocation of the AmazonQ Unit Test Generation build loop",
             "metadata": [
                 {
+                    "type": "codewhispererEndToEndLatency",
+                    "required": false
+                },
+                {
                     "type": "credentialStartUrl",
                     "required": false
                 },
@@ -2365,7 +2349,14 @@
                     "type": "cwsprChatProgrammingLanguage"
                 },
                 {
-                    "type": "latencyOfClientSideBuild",
+                    "type": "isSupportedLanguage"
+                },
+                {
+                    "type": "jobGroup",
+                    "required": false
+                },
+                {
+                    "type": "jobId",
                     "required": false
                 },
                 {
@@ -2374,17 +2365,6 @@
                 },
                 {
                     "type": "source",
-                    "required": false
-                },
-                {
-                    "type": "supportedLanguage"
-                },
-                {
-                    "type": "testGenerationJobGroupName",
-                    "required": false
-                },
-                {
-                    "type": "testGenerationJobId",
                     "required": false
                 },
                 {
@@ -2401,7 +2381,19 @@
                     "required": false
                 },
                 {
+                    "type": "acceptedLinesCount",
+                    "required": false
+                },
+                {
                     "type": "artifactsUploadDuration",
+                    "required": false
+                },
+                {
+                    "type": "buildPayloadBytes",
+                    "required": false
+                },
+                {
+                    "type": "buildZipFileBytes",
                     "required": false
                 },
                 {
@@ -2410,6 +2402,10 @@
                 },
                 {
                     "type": "charsOfCodeGenerated",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererEndToEndLatency",
                     "required": false
                 },
                 {
@@ -2424,38 +2420,22 @@
                     "required": false
                 },
                 {
-                    "type": "latencyOfGeneratingTests",
+                    "type": "generatedLinesCount",
                     "required": false
                 },
                 {
-                    "type": "linesOfCodeAccepted",
+                    "type": "isSupportedLanguage"
+                },
+                {
+                    "type": "jobGroup",
                     "required": false
                 },
                 {
-                    "type": "linesOfCodeGenerated",
+                    "type": "jobId", 
                     "required": false
                 },
                 {
                     "type": "source",
-                    "required": false
-                },
-                {
-                    "type": "supportedLanguage"
-                },
-                {
-                    "type": "testGenerationJobGroupName",
-                    "required": false
-                },
-                {
-                    "type": "testGenerationJobId", 
-                    "required": false
-                },
-                {
-                    "type": "unitTestGenerationBuildPayloadBytes",
-                    "required": false
-                },
-                {
-                    "type": "unitTestGenerationBuildZipFileBytes",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,6 +1,11 @@
 {
     "types": [
         {
+            "name": "acceptedCount",
+            "type": "int",
+            "description": "The number of accepted cases"
+        },
+        {
             "name": "action",
             "type": "string",
             "description": "Name of an action that was taken, displayed, etc. See also `userChoice`."
@@ -176,16 +181,6 @@
         {
             "name": "buildDuration",
             "type": "int",
-            "description": "The amount of time required for the build to complete (in seconds)."
-        },
-        {
-            "name": "buildStatus",
-            "type": "string",
-            "allowedValues": [
-                "SUCCESS",
-                "FAILED",
-                "CANCELLED"
-            ],
             "description": "The amount of time required for the build to complete (in seconds)."
         },
         {
@@ -1228,6 +1223,11 @@
             "description": "The name of the EventBridge Schema used in the operation"
         },
         {
+            "name": "executedCount",
+            "type": "int",
+            "description": "The number of executed operations"
+        },
+        {
             "name": "experimentId",
             "type": "string",
             "description": "The id of the experiment being activated or deactivated"
@@ -1292,6 +1292,11 @@
             "name": "framework",
             "type": "string",
             "description": "Application framework being used"
+        },
+        {
+            "name": "generatedCount",
+            "type": "int",
+            "description": "The number of generated cases"
         },
         {
             "name": "generateFailure",
@@ -1496,31 +1501,6 @@
             "name": "numAttempts",
             "type": "int",
             "description": "Number of generations before the user accepted or rejected"
-        },
-        {
-            "name": "numberOfBuildExecuted",
-            "type": "int",
-            "description": "Number of build executed in unit test generation build loop"
-        },
-        {
-            "name": "numberOfBuildFailed",
-            "type": "int",
-            "description": "Number of build failures in unit test generation build loop"
-        },
-        {
-            "name": "numberOfBuildPassed",
-            "type": "int",
-            "description": "Number of build succeeded in unit test generation build loop"
-        },
-        {
-            "name": "numberOfUnitTestCasesAccepted",
-            "type": "int",
-            "description": "Number of unit test cases accepted"
-        },
-        {
-            "name": "numberOfUnitTestCasesGenerated",
-            "type": "int",
-            "description": "Number of unit test cases generated"
         },
         {
             "name": "oldVersion",
@@ -2319,6 +2299,10 @@
             "description": "Client side metrics of AmazonQ Unit Test Generation",
             "metadata": [
                 {
+                    "type": "acceptedCount",
+                    "required": false
+                },
+                {
                     "type": "charsOfCodeAccepted",
                     "required": false
                 },
@@ -2334,6 +2318,18 @@
                     "type": "cwsprChatProgrammingLanguage"
                 },
                 {
+                    "type": "executedCount",
+                    "required": false
+                },
+                {
+                    "type": "failedCount",
+                    "required": false
+                },
+                {
+                    "type": "generatedCount",
+                    "required": false
+                },
+                {
                     "type": "linesOfCodeAccepted",
                     "required": false
                 },
@@ -2342,23 +2338,7 @@
                     "required": false
                 },
                 {
-                    "type": "numberOfBuildExecuted",
-                    "required": false
-                },
-                {
-                    "type": "numberOfBuildFailed",
-                    "required": false
-                },
-                {
-                    "type": "numberOfBuildPassed",
-                    "required": false
-                },
-                {
-                    "type": "numberOfUnitTestCasesAccepted",
-                    "required": false
-                },
-                {
-                    "type": "numberOfUnitTestCasesGenerated",
+                    "type": "successCount",
                     "required": false
                 },
                 {
@@ -2378,10 +2358,6 @@
             "description": "Client side invocation of the AmazonQ Unit Test Generation build loop",
             "metadata": [
                 {
-                    "type": "buildStatus",
-                    "required": false
-                },
-                {
                     "type": "credentialStartUrl",
                     "required": false
                 },
@@ -2390,6 +2366,10 @@
                 },
                 {
                     "type": "latencyOfClientSideBuild",
+                    "required": false
+                },
+                {
+                    "type": "result",
                     "required": false
                 },
                 {
@@ -2417,6 +2397,10 @@
             "description": "Client side invocation of the AmazonQ Unit Test Generation",
             "metadata": [
                 {
+                    "type": "acceptedCount",
+                    "required": false
+                },
+                {
                     "type": "artifactsUploadDuration",
                     "required": false
                 },
@@ -2436,6 +2420,10 @@
                     "type": "cwsprChatProgrammingLanguage"
                 },
                 {
+                    "type": "generatedCount",
+                    "required": false
+                },
+                {
                     "type": "latencyOfGeneratingTests",
                     "required": false
                 },
@@ -2445,14 +2433,6 @@
                 },
                 {
                     "type": "linesOfCodeGenerated",
-                    "required": false
-                },
-                {
-                    "type": "numberOfUnitTestCasesAccepted",
-                    "required": false
-                },
-                {
-                    "type": "numberOfUnitTestCasesGenerated",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1448,14 +1448,14 @@
             "description": "Time from start to end of Generating unit tests"
         },
         {
-            "name": "linesOfCodeGenerated",
-            "type": "int",
-            "description": "Number of lines of code generated"
-        },
-        {
             "name": "linesOfCodeAccepted",
             "type": "int",
             "description": "Number of lines of code accepted"
+        },
+        {
+            "name": "linesOfCodeGenerated",
+            "type": "int",
+            "description": "Number of lines of code generated"
         },
         {
             "name": "loadFileTime",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1803,6 +1803,16 @@
             "description": "Unique identifier for the trace (a set of events) this metric belongs to"
         },
         {
+            "name": "unitTestGenerationBuildPayloadBytes",
+            "type": "int",
+            "description": "The uncompressed payload size in bytes of the source files in customer project context sent for unit test generation"
+        },
+        {
+            "name": "unitTestGenerationBuildZipFileBytes",
+            "type": "int",
+            "description": "The compressed payload size of source files in bytes of customer project context sent for unit test generation"
+        },
+        {
             "name": "update",
             "type": "boolean",
             "description": "If the operation was an update or not"
@@ -1816,16 +1826,6 @@
             "name": "userChoice",
             "type": "string",
             "description": "User selection from a predefined menu (not user-provided input). See also `action`."
-        },
-        {
-            "name": "unitTestGenerationBuildPayloadBytes",
-            "type": "int",
-            "description": "The uncompressed payload size in bytes of the source files in customer project context sent for unit test generation"
-        },
-        {
-            "name": "unitTestGenerationBuildZipFileBytes",
-            "type": "int",
-            "description": "The compressed payload size of source files in bytes of customer project context sent for unit test generation"
         },
         {
             "name": "userEnteredPromptMessage",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -210,6 +210,16 @@
             "description": "Boolean value of whether or not a Cfn parameter file is provided."
         },
         {
+            "name": "charsOfCodeAccepted",
+            "type": "int",
+            "description": "Number of characters of code accepted"
+        },
+        {
+            "name": "charsOfCodeGenerated",
+            "type": "int",
+            "description": "Number of characters of code generated"
+        },
+        {
             "name": "checkType",
             "type": "string",
             "allowedValues": [
@@ -1446,16 +1456,6 @@
             "name": "linesOfCodeAccepted",
             "type": "int",
             "description": "Number of lines of code accepted"
-        },
-        {
-            "name": "charsOfCodeGenerated",
-            "type": "int",
-            "description": "Number of characters of code generated"
-        },
-        {
-            "name": "charsOfCodeAccepted",
-            "type": "int",
-            "description": "Number of characters of code accepted"
         },
         {
             "name": "loadFileTime",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2314,6 +2314,14 @@
             "description": "Client side metrics of AmazonQ Unit Test Generation",
             "metadata": [
                 {
+                    "type": "charsOfCodeAccepted",
+                    "required": false
+                },
+                {
+                    "type": "charsOfCodeGenerated",
+                    "required": false
+                },
+                {
                     "type": "credentialStartUrl",
                     "required": false
                 },
@@ -2321,29 +2329,11 @@
                     "type": "cwsprChatProgrammingLanguage"
                 },
                 {
-                    "type": "supportedLanguage"
-                },
-                {
-                    "type": "userEnteredPromptMessage"
-                },
-               {
-                    "type": "testGenerationJobGroupName",
-                    "required": false
-                },
-                {
                     "type": "linesOfCodeAccepted",
                     "required": false
                 },
                 {
                     "type": "linesOfCodeGenerated",
-                    "required": false
-                },
-                {
-                    "type": "charsOfCodeAccepted",
-                    "required": false
-                },
-                {
-                    "type": "charsOfCodeGenerated",
                     "required": false
                 },
                 {
@@ -2363,8 +2353,57 @@
                     "required": false
                 },
                 {
+                    "type": "supportedLanguage"
+                },
+                {
+                    "type": "testGenerationJobGroupName",
+                    "required": false
+                },
+                {
                     "type": "numberOfBuildPassed",
                     "required": false
+                },
+                {
+                    "type": "userEnteredPromptMessage"
+                }
+            ]
+        },
+        {
+            "name": "amazonq_utg_buildLoop",
+            "description": "Client side invocation of the AmazonQ Unit Test Generation build loop",
+            "metadata": [
+                {
+                    "type": "buildStatus",
+                    "required": false
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProgrammingLanguage"
+                },
+                {
+                    "type": "latencyOfClientSideBuild",
+                    "required": false
+                },
+                {
+                    "type": "source",
+                    "required": false
+                },
+                {
+                    "type": "supportedLanguage"
+                },
+                {
+                    "type": "testGenerationJobGroupName",
+                    "required": false
+                },
+                {
+                    "type": "testGenerationJobId",
+                    "required": false
+                },
+                {
+                    "type": "userEnteredPromptMessage"
                 }
             ]
         },
@@ -2377,11 +2416,11 @@
                     "required": false
                 },
                 {
-                    "type": "charsOfCodeGenerated",
+                    "type": "charsOfCodeAccepted",
                     "required": false
                 },
-               {
-                    "type": "charsOfCodeAccepted",
+                {
+                    "type": "charsOfCodeGenerated",
                     "required": false
                 },
                 {
@@ -2436,45 +2475,6 @@
                 {
                     "type": "unitTestGenerationBuildZipFileBytes",
                     "required": false
-                }
-            ]
-        },
-        {
-            "name": "amazonq_utg_buildLoop",
-            "description": "Client side invocation of the AmazonQ Unit Test Generation build loop",
-            "metadata": [
-                {
-                    "type": "buildStatus",
-                    "required": false
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "cwsprChatProgrammingLanguage"
-                },
-                {
-                    "type": "latencyOfClientSideBuild",
-                    "required": false
-                },
-                {
-                    "type": "source",
-                    "required": false
-                },
-                {
-                    "type": "supportedLanguage"
-                },
-                {
-                    "type": "testGenerationJobGroupName",
-                    "required": false
-                },
-                {
-                    "type": "testGenerationJobId",
-                    "required": false
-                },
-                {
-                    "type": "userEnteredPromptMessage"
                 }
             ]
         },


### PR DESCRIPTION
## Problem
- No metrics for amazonq unit test generation
## Solution
Planning to add 4 metrics for Unit test generation.
1. amazonq_unitTestGeneration(new)
2. amazonq_utg_generateTests(new)
3. amazonq_utg_buildLoop(new)
4. ui_click(existing)

- Planning to add a new optional field (step) to ui_click to get metrics on which stage user has clicked a button.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
