### PR TITLE
add autoDetected to code scan events

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -4670,6 +4670,10 @@
             "description": "Called when a code scan issue is hovered over",
             "metadata": [
                 {
+                    "type": "autoDetected",
+                    "required": false
+                },
+                {
                     "type": "credentialStartUrl",
                     "required": false
                 },
@@ -4692,6 +4696,10 @@
             "name": "codewhisperer_codeScanIssueIgnore",
             "description": "User ignored a code scan issue. variant=all means the user ignored all issues of a specific type.",
             "metadata": [
+                {
+                    "type": "autoDetected",
+                    "required": false
+                },
                 {
                     "type": "component"
                 },
@@ -4719,6 +4727,10 @@
             "name": "codewhisperer_codeScanIssueViewDetails",
             "description": "Called when a code scan issue webview is opened",
             "metadata": [
+                {
+                    "type": "autoDetected",
+                    "required": false
+                },
                 {
                     "type": "credentialStartUrl",
                     "required": false


### PR DESCRIPTION
## Problem

Hover, ignore, and view details events are missing a flag to indicate the finding was auto-detected

## Solution

Add `autoDetected` to code scan events

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
