### PR TITLE
telemetry(amazonq): intial metric for agentic chat

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -973,6 +973,18 @@
             ]
         },
         {
+            "name": "cwsprAgenticChatInteractionType",
+            "type": "string",
+            "allowedValues": [
+                "RejectDiff",
+                "GeneratedDiff",
+                "RunCommand",
+                "GeneratedCommand",
+                "StopChat"
+            ],
+            "description": "Type of interaction with agentic chat messages"
+        },
+        {
             "name": "cwsprChatAcceptedCharactersLength",
             "type": "int",
             "description": "Count of code characters copied to the editor"
@@ -2587,6 +2599,25 @@
                 {
                     "type": "interactionType",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_interactWithAgenticChat",
+            "description": "When a user interacts with a message in the agentic chat",
+            "metadata": [
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprAgenticChatInteractionType"
+                },
+                {
+                    "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "cwsprChatConversationType"
                 }
             ]
         },


### PR DESCRIPTION
## Problem
- currently no metrics for agentic chat

## Solution
- upstream agentic chat interaction metric
- https://github.com/aws/aws-toolkit-vscode/pull/6979

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
