### PR TITLE
telemetry: add "initialized" lsp stage

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1558,6 +1558,7 @@
                 "validate",
                 "launch",
                 "handshake",
+                "initialized",
                 "all"
             ],
             "description": "The stage of the LSP setup process"


### PR DESCRIPTION
## Problem
LanguageServerSetupStage does not include initialized stage which is needed in VS and LSP protocol. 
VS had an issue where needed to diagnose and measure customer failures that occur after the lsp was successfully started but the IDE failed to make a successful "initialized" communication.
 For reference, LSP clients send an "[initialize](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize)" message back and forth, and then they send an "[initialized](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialized)" message back and forth. The related pr is [here](https://github.com/aws/aws-toolkit-visual-studio-staging/pull/2339). 

## Solution
I add the initialized stage in common's definition. The initialize stage is defined as handshake in common's definition so we do not need to make any modification for initialize. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
