### PR TITLE
telemetry(amazonq): history character count

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1097,6 +1097,11 @@
             "description": "True if the code snippet that user interacts with has a reference."
         },
         {
+            "name": "cwsprChatHistoryMessageCharacterCount",
+            "type": "int",
+            "description": "The number of characters in a history message"
+        },
+        {
             "name": "cwsprChatInteractionTarget",
             "type": "string",
             "description": "Identifies the entity within the message that user interacts with."
@@ -2395,6 +2400,37 @@
                 },
                 {
                     "type": "cwsprChatWorkspaceContextTruncatedLength",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_addMessageHistory",
+            "description": "When a message is added to the history",
+            "metadata": [
+                {
+                    "type": "credentialStartUrl",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatConversationId"
+                },
+                {
+                    "type": "cwsprChatConversationType"
+                },
+                {
+                    "type": "cwsprChatHistoryMessageCharacterCount"
+                },
+                {
+                    "type": "cwsprChatMessageId",
+                    "required": false
+                },
+                {
+                    "type": "cwsprToolName",
+                    "required": false
+                },
+                {
+                    "type": "cwsprToolUseId",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem
- There are user messages (prompt) and assistant response messages (answer). Some prompts will contain toolResults, and a some answers will contain toolUses. All of these combined make up the history
- we want to keep track of the number of characters for each message in the history to help us optimize the prompt caching strategy

## Solution
- add `amazonq_addMessageHistory` metric

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
