### PR TITLE
telemetry(amazonq): active user metric

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2327,6 +2327,18 @@
             ]
         },
         {
+            "name": "amazonq_activeUser",
+            "description": "An active user is when the user sends a message, and the user will be considered active until the remainder of the time window",
+            "metadata": [
+                {
+                    "type": "credentialStartUrl"
+                },
+                {
+                    "type": "result"
+                }
+            ]
+        },
+        {
             "name": "amazonq_addMessage",
             "description": "When a message is added to the conversation",
             "metadata": [


### PR DESCRIPTION
## Problem
- need active user metric

## Solution
- emit new metric for active user

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
