### PR TITLE
telemetry: add `source` to common fields

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1782,7 +1782,7 @@
         {
             "name": "source",
             "type": "string",
-            "description": "The source of the operation"
+            "description": "The source of the operation. This answers 'who' caused/triggered the operation. Example: did an Auth signout happen because of some expiration or since the user explicitly clicked the signout button."
         },
         {
             "name": "sourceFacetType",

--- a/telemetry/vscode/src/generate.ts
+++ b/telemetry/vscode/src/generate.ts
@@ -136,6 +136,7 @@ const commonMetadata = [
     'requestId',
     'requestServiceType',
     'result',
+    'source',
 ] as const
 
 /**

--- a/telemetry/vscode/test/resources/generatorOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOutput.ts
@@ -30,6 +30,8 @@ export interface MetricBase {
     readonly requestServiceType?: string
     /** The result of the operation */
     readonly result?: Result
+    /** The source of the operation. This answers 'who' caused/triggered the operation. Example: did an Auth signout happen because of some expiration or since the user explicitly clicked the signout button. */
+    readonly source?: string
     /** A flag indicating that the metric was not caused by the user. */
     readonly passive?: boolean
     /** @deprecated Arbitrary "value" of the metric. */

--- a/telemetry/vscode/test/resources/generatorOverrideOutput.ts
+++ b/telemetry/vscode/test/resources/generatorOverrideOutput.ts
@@ -30,6 +30,8 @@ export interface MetricBase {
     readonly requestServiceType?: string
     /** The result of the operation */
     readonly result?: Result
+    /** The source of the operation. This answers 'who' caused/triggered the operation. Example: did an Auth signout happen because of some expiration or since the user explicitly clicked the signout button. */
+    readonly source?: string
     /** A flag indicating that the metric was not caused by the user. */
     readonly passive?: boolean
     /** @deprecated Arbitrary "value" of the metric. */


### PR DESCRIPTION
## Problem:

The `source` value has become a common pattern in our telemetry which answers "who" caused the metric event. For example if we had a function() to open a menu, there could be many different entrypoints that could call it.

Right now we have to add `source` to each metric that uses it, but this usage has increased for a lot of metrics.

## Solution:

- `source` will be a part of all metrics as an optional field.
- This has only been implemented for VSC.

## TODO

The other IDEs should consider following this pattern if not already.
**If all IDEs implement this then we can remove the explicit requirements of `source` in `commonDefinitions.json`**

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
