### PR TITLE
telemetry(amazonq): toolUseSuggested

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1220,12 +1220,12 @@
             "description": "The time between the initial server request, including creating the conversation id, and the first usable result"
         },
         {
-            "name": "cwsprChatToolUseId",
+            "name": "cwsprToolId",
             "type": "string",
             "description": "The id of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
         },
         {
-            "name": "cwsprChatToolUseSuggested",
+            "name": "cwsprToolName",
             "type": "string",
             "description": "The name of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2845,10 +2845,10 @@
                     "type": "cwsprChatConversationType"
                 },
                 {
-                    "type": "cwsprChatToolUseId"
+                    "type": "cwsprToolId"
                 },
                 {
-                    "type": "cwsprChatToolUseSuggested"
+                    "type": "cwsprToolName"
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1220,16 +1220,6 @@
             "description": "The time between the initial server request, including creating the conversation id, and the first usable result"
         },
         {
-            "name": "cwsprToolId",
-            "type": "string",
-            "description": "The id of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
-        },
-        {
-            "name": "cwsprToolName",
-            "type": "string",
-            "description": "The name of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
-        },
-        {
             "name": "cwsprChatTotalCodeBlocks",
             "type": "int",
             "description": "Total number of code blocks inside a message in the conversation."
@@ -1278,6 +1268,16 @@
             "name": "cwsprChatWorkspaceContextTruncatedLength",
             "type": "int",
             "description": "Truncated length of workspace context"
+        },
+        {
+            "name": "cwsprToolId",
+            "type": "string",
+            "description": "The id of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
+        },
+        {
+            "name": "cwsprToolName",
+            "type": "string",
+            "description": "The name of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
         },
         {
             "name": "databaseCredentials",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1022,7 +1022,7 @@
                 "Assign",
                 "Transform",
                 "AgenticChat",
-                "AgenticChatWithToolUse"                
+                "AgenticChatWithToolUse"
             ],
             "description": "Identifies the type of conversation"
         },
@@ -1218,6 +1218,16 @@
             "name": "cwsprChatTimeToFirstUsableChunk",
             "type": "int",
             "description": "The time between the initial server request, including creating the conversation id, and the first usable result"
+        },
+        {
+            "name": "cwsprChatToolUseId",
+            "type": "string",
+            "description": "The id of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
+        },
+        {
+            "name": "cwsprChatToolUseSuggested",
+            "type": "string",
+            "description": "The name of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
         },
         {
             "name": "cwsprChatTotalCodeBlocks",
@@ -2817,6 +2827,28 @@
                 {
                     "type": "result",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_toolUseSuggested",
+            "description": "When the LLM either used a tool directly (no acceptance needed) or suggested a tool (user acceptance required)",
+            "metadata": [
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "cwsprChatConversationType"
+                },
+                {
+                    "type": "cwsprChatToolUseId"
+                },
+                {
+                    "type": "cwsprChatToolUseSuggested"
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1270,14 +1270,14 @@
             "description": "Truncated length of workspace context"
         },
         {
-            "name": "cwsprToolId",
-            "type": "string",
-            "description": "The id of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
-        },
-        {
             "name": "cwsprToolName",
             "type": "string",
-            "description": "The name of the tool that LLM used directly (no acceptance needed) or suggested a tool (user acceptance required)"
+            "description": "Client side tool name (ex: fsWrite, executeBash)"
+        },
+        {
+            "name": "cwsprToolUseId",
+            "type": "string",
+            "description": "The id for when a client side tool is used."
         },
         {
             "name": "databaseCredentials",
@@ -2845,10 +2845,10 @@
                     "type": "cwsprChatConversationType"
                 },
                 {
-                    "type": "cwsprToolId"
+                    "type": "cwsprToolName"
                 },
                 {
-                    "type": "cwsprToolName"
+                    "type": "cwsprToolUseId"
                 }
             ]
         },


### PR DESCRIPTION
## Problem
- Want to see the distribution of tools that LLM either used directly (no acceptance needed) or suggested (user acceptance required)

## Solution
- Add metric `toolUseSuggested`

## Notes
- This only takes into account what tool the LLM uses/suggests. This does not take into account whether that tool was actually accepted/rejected.
  - This is because a user can accept/reject at a later time, or even ignore. For example, a generated shell command can be rejected 30 minutes later or dozens of messages later in the conversation. 
  - The goal is to possibly streamline this, likely with the `amazonq_interactWithAgenticChat` metric
- For now, we want info in the distribution of tools that LLM uses/suggests

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
