### PR TITLE
telemetry(amazonq): remove global arguments from amazonq_utgGenerateTests metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2381,10 +2381,6 @@
                 },
                 {
                     "type": "result"
-                },
-                {
-                    "type": "source",
-                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2380,14 +2380,6 @@
                     "required": false
                 },
                 {
-                    "type": "reason",
-                    "required": false
-                },
-                {
-                    "type": "reasonDesc",
-                    "required": false
-                },
-                {
                     "type": "result"
                 },
                 {


### PR DESCRIPTION
## Problem
amazonq_utgGenerateTests metric has fields that are already global arguments

## Solution
remove reason and reasonDesc types from amazonq_utgGenerateTests metric

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
