### PR TITLE
telemetry(amazonq): amazonq_addMessage fields not required

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2210,13 +2210,15 @@
                     "required": false
                 },
                 {
-                    "type": "cwsprChatFullDisplayLatency"
+                    "type": "cwsprChatFullDisplayLatency",
+                    "required": false
                 },
                 {
                     "type": "cwsprChatFullResponseLatency"
                 },
                 {
-                    "type": "cwsprChatFullServerResponseLatency"
+                    "type": "cwsprChatFullServerResponseLatency",
+                    "required": false
                 },
                 {
                     "type": "cwsprChatHasCodeSnippet",
@@ -2291,16 +2293,19 @@
                     "type": "cwsprChatTimeBetweenChunks"
                 },
                 {
-                    "type": "cwsprChatTimeBetweenDisplays"
+                    "type": "cwsprChatTimeBetweenDisplays",
+                    "required": false
                 },
                 {
                     "type": "cwsprChatTimeToFirstChunk"
                 },
                 {
-                    "type": "cwsprChatTimeToFirstDisplay"
+                    "type": "cwsprChatTimeToFirstDisplay",
+                    "required": false
                 },
                 {
-                    "type": "cwsprChatTimeToFirstUsableChunk"
+                    "type": "cwsprChatTimeToFirstUsableChunk",
+                    "required": false
                 },
                 {
                     "type": "cwsprChatTriggerInteraction"


### PR DESCRIPTION
## Problem
5 fields in amazonq_addMessage are marked as required in VS code but are missing from Jetbrains. 


## Solution
Making these fields optional in common repo will allow for Vscode - JB compatibility

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
