### PR TITLE
telemetry(amazonq): adding enabled and perfE2ELatency to agentic chat metrics

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2455,6 +2455,10 @@
                     "required": false
                 },
                 {
+                    "type": "enabled",
+                    "required": false
+                },
+                {
                     "type": "languageServerVersion",
                     "required": false
                 },
@@ -2711,11 +2715,11 @@
                     "type": "cwsprChatConversationType"
                 },
                 {
-                    "type": "cwsprChatMessageId",
+                    "type": "cwsprToolUseId",
                     "required": false
                 },
                 {
-                    "type": "cwsprToolUseId",
+                    "type": "enabled",
                     "required": false
                 },
                 {
@@ -2941,6 +2945,10 @@
                     "required": false
                 },
                 {
+                    "type": "enabled",
+                    "required": false
+                },
+                {
                     "type": "languageServerVersion",
                     "required": false
                 }
@@ -3048,7 +3056,15 @@
                     "type": "cwsprToolUseId"
                 },
                 {
+                    "type": "enabled",
+                    "required": false
+                },
+                {
                     "type": "languageServerVersion",
+                    "required": false
+                },
+                {
+                    "type": "perfE2ELatency",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem
- Missing metric field to separate agentic coding mode.
- Need to add a new field for amazonq_toolUseSuggested metric to calculate the latency of tools.
## Solution
- Fixed above issues.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
