### PR TITLE
telemetry: add more latency fields to invokeLLM metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1816,7 +1816,7 @@
         {
             "name": "latency",
             "type": "string",
-            "description": "latency/s from any operation or an execution like tool execution."
+            "description": "latency/s from any operation or an execution such as LLM response time."
         },
         {
             "name": "loadFileTime",
@@ -2191,6 +2191,11 @@
             "name": "templateName",
             "type": "string",
             "description": "Generic name of a template"
+        },
+        {
+            "name": "toolCallLatency",
+            "type": "string",
+            "description": "latency/s from any operation or an execution like tool execution."
         },
         {
             "name": "toolId",
@@ -2875,6 +2880,14 @@
                     "type": "cwsprChatConversationType"
                 },
                 {
+                    "type": "cwsprChatTimeBetweenChunks",
+                    "required": false
+                },
+                {
+                    "type": "cwsprChatTimeToFirstChunk",
+                    "required": false
+                },
+                {
                     "type": "cwsprToolName"
                 },
                 {
@@ -2890,6 +2903,10 @@
                 },
                 {
                     "type": "latency",
+                    "required": false
+                },
+                {
+                    "type": "toolCallLatency",
                     "required": false
                 }
             ]


### PR DESCRIPTION
## Problem
- invokeLLM metric needs more fields for latency

## Solution
- `amazonq_invokeLLM` metric has these fields:
    - `latency`
    - `toolCallLatency`
    - `timeToFirstChunk`
    - `timeBetweenChunks`

## Note
- I would've liked to use a more reusable/general name such as `latency2` (like how we have requestId and requestId2) instead of `toolCallLatency` which seems very specific to only tools. However, I have already put in the implementation PR to make the deadline for the flare release, as flare release happens 1 day before toolkit release. 
- VSC is the only IDE which requires a version bump for aws-toolkit-common. All other IDEs (JB, Eclipse, VS) use flare as the source of truth for metrics. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
