### PR TITLE
Amazon Q Test Generation: Adding telemetry metric for /test for files outside of workspace.

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1434,6 +1434,11 @@
             "description": "True if user selected code snippet as input else false"
         },
         {
+            "name": "isFileInWorkspace",
+            "type": "boolean",
+            "description": "Indicate if the file is in the current workspace."
+        },
+        {
             "name": "isReAuth",
             "type": "boolean",
             "description": "If this was performed as part of the reauthentication flow."
@@ -2352,6 +2357,9 @@
                 {
                     "type": "isCodeBlockSelected",
                     "required": false
+                },
+                {
+                    "type": "isFileInWorkspace"
                 },
                 {
                     "type": "isSupportedLanguage"


### PR DESCRIPTION
## Problem
/test does not run workflow for external files in a workspace instead runs conversation APIs to produce tests for user in chat. 

## Solution
Adding metric to check whether target file in editor is a file in active workspace.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
