### PR TITLE
telemetry: Adding metrics for amazonq unit test generation

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -199,14 +199,14 @@
             "description": "The uncompressed payload size in bytes of the source files in customer project context"
         },
         {
-            "name": "buildZipFileBytes",
-            "type": "int",
-            "description": "The compressed payload size of source files in bytes of customer project context sent"
-        },
-        {
             "name": "buildSystemVersion",
             "type": "string",
             "description": "The build system version on the user's machine"
+        },
+        {
+            "name": "buildZipFileBytes",
+            "type": "int",
+            "description": "The compressed payload size of source files in bytes of customer project context sent"
         },
         {
             "name": "causedBy",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1456,6 +1456,16 @@
             "description": "Indicate if the language is supported"
         },
         {
+            "name": "jobGroup",
+            "type": "string",
+            "description": "Job group name used in the operation"
+        },
+        {
+            "name": "jobId",
+            "type": "string",
+            "description": "Job id used in the operation"
+        },
+        {
             "name": "lambdaArchitecture",
             "type": "string",
             "allowedValues": [

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -13,7 +13,7 @@
         {
             "name": "acceptedLinesCount",
             "type": "int",
-            "description": "The number of accepted suggestions"
+            "description": "The number of accepted lines of code"
         },
         {
             "name": "action",
@@ -1323,6 +1323,11 @@
             "name": "generatedCount",
             "type": "int",
             "description": "The number of generated cases"
+        },
+        {
+            "name": "generatedLinesCount",
+            "type": "int",
+            "description": "The number of generated lines of code"
         },
         {
             "name": "generateFailure",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1353,6 +1353,11 @@
             "description": "A time based filter was used"
         },
         {
+            "name": "hasUserPromptSupplied",
+            "type": "boolean",
+            "description": "True if user supplied prompt message as input else false"
+        },
+        {
             "name": "httpMethod",
             "type": "string",
             "description": "Any valid HTTP method (GET/HEAD/etc)"
@@ -1822,11 +1827,6 @@
             "name": "userChoice",
             "type": "string",
             "description": "User selection from a predefined menu (not user-provided input). See also `action`."
-        },
-        {
-            "name": "userEnteredPromptMessage",
-            "type": "boolean",
-            "description": "True if user enter prompt message as input else false"
         },
         {
             "name": "userId",
@@ -2354,6 +2354,9 @@
                     "required": false
                 },
                 {
+                    "type": "hasUserPromptSupplied"
+                },
+                {
                     "type": "isSupportedLanguage"
                 },
                 {
@@ -2363,9 +2366,6 @@
                 {
                     "type": "successCount",
                     "required": false
-                },
-                {
-                    "type": "userEnteredPromptMessage"
                 }
             ]
         },
@@ -2392,6 +2392,9 @@
                     "required": false
                 },
                 {
+                    "type": "hasUserPromptSupplied"
+                },
+                {
                     "type": "perfClientLatency",
                     "required": false
                 },
@@ -2402,9 +2405,6 @@
                 {
                     "type": "source",
                     "required": false
-                },
-                {
-                    "type": "userEnteredPromptMessage"
                 }
             ]
         },
@@ -2456,6 +2456,9 @@
                     "required": false
                 },
                 {
+                    "type": "hasUserPromptSupplied"
+                },
+                {
                     "type": "isSupportedLanguage"
                 },
                 {
@@ -2473,9 +2476,6 @@
                 {
                     "type": "source",
                     "required": false
-                },
-                {
-                    "type": "userEnteredPromptMessage"
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1,6 +1,21 @@
 {
     "types": [
         {
+            "name": "acceptedCharactersCount",
+            "type": "int",
+            "description": "The number of accepted characters"
+        },
+        {
+            "name": "acceptedCount",
+            "type": "int",
+            "description": "The number of accepted cases"
+        },
+        {
+            "name": "acceptedLinesCount",
+            "type": "int",
+            "description": "The number of accepted suggestions"
+        },
+        {
             "name": "action",
             "type": "string",
             "description": "Name of an action that was taken, displayed, etc. See also `userChoice`."
@@ -177,6 +192,16 @@
             "name": "buildDuration",
             "type": "int",
             "description": "The amount of time required for the build to complete (in seconds)."
+        },
+        {
+            "name": "buildPayloadBytes",
+            "type": "int",
+            "description": "The uncompressed payload size in bytes of the source files in customer project context"
+        },
+        {
+            "name": "buildZipFileBytes",
+            "type": "int",
+            "description": "The compressed payload size of source files in bytes of customer project context sent"
         },
         {
             "name": "buildSystemVersion",
@@ -1219,6 +1244,11 @@
             "description": "The name of the EventBridge Schema used in the operation"
         },
         {
+            "name": "executedCount",
+            "type": "int",
+            "description": "The number of executed operations"
+        },
+        {
             "name": "experimentId",
             "type": "string",
             "description": "The id of the experiment being activated or deactivated"
@@ -1283,6 +1313,16 @@
             "name": "framework",
             "type": "string",
             "description": "Application framework being used"
+        },
+        {
+            "name": "generatedCharactersCount",
+            "type": "int",
+            "description": "Number of characters of code generated"
+        },
+        {
+            "name": "generatedCount",
+            "type": "int",
+            "description": "The number of generated cases"
         },
         {
             "name": "generateFailure",
@@ -1404,6 +1444,11 @@
             "name": "isRetry",
             "type": "boolean",
             "description": "Whether or not the operation was a retry"
+        },
+        {
+            "name": "isSupportedLanguage",
+            "type": "boolean",
+            "description": "Indicate if the language is supported"
         },
         {
             "name": "lambdaArchitecture",
@@ -1697,6 +1742,11 @@
             "description": "Date/time that an SSO client registration expires."
         },
         {
+            "name": "step",
+            "type": "string",
+            "description": "Indicates the stage at which a user interface click action was performed." 
+        },
+        {
             "name": "successCount",
             "type": "int",
             "description": "The number of successful operations"
@@ -1757,6 +1807,11 @@
             "name": "userChoice",
             "type": "string",
             "description": "User selection from a predefined menu (not user-provided input). See also `action`."
+        },
+        {
+            "name": "userEnteredPromptMessage",
+            "type": "boolean",
+            "description": "True if user enter prompt message as input else false"
         },
         {
             "name": "userId",
@@ -2237,6 +2292,175 @@
                 {
                     "type": "result",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_unitTestGeneration",
+            "description": "Client side metrics of AmazonQ Unit Test Generation",
+            "metadata": [
+                {
+                    "type": "acceptedCharactersCount",
+                    "required": false
+                },
+                {
+                    "type": "acceptedCount",
+                    "required": false
+                },
+                {
+                    "type": "acceptedLinesCount",
+                    "required": false
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProgrammingLanguage"
+                },
+                {
+                    "type": "executedCount",
+                    "required": false
+                },
+                {
+                    "type": "failedCount",
+                    "required": false
+                },
+                {
+                    "type": "generatedCharactersCount",
+                    "required": false
+                },
+                {
+                    "type": "generatedCount",
+                    "required": false
+                },
+                {
+                    "type": "generatedLinesCount",
+                    "required": false
+                },
+                {
+                    "type": "isSupportedLanguage"
+                },
+                {
+                    "type": "jobGroup",
+                    "required": false
+                },
+                {
+                    "type": "successCount",
+                    "required": false
+                },
+                {
+                    "type": "userEnteredPromptMessage"
+                }
+            ]
+        },
+        {
+            "name": "amazonq_utg_buildLoop",
+            "description": "Client side invocation of the AmazonQ Unit Test Generation build loop",
+            "metadata": [
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProgrammingLanguage"
+                },
+                {
+                    "type": "isSupportedLanguage"
+                },
+                {
+                    "type": "jobGroup",
+                    "required": false
+                },
+                {
+                    "type": "jobId",
+                    "required": false
+                },
+                {
+                    "type": "perfClientLatency",
+                    "required": false
+                },
+                {
+                    "type": "result",
+                    "required": false
+                },
+                {
+                    "type": "source",
+                    "required": false
+                },
+                {
+                    "type": "userEnteredPromptMessage"
+                }
+            ]
+        },
+        {
+            "name": "amazonq_utg_generateTests",
+            "description": "Client side invocation of the AmazonQ Unit Test Generation",
+            "metadata": [
+                {
+                    "type": "acceptedCharactersCount",
+                    "required": false
+                },
+                {
+                    "type": "acceptedCount",
+                    "required": false
+                },
+                {
+                    "type": "acceptedLinesCount",
+                    "required": false
+                },
+                {
+                    "type": "artifactsUploadDuration",
+                    "required": false
+                },
+                {
+                    "type": "buildPayloadBytes",
+                    "required": false
+                },
+                {
+                    "type": "buildZipFileBytes",
+                    "required": false
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatProgrammingLanguage"
+                },
+                {
+                    "type": "generatedCharactersCount",
+                    "required": false
+                },
+                {
+                    "type": "generatedCount",
+                    "required": false
+                },
+                {
+                    "type": "generatedLinesCount",
+                    "required": false
+                },
+                {
+                    "type": "isSupportedLanguage"
+                },
+                {
+                    "type": "jobGroup",
+                    "required": false
+                },
+                {
+                    "type": "jobId", 
+                    "required": false
+                },
+                {
+                    "type": "perfClientLatency",
+                    "required": false
+                },
+                {
+                    "type": "source",
+                    "required": false
+                },
+                {
+                    "type": "userEnteredPromptMessage"
                 }
             ]
         },
@@ -7035,6 +7259,10 @@
             "metadata": [
                 {
                     "type": "elementId"
+                },
+                {
+                    "type": "step",
+                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2381,6 +2381,9 @@
                     "type": "cwsprChatProgrammingLanguage"
                 },
                 {
+                    "type": "hasUserPromptSupplied"
+                },
+                {
                     "type": "isSupportedLanguage"
                 },
                 {
@@ -2390,9 +2393,6 @@
                 {
                     "type": "jobId",
                     "required": false
-                },
-                {
-                    "type": "hasUserPromptSupplied"
                 },
                 {
                     "type": "perfClientLatency",


### PR DESCRIPTION
## Problem
- No metrics for amazonq unit test generation
## Solution
Planning to add 4 metrics for Unit test generation.
1. amazonq_unitTestGeneration(new)
2. amazonq_utg_generateTests(new)
3. amazonq_utg_buildLoop(new)
4. ui_click(existing)

- Planning to add a new optional field (step) to ui_click to get metrics on which stage user has clicked a button.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
