### PR TITLE
telemetry(amazonq): add id2 metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1550,11 +1550,6 @@
             "description": "Metric-defined identifier"
         },
         {
-            "name": "id2",
-            "type": "string",
-            "description": "x-amz-id-2 for S3 Upload Debugging"
-        },
-        {
             "name": "includesFix",
             "type": "boolean",
             "description": "Whether the security issue includes a suggested fix"
@@ -1852,6 +1847,11 @@
             "name": "requestId",
             "type": "string",
             "description": "Request ID (if any) associated with a metric. For example, an event with `requestServiceType: s3` means that the request ID is associated with an S3 API call. Events that cover multiple API calls should use the request ID of the most recent call."
+        },
+        {
+            "name": "requestId2",
+            "type": "string",
+            "description": "A special token that is used together with the request ID header to help AWS troubleshoot problems. For example, this has to be provided with requestId when debugging S3 upload errors."
         },
         {
             "name": "requestServiceType",
@@ -2477,15 +2477,15 @@
                     "required": false
                 },
                 {
-                    "type": "id2",
-                    "required": false
-                },
-                {
                     "type": "reason",
                     "required": false
                 },
                 {
                     "type": "requestId",
+                    "required": false
+                },
+                {
+                    "type": "requestId2",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1550,6 +1550,11 @@
             "description": "Metric-defined identifier"
         },
         {
+            "name": "id2",
+            "type": "string",
+            "description": "x-amz-id-2 for S3 Upload Debugging"
+        },
+        {
             "name": "includesFix",
             "type": "boolean",
             "description": "Whether the security issue includes a suggested fix"
@@ -2469,6 +2474,10 @@
                 },
                 {
                     "type": "duration",
+                    "required": false
+                },
+                {
+                    "type": "id2",
                     "required": false
                 },
                 {


### PR DESCRIPTION
## Problem

## Solution

Some users are reporting S3 upload failures but we don't have the id2 that S3 team requires to investigate further.
Emit amazonq_createUpload metric with id2, and add logs for these ids so customers can use too.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
