### PR TITLE
telemetry(AmazonQ): Adding amazonq_feedback event for feedback

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1426,6 +1426,15 @@
             "description": "User-selected time range type while starting an insights query"
         },
         {
+            "name": "interactionType",
+            "type": "string",
+            "description": "User can click on thumbs up / down or comment or give rating to share feedback.",
+            "allowedValues": [
+                "downvote",
+                "upvote"
+            ]
+        },
+        {
             "name": "invalidInputFields",
             "type": "string",
             "description": "Comma delimited list of input fields that user has invalid inputs typed. e.g. 'profileName,accessKey,startUrl'"
@@ -1873,15 +1882,6 @@
             "description": "A generic version metadata"
         },
         {
-            "name": "vote",
-            "type": "string",
-            "description": "User can click on thumbs up or thumbs down for feedback.",
-            "allowedValues": [
-                "downvote",
-                "upvote"
-            ]
-        },
-        {
             "name": "workflowToken",
             "type": "string",
             "description": "A token used for flow metrics to link calls together"
@@ -2155,7 +2155,7 @@
                     "type": "featureId"
                 },
                 {
-                    "type": "vote",
+                    "type": "interactionType",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1430,8 +1430,17 @@
             "type": "string",
             "description": "User interaction, especially for AI-related features.",
             "allowedValues": [
+                "acceptDiff",
+                "insertAtCursor",
+                "copySnippet",
+                "copy",
+                "clickLink",
+                "clickFollowUp",
+                "hoverReference",
+                "upvote",
                 "downvote",
-                "upvote"
+                "clickBodyLink",
+                "viewDiff"
             ]
         },
         {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1251,6 +1251,8 @@
             "description": "The id of the feature the user is interacting in. See also: `component`, `featureId`, `module`, `resourceType`.",
             "allowedValues": [
                 "amazonQ",
+                "amazonQTest",
+                "amazonQReview",
                 "awsExplorer",
                 "awsToolkit",
                 "codewhisperer",
@@ -1871,6 +1873,15 @@
             "description": "A generic version metadata"
         },
         {
+            "name": "vote",
+            "type": "string",
+            "description": "User can click on thumbs up or thumbs down for feedback.",
+            "allowedValues": [
+                "upvote",
+                "downvote"
+            ]
+        },
+        {
             "name": "workflowToken",
             "type": "string",
             "description": "A token used for flow metrics to link calls together"
@@ -1973,34 +1984,6 @@
                 },
                 {
                     "type": "result",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "amazonq_approachThumbsDown",
-            "description": "User clicked on the thumbs down button to say that they are unsatisfied",
-            "unit": "Count",
-            "metadata": [
-                {
-                    "type": "amazonqConversationId"
-                },
-                {
-                    "type": "credentialStartUrl",
-                    "required": false
-                }
-            ]
-        },
-        {
-            "name": "amazonq_approachThumbsUp",
-            "description": "User clicked on the thumbs up button, to mention that they are satisfied",
-            "unit": "Count",
-            "metadata": [
-                {
-                    "type": "amazonqConversationId"
-                },
-                {
-                    "type": "credentialStartUrl",
                     "required": false
                 }
             ]
@@ -2152,6 +2135,27 @@
                 },
                 {
                     "type": "credentialStartUrl",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_feedback",
+            "description": "When a user gives feedback using vote or comment or rating in the conversation",
+            "metadata": [
+                {
+                    "type": "amazonqConversationId",
+                    "required": false
+                },
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "featureId"
+                },
+                {
+                    "type": "vote",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1021,7 +1021,7 @@
                 "viewDiff"
             ],
             "type": "string",
-            "description": "Indicates the specific interaction type with a message in a conversation"
+            "description": "(Deprecated, use `interactionType` instead.) User interaction type, especially for AI-related features."
         },
         {
             "name": "cwsprChatMessageId",
@@ -1428,7 +1428,7 @@
         {
             "name": "interactionType",
             "type": "string",
-            "description": "User can click on thumbs up / down or comment or give rating to share feedback.",
+            "description": "User interaction, especially for AI-related features.",
             "allowedValues": [
                 "downvote",
                 "upvote"

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1877,8 +1877,8 @@
             "type": "string",
             "description": "User can click on thumbs up or thumbs down for feedback.",
             "allowedValues": [
-                "upvote",
-                "downvote"
+                "downvote",
+                "upvote"
             ]
         },
         {


### PR DESCRIPTION
## Problem
- Missing generic feedback event for AmazonQ.
## Solution
- Added generic`amazonq_feedback ` event for feedback for different features.
```
 {
            "name": "amazonq_feedback",
            "description": "When a user gives feedback using vote or comment or rating in the conversation",
            "metadata": [
                {
                    "type": "amazonqConversationId",
                    "required": false
                },
                {
                    "type": "credentialStartUrl",
                    "required": false
                },
                {
                    "type": "featureId"
                },
                {
                    "type": "interactionType",
                    "required": false
                }
            ]
        },
 ```
 
 - `featureId` can be amazonQTest/amazonQReview or any amazonQ Feature.
 - `interactionType` can be upvote/downvote or comment or rating.
 - This event can be expanded by adding additional fields like comment, rating according to the requirement.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
