### PR TITLE
Add `source` to C# Telemetry Generator as a common field

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Core/DefinitionsBuilder.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Core/DefinitionsBuilder.cs
@@ -27,6 +27,7 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator.Core
         {
             "reason",
             "reasonDesc",
+            "source",
             "errorCode",
             "causedBy",
             "httpStatusCode",
@@ -439,6 +440,11 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Generator.Core
             var payloadReasonDescription = new CodeFieldReferenceExpression(payload, "ReasonDescription");
             tryStatements.Add(new CodeExpressionStatement(new CodeMethodInvokeExpression(datumAddData,
                 new CodePrimitiveExpression("reasonDesc"), payloadReasonDescription)));
+
+            // Generate: datum.AddMetadata("source", payload.Source);
+            var payloadSource = new CodeFieldReferenceExpression(payload, "Source");
+            tryStatements.Add(new CodeExpressionStatement(new CodeMethodInvokeExpression(datumAddData,
+                new CodePrimitiveExpression("source"), payloadSource)));
 
             // Generate: datum.AddMetadata("errorCode", payload.ErrorCode);
             var payloadErrorCode = new CodeFieldReferenceExpression(payload, "ErrorCode");

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/SampleData/Outcomes/sampleDefinitions-generated.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/SampleData/Outcomes/sampleDefinitions-generated.txt
@@ -58,6 +58,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -118,6 +119,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -178,6 +180,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -246,6 +249,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -314,6 +318,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -391,6 +396,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -451,6 +457,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/SampleData/Outcomes/sampleDefinitions-supplemental.txt
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events.Generator.Tests/SampleData/Outcomes/sampleDefinitions-supplemental.txt
@@ -58,6 +58,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -118,6 +119,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -178,6 +180,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -246,6 +249,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -314,6 +318,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -391,6 +396,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);
@@ -451,6 +457,7 @@ namespace Test
                 datum.AddMetadata("awsRegion", payload.AwsRegion);
                 datum.AddMetadata("reason", payload.Reason);
                 datum.AddMetadata("reasonDesc", payload.ReasonDescription);
+                datum.AddMetadata("source", payload.Source);
                 datum.AddMetadata("errorCode", payload.ErrorCode);
                 datum.AddMetadata("causedBy", payload.CausedBy);
                 datum.AddMetadata("httpStatusCode", payload.HttpStatusCode);

--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/BaseTelemetryEvent.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/Core/BaseTelemetryEvent.cs
@@ -39,6 +39,13 @@ namespace Amazon.AwsToolkit.Telemetry.Events.Core
         public string ReasonDescription;
 
         /// <summary>
+        /// The source of the operation. This answers 'who' caused/triggered the operation.
+        /// Example: did an Auth signout happen because of some expiration or since the user
+        /// explicitly clicked the signout button.
+        /// </summary>
+        public string Source;
+
+        /// <summary>
         /// Optional - User-friendly error codes describing a failed operation
         /// This is often used in failure scenarios to provide additional details about why something failed.
         /// </summary>


### PR DESCRIPTION
Follow up to: https://github.com/aws/aws-toolkit-common/pull/977 but for VS/C#
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
