### PR TITLE
telemetry(amazonq): remove unused metric and field

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -486,17 +486,6 @@
             "description": "A unique upload ID for S3"
         },
         {
-            "name": "codeTransformVCSViewerSrcComponents",
-            "type": "string",
-            "description": "Names of components that can initiate the diff viewer",
-            "allowedValues": [
-                "chat",
-                "toastNotification",
-                "treeView",
-                "treeViewHeader"
-            ]
-        },
-        {
             "name": "codewhispererAcceptedTokens",
             "type": "int",
             "description": "The number of tokens that are accepted and not modified by the user"
@@ -4330,36 +4319,6 @@
                 {
                     "type": "codeTransformSessionId",
                     "required": true
-                }
-            ]
-        },
-        {
-            "name": "codeTransform_viewArtifact",
-            "description": "User clicks to view downloaded artifact.",
-            "metadata": [
-                {
-                    "type": "codeTransformArtifactType",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformJobId",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformSessionId",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformStatus",
-                    "required": true
-                },
-                {
-                    "type": "codeTransformVCSViewerSrcComponents",
-                    "required": true
-                },
-                {
-                    "type": "userChoice",
-                    "required": false
                 }
             ]
         },


### PR DESCRIPTION
## Problem

`codeTransform_viewArtifact` and its `codeTransformVCSViewerSrcComponents` field are unused.

## Solution

Remove them.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
