### PR TITLE
telemetry: add metrics for pinned context

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1161,6 +1161,26 @@
             "description": "Unique identifier for each message in an conversation"
         },
         {
+            "name": "cwsprChatPinnedCodeContextCount",
+            "type": "int",
+            "description": "Number of pinned code symbols added to context"
+        },
+        {
+            "name": "cwsprChatPinnedFileContextCount",
+            "type": "int",
+            "description": "Number of pinned files added to context"
+        },
+        {
+            "name": "cwsprChatPinnedFolderContextCount",
+            "type": "int",
+            "description": "Number of pinned folders added to context"
+        },
+        {
+            "name": "cwsprChatPinnedPromptContextCount",
+            "type": "int",
+            "description": "Number of pinned saved prompts added to context"
+        },
+        {
             "name": "cwsprChatProgrammingLanguage",
             "type": "string",
             "description": "Programming language associated with the message"
@@ -1218,7 +1238,7 @@
         {
             "name": "cwsprChatRuleContextCount",
             "type": "int",
-            "description": "Number of workspace rules automatically added to context"
+            "description": "Number of workspace rules automatically added to context (does not include inactive rules)"
         },
         {
             "name": "cwsprChatRuleContextLength",
@@ -1264,6 +1284,11 @@
             "name": "cwsprChatTotalCodeBlocks",
             "type": "int",
             "description": "Total number of code blocks inside a message in the conversation."
+        },
+        {
+            "name": "cwsprChatTotalRuleContextCount",
+            "type": "int",
+            "description": "Total number of workspace rules (both active and inactive)"
         },
         {
             "name": "cwsprChatTriggerInteraction",
@@ -2414,6 +2439,22 @@
                     "type": "cwsprChatMessageId"
                 },
                 {
+                    "type": "cwsprChatPinnedCodeContextCount",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatPinnedFileContextCount",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatPinnedFolderContextCount",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatPinnedPromptContextCount",
+                    "required": false
+                },
+                {
                     "type": "cwsprChatProgrammingLanguage",
                     "required": false
                 },
@@ -2483,6 +2524,10 @@
                 },
                 {
                     "type": "cwsprChatTimeToFirstUsableChunk",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatTotalRuleContextCount",
                     "required": false
                 },
                 {


### PR DESCRIPTION
Add telemetry for pinned context

## New Metrics Added:

### Pinned Context Counts
- `cwsprChatPinnedCodeContextCount`: Tracks the number of pinned code symbols added to context
- `cwsprChatPinnedFileContextCount`: Tracks the number of pinned files added to context
- `cwsprChatPinnedFolderContextCount`: Tracks the number of pinned folders added to context
- `cwsprChatPinnedPromptContextCount`: Tracks the number of pinned saved prompts added to context

### Rule Context Tracking
- `cwsprChatTotalRuleContextCount`: Tracks the total number of workspace rules (both active and inactive)
- Updated description for `cwsprChatRuleContextCount` to clarify it only includes active rules

All new metrics have been added to `amazonq_addMessage` and are marked as optional fields.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
