### PR TITLE
fix(cwl): Rename LiveTail metric definitions

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1265,6 +1265,16 @@
             "description": "Filename extension (examples: .txt, .yml, .yaml, .asl.yaml, ...), or empty string if the filename does not contain dot (.) between two chars."
         },
         {
+            "name": "filterType",
+            "type": "string",
+            "allowedValues": [
+                "all",
+                "prefix",
+                "specific"
+            ],
+            "description": "Type of filter applied"
+        },
+        {
             "name": "findingId",
             "type": "string",
             "description": "The id of a security finding from a code scan"
@@ -1296,11 +1306,6 @@
             "name": "hasChatAuth",
             "type": "boolean",
             "description": "Whether the user has access to CodeWhisperer Chat"
-        },
-        {
-            "name": "hasLogEventFilterPattern",
-            "type": "boolean",
-            "description": "If LogEvent filter pattern is applied"
         },
         {
             "name": "hasTextFilter",
@@ -1442,11 +1447,6 @@
             "name": "locale",
             "type": "string",
             "description": "User locale. Examples: en-US, en-GB, etc."
-        },
-        {
-            "name": "logStreamFilterType",
-            "type": "string",
-            "description": "Type of LogStream filter applied to session"
         },
         {
             "name": "metricId",
@@ -3646,6 +3646,48 @@
             ]
         },
         {
+            "name": "cloudwatchlogs_startLiveTail",
+            "description": "When user starts a new LiveTail command",
+            "metadata": [
+                {
+                    "type": "filterType",
+                    "required": false
+                },
+                {
+                    "type": "hasTextFilter",
+                    "required": false
+                },
+                {
+                    "type": "result"
+                },
+                {
+                    "type": "sessionAlreadyStarted",
+                    "required": true
+                },
+                {
+                    "type": "source",
+                    "required": true
+                }
+            ]
+        },
+        {
+            "name": "cloudwatchlogs_stopLiveTail",
+            "description": "When user stops a liveTailSession",
+            "metadata": [
+                {
+                    "type": "duration",
+                    "required": true
+                },
+                {
+                    "type": "result"
+                },
+                {
+                    "type": "source",
+                    "required": true
+                }
+            ]
+        },
+        {
             "name": "cloudwatchlogs_tailStream",
             "description": "Tail stream off/on",
             "metadata": [
@@ -5007,48 +5049,6 @@
                 {
                     "type": "reason",
                     "required": false
-                }
-            ]
-        },
-        {
-            "name": "cwlLiveTail_Start",
-            "description": "When user starts a new LiveTail command",
-            "metadata": [
-                {
-                    "type": "hasLogEventFilterPattern",
-                    "required": false
-                },
-                {
-                    "type": "logStreamFilterType",
-                    "required": false
-                },
-                {
-                    "type": "result"
-                },
-                {
-                    "type": "sessionAlreadyStarted",
-                    "required": true
-                },
-                {
-                    "type": "source",
-                    "required": true
-                }
-            ]
-        },
-        {
-            "name": "cwlLiveTail_Stop",
-            "description": "When user stops a liveTailSession",
-            "metadata": [
-                {
-                    "type": "duration",
-                    "required": true
-                },
-                {
-                    "type": "result"
-                },
-                {
-                    "type": "source",
-                    "required": true
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3658,9 +3658,6 @@
                     "required": false
                 },
                 {
-                    "type": "result"
-                },
-                {
                     "type": "sessionAlreadyStarted",
                     "required": true
                 },
@@ -3674,13 +3671,6 @@
             "name": "cloudwatchlogs_stopLiveTail",
             "description": "When user stops a liveTailSession",
             "metadata": [
-                {
-                    "type": "duration",
-                    "required": true
-                },
-                {
-                    "type": "result"
-                },
                 {
                     "type": "source",
                     "required": true


### PR DESCRIPTION
## Problem
Addresses feedback on https://github.com/aws/aws-toolkit-common/pull/916.

## Solution
* Uses `hasTextFilter` instead of defining a new `hasLogEventFilterPattern` property
* Defines a more generic `filterPattern` type, as an enum that supports logStream filter type strings
* renames metrics to `cloudwatchlogs_startLiveTail` and `cloudwatchlogs_stopLiveTail`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
