### PR TITLE
telemetry: mark codeFixAction as optional

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -4373,7 +4373,8 @@
             "description": "Called when a code scan issue suggested fix is applied",
             "metadata": [
                 {
-                    "type": "codeFixAction"
+                    "type": "codeFixAction",
+                    "required": false
                 },
                 {
                     "type": "component"


### PR DESCRIPTION

## Problem
- `codeFixAction` in `codewhisperer_codeScanIssueApplyFix` event is marked as required.
## Solution
- Updating `codeFixAction` in `codewhisperer_codeScanIssueApplyFix` event.
- This change is related to this PR: https://github.com/aws/aws-toolkit-common/pull/907
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
