### PR TITLE
telemetry(amazonq): list of request ids in addMessage

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1185,11 +1185,6 @@
             "description": "Number of references in response"
         },
         {
-            "name": "cwsprChatRequestIds",
-            "type": "string",
-            "description": "The list of request ids corresponding to this user message. Request ids must be in chronological order"
-        },
-        {
             "name": "cwsprChatRequestLength",
             "type": "int",
             "description": "Number of characters in request"
@@ -1953,6 +1948,11 @@
             "description": "A special token that is used together with the request ID header to help AWS troubleshoot problems. For example, this has to be provided with requestId when debugging S3 upload errors."
         },
         {
+            "name": "requestIds",
+            "type": "string",
+            "description": "Request ids (comma-separated) associated with a task or action, in chronological order. For example 'id1,id2,id3'"
+        },
+        {
             "name": "requestServiceType",
             "type": "string",
             "description": "Per-request service identifier. Unlike `serviceType` (which describes the originator of the request), this describes the request itself."
@@ -2384,10 +2384,6 @@
                     "required": false
                 },
                 {
-                    "type": "cwsprChatRequestIds",
-                    "required": false
-                },
-                {
                     "type": "cwsprChatRequestLength"
                 },
                 {
@@ -2460,6 +2456,10 @@
                 },
                 {
                     "type": "languageServerVersion",
+                    "required": false
+                },
+                {
+                    "type": "requestIds",
                     "required": false
                 }
             ]
@@ -2715,15 +2715,15 @@
                     "required": false
                 },
                 {
-                    "type": "cwsprChatRequestIds",
-                    "required": false
-                },
-                {
                     "type": "cwsprToolUseId",
                     "required": false
                 },
                 {
                     "type": "languageServerVersion",
+                    "required": false
+                },
+                {
+                    "type": "requestIds",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1185,6 +1185,11 @@
             "description": "Number of references in response"
         },
         {
+            "name": "cwsprChatRequestIds",
+            "type": "string",
+            "description": "The list of request ids corresponding to this user message. Request ids must be in chronological order"
+        },
+        {
             "name": "cwsprChatRequestLength",
             "type": "int",
             "description": "Number of characters in request"
@@ -2379,6 +2384,10 @@
                     "required": false
                 },
                 {
+                    "type": "cwsprChatRequestIds",
+                    "required": false
+                },
+                {
                     "type": "cwsprChatRequestLength"
                 },
                 {
@@ -2700,6 +2709,18 @@
                 },
                 {
                     "type": "cwsprChatConversationType"
+                },
+                {
+                    "type": "cwsprChatMessageId",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatRequestIds",
+                    "required": false
+                },
+                {
+                    "type": "cwsprToolUseId",
+                    "required": false
                 },
                 {
                     "type": "languageServerVersion",


### PR DESCRIPTION
## Problem
- The following are new science requirements:
    - In the new agentic chat after a user types a message, it may trigger multiple LLM calls, but we only store the final LLM requestID (`cwsprChatMessageId`), which is the one that generates the response shown to the user. Earlier LLM calls in the sequence, which handle internal processing and aren't visible to users, are not currently emitted.

    - We currently emit the LLM interaction events, but we lose emission of the associated LLM/Tool RequestID’s that led to the user interaction event (ie we don’t know which LLM requests the user click stop button, we don’t know which write tool ID the user chose to undo). 

## Solution
- Emit all LLM RequestIDs in the order that these requests were made in `amazonq_addMessage`
    - As the list of RequestIDs may be long, will look into the max char limit of a field in kibana
- Emit Tool/LLM requestIDs related to User Interaction Events in `amazonq_interactWithAgenticChat`



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
