### PR TITLE
telemetry(amazonq): add job ID to more metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3915,6 +3915,10 @@
                     "required": true
                 },
                 {
+                    "type": "codeTransformJobId",
+                    "required": false
+                },
+                {
                     "type": "codeTransformRuntimeError",
                     "required": false
                 },
@@ -4097,6 +4101,10 @@
                     "required": false
                 },
                 {
+                    "type": "codeTransformJobId",
+                    "required": false
+                },
+                {
                     "type": "codeTransformProjectId",
                     "required": false
                 },
@@ -4168,6 +4176,10 @@
                 {
                     "type": "codeTransformDependenciesCopied",
                     "required": true
+                },
+                {
+                    "type": "codeTransformJobId",
+                    "required": false
                 },
                 {
                     "type": "codeTransformRunTimeLatency",


### PR DESCRIPTION
## Problem

It can be difficult to track what happens to transformation jobs without the job ID attached to each metric.

## Solution

Add it where missing.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
