### PR TITLE
telemetry(amazonq): AgenticChat cwsprChatConversationType

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1020,7 +1020,8 @@
             "allowedValues": [
                 "Chat",
                 "Assign",
-                "Transform"
+                "Transform",
+                "AgenticChat"
             ],
             "description": "Identifies the type of conversation"
         },


### PR DESCRIPTION
## Problem
- new product requirements include determining `Chat` vs `AgenticChat`

## Solution
- added `AgenticChat` cwsprChatConversationType

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
