### PR TITLE
refactor: rename existing toolkit module metric names to new format 

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -7156,7 +7156,7 @@
         },
         {
             "name": "toolkit_moduleClose",
-            "description": "The user closed 'something' (specified by 'module'). Examples: a view, feature, resource, ...",
+            "description": "The module has closed/terminated. Use this when the module is done being used.",
             "metadata": [
                 {
                     "type": "module",
@@ -7166,8 +7166,8 @@
             "passive": true
         },
         {
-            "name": "toolkit_moduleInit",
-            "description": "The Toolkit has completed initialization for the specified module.",
+            "name": "toolkit_moduleLoad",
+            "description": "The module has loaded, i.e it has rendered/resolved/finished. Use this after `toolkit_moduleOpen` to indicate success.",
             "metadata": [
                 {
                     "type": "attempts",
@@ -7194,7 +7194,7 @@
         },
         {
             "name": "toolkit_moduleOpen",
-            "description": "User opened 'something' (specified by 'module'). Examples: a view, feature, resource, ...",
+            "description": "The opening of a module **started**. This does not imply it successfully finished, use `toolkit_moduleLoad` for that. The open/load separation exists because it may be difficult to capture then entire process in a single metric. A 'module' is a general term that represents things like: a view, feature, resource, ... ",
             "metadata": [
                 {
                     "type": "module",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -7060,6 +7060,44 @@
             ]
         },
         {
+            "name": "toolkit_didCloseModule",
+            "description": "The module has closed/terminated. Use this when the module is done being used.",
+            "metadata": [
+                {
+                    "type": "module",
+                    "required": true
+                }
+            ],
+            "passive": true
+        },
+        {
+            "name": "toolkit_didLoadModule",
+            "description": "The module has loaded, i.e it has rendered/resolved/finished. Use this after `toolkit_willOpenModule` to indicate success.",
+            "metadata": [
+                {
+                    "type": "attempts",
+                    "required": false
+                },
+                {
+                    "type": "duration",
+                    "required": false
+                },
+                {
+                    "type": "module",
+                    "required": true
+                },
+                {
+                    "type": "result",
+                    "required": true
+                },
+                {
+                    "type": "version",
+                    "required": false
+                }
+            ],
+            "passive": true
+        },
+        {
             "name": "toolkit_featureState",
             "description": "Represents the current enabled state of a feature. Used to track user journey through a feature. Emitted after feature-specific operations of interest in the Toolkit.",
             "metadata": [
@@ -7155,63 +7193,6 @@
             ]
         },
         {
-            "name": "toolkit_moduleClose",
-            "description": "The module has closed/terminated. Use this when the module is done being used.",
-            "metadata": [
-                {
-                    "type": "module",
-                    "required": true
-                }
-            ],
-            "passive": true
-        },
-        {
-            "name": "toolkit_moduleLoad",
-            "description": "The module has loaded, i.e it has rendered/resolved/finished. Use this after `toolkit_moduleOpen` to indicate success.",
-            "metadata": [
-                {
-                    "type": "attempts",
-                    "required": false
-                },
-                {
-                    "type": "duration",
-                    "required": false
-                },
-                {
-                    "type": "module",
-                    "required": true
-                },
-                {
-                    "type": "result",
-                    "required": true
-                },
-                {
-                    "type": "version",
-                    "required": false
-                }
-            ],
-            "passive": true
-        },
-        {
-            "name": "toolkit_moduleOpen",
-            "description": "The opening of a module **started**. This does not imply it successfully finished, use `toolkit_moduleLoad` for that. The open/load separation exists because it may be difficult to capture then entire process in a single metric. A 'module' is a general term that represents things like: a view, feature, resource, ... ",
-            "metadata": [
-                {
-                    "type": "module",
-                    "required": true
-                },
-                {
-                    "type": "result",
-                    "required": true
-                },
-                {
-                    "type": "source",
-                    "required": true
-                }
-            ],
-            "passive": true
-        },
-        {
             "name": "toolkit_showAction",
             "description": "Toolkit presented an action. `source` is the notification that produced the action. See also `toolkit_showNotification`.",
             "metadata": [
@@ -7290,6 +7271,25 @@
         {
             "name": "toolkit_viewLogs",
             "description": "View logs for the toolkit"
+        },
+        {
+            "name": "toolkit_willOpenModule",
+            "description": "The opening of a module **started**. This does not imply it successfully finished, use `toolkit_didLoadModule` for that. The open/load separation exists because it may be difficult to capture then entire process in a single metric. A 'module' is a general term that represents things like: a view, feature, resource, ... ",
+            "metadata": [
+                {
+                    "type": "module",
+                    "required": true
+                },
+                {
+                    "type": "result",
+                    "required": true
+                },
+                {
+                    "type": "source",
+                    "required": true
+                }
+            ],
+            "passive": true
         },
         {
             "name": "ui_click",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -7060,17 +7060,6 @@
             ]
         },
         {
-            "name": "toolkit_closeModule",
-            "description": "The user closed 'something' (specified by 'module'). Examples: a view, feature, resource, ...",
-            "metadata": [
-                {
-                    "type": "module",
-                    "required": true
-                }
-            ],
-            "passive": true
-        },
-        {
             "name": "toolkit_featureState",
             "description": "Represents the current enabled state of a feature. Used to track user journey through a feature. Emitted after feature-specific operations of interest in the Toolkit.",
             "metadata": [
@@ -7136,33 +7125,6 @@
             "passive": true
         },
         {
-            "name": "toolkit_initModule",
-            "description": "The Toolkit has completed initialization for the specified module.",
-            "metadata": [
-                {
-                    "type": "attempts",
-                    "required": false
-                },
-                {
-                    "type": "duration",
-                    "required": false
-                },
-                {
-                    "type": "module",
-                    "required": true
-                },
-                {
-                    "type": "result",
-                    "required": true
-                },
-                {
-                    "type": "version",
-                    "required": false
-                }
-            ],
-            "passive": true
-        },
-        {
             "name": "toolkit_invokeAction",
             "description": "User invoked an action. `source` is the notification that produced the action",
             "metadata": [
@@ -7193,7 +7155,45 @@
             ]
         },
         {
-            "name": "toolkit_openModule",
+            "name": "toolkit_moduleClose",
+            "description": "The user closed 'something' (specified by 'module'). Examples: a view, feature, resource, ...",
+            "metadata": [
+                {
+                    "type": "module",
+                    "required": true
+                }
+            ],
+            "passive": true
+        },
+        {
+            "name": "toolkit_moduleInit",
+            "description": "The Toolkit has completed initialization for the specified module.",
+            "metadata": [
+                {
+                    "type": "attempts",
+                    "required": false
+                },
+                {
+                    "type": "duration",
+                    "required": false
+                },
+                {
+                    "type": "module",
+                    "required": true
+                },
+                {
+                    "type": "result",
+                    "required": true
+                },
+                {
+                    "type": "version",
+                    "required": false
+                }
+            ],
+            "passive": true
+        },
+        {
+            "name": "toolkit_moduleOpen",
             "description": "User opened 'something' (specified by 'module'). Examples: a view, feature, resource, ...",
             "metadata": [
                 {


### PR DESCRIPTION
## Problem:

We have a new telemetry metric name format defined in our telemetry
readme. The current module metrics do not follow this spec.

## Solution:

- Rename the existing metrics to match #984 spec. Eg: `toolkit_openModule` -> `toolkit_willOpenModule`
- Reorder the renamed metric alphabetically
- Note we are not doing this for everything, but for some select metrics.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
