### PR TITLE
Migrate to Maven Central Publisher Portal

### DIFF
--- a/telemetry/jetbrains/build.gradle.kts
+++ b/telemetry/jetbrains/build.gradle.kts
@@ -170,8 +170,8 @@ nexusPublishing {
 
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(project.findProperty("ossrhUsername") as? String)
             password.set(project.findProperty("ossrhPassword") as? String)
 


### PR DESCRIPTION
## Problem
Sonatype is [deprecating the OSSRH and the Nexus Repository Manager v2](https://central.sonatype.org/news/20250326_ossrh_sunset/) at the end of the month
 
## Solution
Migrate to Sonatype's Central Publisher Portal by way of the [Portal OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#get-to-manualsearchrepositories)

# WORDS OF WARNING
* **This is a one-way door**. We can't go back once credentials are generated
* We will need to generate new credentials and add them to internal Secrets (merge this PR in conjunction with that one)
* We need to see if we can do a metric definition deployment to ensure nothing breaks and that there are no additional steps required (specifically noting the approval/publish workflow in the [Central Publisher Portal intro](https://central.sonatype.org/publish/publish-portal-guide/#component-validation))

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
