### PR TITLE
telemetry(amazonq): agentic loop

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1269,6 +1269,11 @@
             "description": "Truncated length of workspace context"
         },
         {
+            "name": "cwsprIsAgenticLoop",
+            "type": "boolean",
+            "description": "If the message is apart of an agentic loop (LLM asks to run a tool and receives results back)"
+        },
+        {
             "name": "databaseCredentials",
             "type": "string",
             "allowedValues": [
@@ -2384,6 +2389,10 @@
                 },
                 {
                     "type": "cwsprChatWorkspaceContextTruncatedLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprIsAgenticLoop",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1021,7 +1021,8 @@
                 "Chat",
                 "Assign",
                 "Transform",
-                "AgenticChat"
+                "AgenticChat",
+                "AgenticChatWithToolUse"                
             ],
             "description": "Identifies the type of conversation"
         },
@@ -1267,11 +1268,6 @@
             "name": "cwsprChatWorkspaceContextTruncatedLength",
             "type": "int",
             "description": "Truncated length of workspace context"
-        },
-        {
-            "name": "cwsprIsAgenticLoop",
-            "type": "boolean",
-            "description": "If the message is apart of an agentic loop (LLM asks to run a tool and receives results back)"
         },
         {
             "name": "databaseCredentials",
@@ -2389,10 +2385,6 @@
                 },
                 {
                     "type": "cwsprChatWorkspaceContextTruncatedLength",
-                    "required": false
-                },
-                {
-                    "type": "cwsprIsAgenticLoop",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem
- want to figure out if a message is apart of an agentic loop or not

## Solution
- add field `AgenticChatWithToolUse `


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
