### PR TITLE
telemetry(amazonq): use existing metadata field

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -471,11 +471,6 @@
             "description": "A unique upload ID for S3"
         },
         {
-            "name": "codeTransformValidationMetadata",
-            "type": "string",
-            "description": "A field for storing various validation metadata"
-        },
-        {
             "name": "codeTransformVCSViewerSrcComponents",
             "type": "string",
             "description": "Names of components that can initiate the diff viewer",
@@ -4187,7 +4182,7 @@
                     "required": true
                 },
                 {
-                    "type": "codeTransformValidationMetadata",
+                    "type": "codeTransformMetadata",
                     "required": false
                 },
                 {


### PR DESCRIPTION
## Problem

Use an existing metadata field instead of making a new one, as was done in an earlier PR.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
