### PR TITLE
telemetry(amazonq): add fields for code fix events

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -159,6 +159,11 @@
             "description": "The type of auth flow used for signing in"
         },
         {
+            "name": "autoDetected",
+            "type": "boolean",
+            "description": "Whether the code issue was detected by auto-review"
+        },
+        {
             "name": "awsAccount",
             "type": "string",
             "description": "AWS account ID associated with a metric.\n- \"n/a\" if credentials are not available.\n- \"not-set\" if credentials are not selected.\n- \"invalid\" if account ID cannot be obtained."
@@ -1286,6 +1291,11 @@
             "name": "findingsCount",
             "type": "int",
             "description": "Number of findings discovered after executing IAM Policy Checks"
+        },
+        {
+            "name": "fixGenerated",
+            "type": "boolean",
+            "description": "Whether a code fix request was able to generate a fix"
         },
         {
             "name": "fps",
@@ -4464,7 +4474,15 @@
             "description": "Called when a code scan issue suggested fix is applied",
             "metadata": [
                 {
+                    "type": "autoDetected",
+                    "required": false
+                },
+                {
                     "type": "codeFixAction",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererCodeScanJobId",
                     "required": false
                 },
                 {
@@ -4491,6 +4509,14 @@
             "description": "Generated fix for a code scan issue. variant=refresh means the user chose to generate a fix again after one already exists.",
             "metadata": [
                 {
+                    "type": "autoDetected",
+                    "required": false
+                },
+                {
+                    "type": "codewhispererCodeScanJobId",
+                    "required": false
+                },
+                {
                     "type": "component"
                 },
                 {
@@ -4502,6 +4528,10 @@
                 },
                 {
                     "type": "findingId"
+                },
+                {
+                    "type": "fixGenerated",
+                    "required": false
                 },
                 {
                     "type": "ruleId",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1293,11 +1293,6 @@
             "description": "Number of findings discovered after executing IAM Policy Checks"
         },
         {
-            "name": "fixGenerated",
-            "type": "boolean",
-            "description": "Whether a code fix request was able to generate a fix"
-        },
-        {
             "name": "fps",
             "type": "int",
             "description": "Average frames per second"
@@ -4530,7 +4525,7 @@
                     "type": "findingId"
                 },
                 {
-                    "type": "fixGenerated",
+                    "type": "includesFix",
                     "required": false
                 },
                 {


### PR DESCRIPTION
## Problem

Need to understand:
- How many users are using fix feature from /review (not auto-review)
- How many fixes were generated/applied for each scanJob
- How many code fix requests were unable to generate a fix

## Solution

- Add flag `autoDetected` to be able to filter out auto-review findings
- Add flag `fixGenerated` to be able to see fixes that generated no fixes
- Add `codewhispererCodeScanJobId` to associate a fix action with a specific scan that produced the finding

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
