### PR TITLE
telemetry: Code Scan Issue Fix diff usage

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -265,7 +265,7 @@
                 "openDiff",
                 "insertAtCursor",
                 "copyDiff",
-                "quickFix"
+                "applyFix"
             ]
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,11 +1,6 @@
 {
     "types": [
         {
-            "name": "action",
-            "type": "string",
-            "description": "Name of an action that was taken, displayed, etc. See also `userChoice`."
-        },
-        {
             "name": "acceptedFixType",
             "type": "string",
             "description": "Captures the type of fix that was accepted",
@@ -14,6 +9,11 @@
                 "insertAtCursor",
                 "copyDiff"
             ]
+        },
+        {
+            "name": "action",
+            "type": "string",
+            "description": "Name of an action that was taken, displayed, etc. See also `userChoice`."
         },
         {
             "name": "amazonqCodeGenerationResult",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,7 +1,7 @@
 {
     "types": [
         {
-            "name": "acceptedFixType",
+            "name": "codeFixAction",
             "type": "string",
             "description": "Captures the type of fix that was accepted",
             "allowedValues": [

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -4413,6 +4413,10 @@
             "description": "User chose to utilise the diff of a code scan issue fix",
             "metadata": [
                 {
+                    "type": "acceptedFixType",
+                    "required": false
+                },
+                {
                     "type": "component"
                 },
                 {
@@ -4428,10 +4432,6 @@
                 },
                 {
                     "type": "variant",
-                    "required": false
-                },
-                {
-                    "type": "acceptedFixType",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,17 +1,6 @@
 {
     "types": [
         {
-            "name": "codeFixAction",
-            "type": "string",
-            "description": "Captures the type of fix that was accepted",
-            "allowedValues": [
-                "openDiff",
-                "insertAtCursor",
-                "copyDiff",
-                "quickFix"
-            ]
-        },
-        {
             "name": "action",
             "type": "string",
             "description": "Name of an action that was taken, displayed, etc. See also `userChoice`."
@@ -266,6 +255,17 @@
             "allowedValues": [
                 "remote",
                 "local"
+            ]
+        },
+        {
+            "name": "codeFixAction",
+            "type": "string",
+            "description": "Captures the type of fix that was accepted",
+            "allowedValues": [
+                "openDiff",
+                "insertAtCursor",
+                "copyDiff",
+                "quickFix"
             ]
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -6,6 +6,16 @@
             "description": "Name of an action that was taken, displayed, etc. See also `userChoice`."
         },
         {
+            "name": "acceptedFixType",
+            "type": "string",
+            "description": "Captures the type of fix that was accepted",
+            "allowedValues": [
+                "acceptDiff",
+                "insertAtCursor",
+                "copyDiff"
+            ]
+        },
+        {
             "name": "amazonqCodeGenerationResult",
             "type": "string",
             "description": "Captures if code generation result is Complete, Failed, etc."
@@ -4394,6 +4404,34 @@
                 },
                 {
                     "type": "variant",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "codewhisperer_codeScanIssueGenerateFixDiffUse",
+            "description": "User chose to utilise the diff of a code scan issue fix",
+            "metadata": [
+                {
+                    "type": "component"
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "detectorId"
+                },
+                {
+                    "type": "ruleId",
+                    "required": false
+                },
+                {
+                    "type": "variant",
+                    "required": false
+                },
+                {
+                    "type": "acceptedFixType",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -5,9 +5,10 @@
             "type": "string",
             "description": "Captures the type of fix that was accepted",
             "allowedValues": [
-                "acceptDiff",
+                "openDiff",
                 "insertAtCursor",
-                "copyDiff"
+                "copyDiff",
+                "quickFix"
             ]
         },
         {
@@ -4363,6 +4364,9 @@
             "description": "Called when a code scan issue suggested fix is applied",
             "metadata": [
                 {
+                    "type": "codeFixAction"
+                },
+                {
                     "type": "component"
                 },
                 {
@@ -4397,34 +4401,6 @@
                 },
                 {
                     "type": "findingId"
-                },
-                {
-                    "type": "ruleId",
-                    "required": false
-                },
-                {
-                    "type": "variant",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "codewhisperer_codeScanIssueGenerateFixDiffUse",
-            "description": "User chose to utilise the diff of a code scan issue fix",
-            "metadata": [
-                {
-                    "type": "acceptedFixType",
-                    "required": false
-                },
-                {
-                    "type": "component"
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                },
-                {
-                    "type": "detectorId"
                 },
                 {
                     "type": "ruleId",


### PR DESCRIPTION
## Problem
Need to record Telemetry when user is accepting code scan issue generated fix with three options of viewing code, inserting or copying it.

## Solution
- Added Telemetry event to record it.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
