### PR TITLE
telemetry(amazonq): add metrics for code symbols, chat history and export

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -56,6 +56,11 @@
             "description": "The time it takes to generate code generation response"
         },
         {
+            "name": "amazonqHistoryFileSize",
+            "type": "int",
+            "description": "The size of a chat history file (in bytes)"
+        },
+        {
             "name": "amazonqNumberOfFilesAccepted",
             "type": "double",
             "description": "Captures the number of accepted files as a part of code generation iteration"
@@ -74,6 +79,16 @@
             "name": "amazonqRepositorySize",
             "type": "double",
             "description": "Captures the size of the source code"
+        },
+        {
+            "name": "amazonqTimeToLoadHistory",
+            "type": "int",
+            "description": "The time (in milliseconds) it takes to load chat history from filesystem"
+        },
+        {
+            "name": "amazonqTimeToSearchHistory",
+            "type": "int",
+            "description": "The time (in milliseconds) it takes to search through all messages in chat history for a user-provided search string"
         },
         {
             "name": "amazonqUploadIntent",
@@ -230,6 +245,17 @@
             "name": "cfnParameterFileUsed",
             "type": "boolean",
             "description": "Boolean value of whether or not a Cfn parameter file is provided."
+        },
+        {
+            "name": "chatHistoryAction",
+            "type": "string",
+            "allowedValues": [
+                "search",
+                "export",
+                "open",
+                "delete"
+            ],
+            "description": "The type of action performed on chat history"
         },
         {
             "name": "checkType",
@@ -1010,6 +1036,21 @@
             "description": "Index of the code block inside a message in the conversation."
         },
         {
+            "name": "cwsprChatCodeContextCount",
+            "type": "int",
+            "description": "Number of code symbols added to context"
+        },
+        {
+            "name": "cwsprChatCodeContextLength",
+            "type": "int",
+            "description": "Total length of code symbols added to context"
+        },
+        {
+            "name": "cwsprChatCodeContextTruncatedLength",
+            "type": "int",
+            "description": "Truncated length of code symbols added to context"
+        },
+        {
             "name": "cwsprChatConversationId",
             "type": "string",
             "description": "Uniquely identifies a message with which the user interacts."
@@ -1472,6 +1513,15 @@
             "description": "The experiment action taken action taken"
         },
         {
+            "name": "exportFormat",
+            "type": "string",
+            "allowedValues": [
+                "html",
+                "markdown"
+            ],
+            "description": "The file format chosen by the user when exporting chat history"
+        },
+        {
             "name": "failedCount",
             "type": "int",
             "description": "The number of failed operations"
@@ -1836,6 +1886,11 @@
             "name": "oldVersion",
             "type": "string",
             "description": "The old version of something. Useful when updating dependent resources."
+        },
+        {
+            "name": "openTabCount",
+            "type": "int",
+            "description": "The number of tabs automatically opened from history"
         },
         {
             "name": "parentId",
@@ -2248,6 +2303,18 @@
                     "required": false
                 },
                 {
+                    "type": "cwsprChatCodeContextCount",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatCodeContextLength",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatCodeContextTruncatedLength",
+                    "required": false
+                },
+                {
                     "type": "cwsprChatConversationId"
                 },
                 {
@@ -2603,6 +2670,20 @@
             ]
         },
         {
+            "name": "amazonq_exportTab",
+            "description": "When a user exports the current Amazon Q chat tab",
+            "metadata": [
+                {
+                    "type": "exportFormat",
+                    "required": true
+                },
+                {
+                    "type": "languageServerVersion",
+                    "required": false
+                }
+            ]
+        },
+        {
             "name": "amazonq_feedback",
             "description": "When a user gives feedback using vote or comment or rating in the conversation",
             "metadata": [
@@ -2789,6 +2870,28 @@
             ]
         },
         {
+            "name": "amazonq_loadHistory",
+            "description": "When a history file is loaded from the filesystem and open tabs are restored",
+            "metadata": [
+                {
+                    "type": "amazonqHistoryFileSize",
+                    "required": true
+                },
+                {
+                    "type": "amazonqTimeToLoadHistory",
+                    "required": true
+                },
+                {
+                    "type": "languageServerVersion",
+                    "required": false
+                },
+                {
+                    "type": "openTabCount",
+                    "required": true
+                }
+            ]
+        },
+        {
             "name": "amazonq_messageResponseError",
             "description": "When an error has occured in response to a prompt",
             "metadata": [
@@ -2859,6 +2962,32 @@
                 },
                 {
                     "type": "result",
+                    "required": false
+                }
+            ]
+        },
+        {
+            "name": "amazonq_performChatHistoryAction",
+            "description": "When a user searches, exports, opens, or deletes a conversation from history",
+            "metadata": [
+                {
+                    "type": "amazonqHistoryFileSize",
+                    "required": false
+                },
+                {
+                    "type": "amazonqTimeToSearchHistory",
+                    "required": false
+                },
+                {
+                    "type": "chatHistoryAction",
+                    "required": true
+                },
+                {
+                    "type": "exportFormat",
+                    "required": false
+                },
+                {
+                    "type": "languageServerVersion",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1513,15 +1513,6 @@
             "description": "The experiment action taken action taken"
         },
         {
-            "name": "exportFormat",
-            "type": "string",
-            "allowedValues": [
-                "html",
-                "markdown"
-            ],
-            "description": "The file format chosen by the user when exporting chat history"
-        },
-        {
             "name": "failedCount",
             "type": "int",
             "description": "The number of failed operations"
@@ -2674,7 +2665,7 @@
             "description": "When a user exports the current Amazon Q chat tab",
             "metadata": [
                 {
-                    "type": "exportFormat",
+                    "type": "filenameExt",
                     "required": true
                 },
                 {
@@ -2983,7 +2974,7 @@
                     "required": true
                 },
                 {
-                    "type": "exportFormat",
+                    "type": "filenameExt",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -247,17 +247,6 @@
             "description": "Boolean value of whether or not a Cfn parameter file is provided."
         },
         {
-            "name": "chatHistoryAction",
-            "type": "string",
-            "allowedValues": [
-                "search",
-                "export",
-                "open",
-                "delete"
-            ],
-            "description": "The type of action performed on chat history"
-        },
-        {
             "name": "checkType",
             "type": "string",
             "allowedValues": [
@@ -2962,16 +2951,16 @@
             "description": "When a user searches, exports, opens, or deletes a conversation from history",
             "metadata": [
                 {
+                    "type": "action",
+                    "required": true
+                },
+                {
                     "type": "amazonqHistoryFileSize",
                     "required": false
                 },
                 {
                     "type": "amazonqTimeToSearchHistory",
                     "required": false
-                },
-                {
-                    "type": "chatHistoryAction",
-                    "required": true
                 },
                 {
                     "type": "filenameExt",


### PR DESCRIPTION
## Problem

- There is no telemetry for # and length of `@Code` added to messages by users
- There is no telemetry to measure metrics for chat history and export features: 
  - Number of tabs automatically restored from history
  - Number of users exporting chat transcripts, with which format (markdown vs html)
  - Number of users who are opening chat history list (will use existing ui_click metric, no changes needed in this PR)
  - Number of users who are searching, exporting, deleting, and opening conversations from history
  - How long it takes to complete history searches
  - History file sizes, time to load history files into memory

## Solution
Add the following metrics:
- amazonq_exportTab
- amazonq_loadHistory
- amazonq_performChatHistoryAction

To measure code symbol use, add the following types to amazonq_addMessage metric:
- cwsprChatCodeContextCount
- cwsprChatCodeContextLength
- cwsprChatCodeContextTruncatedLength


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
