### PR TITLE
feat: add general latency metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -210,6 +210,11 @@
             "description": "User inputted check type to denote which custom check to run."
         },
         {
+            "name": "clientLatency",
+            "type": "double",
+            "description": "The time duration in milliseconds to process an action on the client side"
+        },
+        {
             "name": "cloudWatchLogsPresentation",
             "type": "string",
             "allowedValues": [
@@ -998,21 +1003,6 @@
             "description": "Identifies the entity within the message that user interacts with."
         },
         {
-            "name": "clientLatency",
-            "type": "double",
-            "description": "The time duration in milliseconds to process an action on the client side"
-        },
-        {
-            "name": "serverLatency",
-            "type": "double",
-            "description": "The time duration in milliseconds to finish a request to the server side"
-        },
-        {
-            "name": "e2eLatency",
-            "type": "double",
-            "description": "The time duration in milliseconds to complete an end to end flow"
-        },
-        {
             "name": "cwsprChatInteractionType",
             "allowedValues": [
                 "acceptDiff",
@@ -1154,13 +1144,18 @@
             "description": "The type of DynamoDB entity referenced by a metric or operation"
         },
         {
+            "name": "e2eLatency",
+            "type": "double",
+            "description": "The time duration in milliseconds to complete an end to end flow"
+        },
+        {
             "name": "ec2ConnectionType",
             "type": "string",
             "allowedValues": [
                 "remoteDesktop",
                 "ssh",
                 "scp",
-                "ssm", 
+                "ssm",
                 "remoteWorkspace"
             ],
             "description": "Ways to connect to an EC2 Instance"
@@ -1641,6 +1636,11 @@
                 "TypeScript3"
             ],
             "description": "Languages targeted by the schemas service"
+        },
+        {
+            "name": "serverLatency",
+            "type": "double",
+            "description": "The time duration in milliseconds to finish a request to the server side"
         },
         {
             "name": "serviceType",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -998,6 +998,21 @@
             "description": "Identifies the entity within the message that user interacts with."
         },
         {
+            "name": "clientLatency",
+            "type": "double",
+            "description": "The time duration in milliseconds to process an action on the client side"
+        },
+        {
+            "name": "serverLatency",
+            "type": "double",
+            "description": "The time duration in milliseconds to finish a request to the server side"
+        },
+        {
+            "name": "e2eLatency",
+            "type": "double",
+            "description": "The time duration in milliseconds to complete an end to end flow"
+        },
+        {
             "name": "cwsprChatInteractionType",
             "allowedValues": [
                 "acceptDiff",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -210,11 +210,6 @@
             "description": "User inputted check type to denote which custom check to run."
         },
         {
-            "name": "clientLatency",
-            "type": "double",
-            "description": "The time duration in milliseconds to process an action on the client side"
-        },
-        {
             "name": "cloudWatchLogsPresentation",
             "type": "string",
             "allowedValues": [
@@ -1144,11 +1139,6 @@
             "description": "The type of DynamoDB entity referenced by a metric or operation"
         },
         {
-            "name": "e2eLatency",
-            "type": "double",
-            "description": "The time duration in milliseconds to complete an end to end flow"
-        },
-        {
             "name": "ec2ConnectionType",
             "type": "string",
             "allowedValues": [
@@ -1499,6 +1489,21 @@
             "description": "Number of generation paths modified"
         },
         {
+            "name": "perfClientLatency",
+            "type": "double",
+            "description": "The time duration in milliseconds to process an action on the client side"
+        },
+        {
+            "name": "perfE2ELatency",
+            "type": "double",
+            "description": "The time duration in milliseconds to complete an end to end flow"
+        },
+        {
+            "name": "perfServerLatency",
+            "type": "double",
+            "description": "The time duration in milliseconds to finish a request to the server side"
+        },
+        {
             "name": "platform",
             "type": "string",
             "description": "Language-specific identification. Examples: v4.6.1, netcoreapp3.1, nodejs12.x. Not AWS Lambda specific. Allows for additional details when other fields are opaque, such as the Lambda runtime value 'provided'."
@@ -1636,11 +1641,6 @@
                 "TypeScript3"
             ],
             "description": "Languages targeted by the schemas service"
-        },
-        {
-            "name": "serverLatency",
-            "type": "double",
-            "description": "The time duration in milliseconds to finish a request to the server side"
         },
         {
             "name": "serviceType",


### PR DESCRIPTION
## Problem
- Soooooooooo many teams have specific latency metric fields and many are asking to add them for re-invent

## Solution
- De-dup a lot of them e.g. amazonqGenerateApproachLatency, amazonqGenerateCodeResponseLatency, amazonqEndOfTheConversationLatency, etc

## Other notes
- amazonq_approachInvoke would then have perfServerLatency instead of an individual amazonqGenerateApproachLatency field
- amazonq_codeGenerationInvoke would then have perfServerLatency instead of an individual amazonqGenerateCodeResponseLatency field
- amazonq_endChat would then have perfE2ELatency instead of an individual amazonqEndOfTheConversationLatency field

- In the future we can re-use the perfClientLatency metric for tracking the duration of different events that only happen in the client side (e.g. how long the client latency takes in the amazon q chat flow)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
