### PR TITLE
telemetry(amazonq): update upload intent values

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -81,7 +81,9 @@
             "description": "The intent of the upload",
             "allowedValues": [
                 "TRANSFORMATION",
-                "TASK_ASSIST_PLANNING"
+                "TASK_ASSIST_PLANNING",
+                "AUTOMATIC_FILE_SECURITY_SCAN",
+                "FULL_PROJECT_SECURITY_SCAN"
             ]
         },
         {


### PR DESCRIPTION
## Problem

`amazonqUploadIntent` is missing code scan values

## Solution

Add:
- `AUTOMATIC_FILE_SECURITY_SCAN`
- `FULL_PROJECT_SECURITY_SCAN`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
