### PR TITLE
telemetry(amazonq): add value for java downgrade attempt

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -421,9 +421,8 @@
             "allowedValues": [
                 "NoPom",
                 "NoJavaProject",
-                "MixedLanguages",
                 "UnsupportedJavaVersion",
-                "ProjectJDKDiffersFromBuildSystemJDK",
+                "JavaDowngradeAttempt",
                 "UnsupportedBuildSystem",
                 "EmptyProject",
                 "NonSsoLogin",


### PR DESCRIPTION
## Problem

1) Two of the allowed values for the `codeTransformPreValidationError` field were unused.
2) We need a way to represent when user tries to downgrade from 21->17 since that is not supported.

## Solution

Modify `allowedValues` accordingly.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
