### PR TITLE
telemetry(common): add new value to saveType metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1688,7 +1688,8 @@
             "type": "string",
             "allowedValues": [
                 "MANUAL_SAVE",
-                "AUTO_SAVE"
+                "AUTO_SAVE",
+                "AUTO_SYNC"
             ],
             "description": "Type of save executed"
         },


### PR DESCRIPTION
## Problem
`saveType` metric (used for threat composer and step functions integrations) does not have an value for auto-sync event (i.e. when the content from webview is auto-synced with local file)

## Solution

Add `AUTO_SYNC` value to the metric

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
