### PR TITLE
refactor(amazonq): remove duplicate metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3961,20 +3961,6 @@
             ]
         },
         {
-            "name": "codeTransform_jobIsStartedFromChatPrompt",
-            "description": "The user initiates a transform job from the Amazon Q chat prompt.",
-            "metadata": [
-                {
-                    "type": "codeTransformSessionId",
-                    "required": true
-                },
-                {
-                    "type": "credentialSourceId",
-                    "required": false
-                }
-            ]
-        },
-        {
             "name": "codeTransform_jobStart",
             "description": "Transform job started for uploaded project.",
             "metadata": [


### PR DESCRIPTION
## Problem

`codeTransform_jobIsStartedFromChatPrompt` is unused, and we already have `codeTransform_initiateTransform`

## Solution

Remove

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
