### PR TITLE
telemety(amazonq): add tool permission to invokeLLM and mcpServerInit

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1326,11 +1326,6 @@
             "description": "Client side tool/s name (ex: fsWrite, executeBash)"
         },
         {
-            "name": "cwsprToolPermission",
-            "type": "string",
-            "description": "Permission of tool/s set by user"
-        },
-        {
             "name": "cwsprToolUseId",
             "type": "string",
             "description": "The id/s when a client side tool/s is used."
@@ -1959,6 +1954,11 @@
             "description": "The time duration in milliseconds to finish a request to the server side"
         },
         {
+            "name": "permission",
+            "type": "string",
+            "description": "Permission of tool/s set by user"
+        },
+        {
             "name": "platform",
             "type": "string",
             "description": "Language-specific identification. Examples: v4.6.1, netcoreapp3.1, nodejs12.x. Not AWS Lambda specific. Allows for additional details when other fields are opaque, such as the Lambda runtime value 'provided'."
@@ -2224,6 +2224,11 @@
                 "sam-cli",
                 "docker"
             ]
+        },
+        {
+            "name": "toolName",
+            "type": "string",
+            "description": "Tool/s name, including MCP (ex: fsWrite,executeBash)"
         },
         {
             "name": "totalResourceCount",
@@ -2959,10 +2964,6 @@
                     "type": "cwsprToolName"
                 },
                 {
-                    "type": "cwsprToolPermission",
-                    "required": false
-                },
-                {
                     "type": "cwsprToolUseId"
                 },
                 {
@@ -2975,6 +2976,10 @@
                 },
                 {
                     "type": "latency",
+                    "required": false
+                },
+                {
+                    "type": "permission",
                     "required": false
                 },
                 {
@@ -3120,14 +3125,6 @@
                     "required": false
                 },
                 {
-                    "type": "cwsprToolName",
-                    "required": false
-                },
-                {
-                    "type": "cwsprToolPermission",
-                    "required": false
-                },
-                {
                     "type": "enabled",
                     "required": false
                 },
@@ -3144,11 +3141,19 @@
                     "required": false
                 },
                 {
+                    "type": "permission",
+                    "required": false
+                },
+                {
                     "type": "scope",
                     "required": false
                 },
                 {
                     "type": "source",
+                    "required": false
+                },
+                {
+                    "type": "toolName",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3141,6 +3141,14 @@
                 {
                     "type": "transportType",
                     "required": false
+                },
+                {
+                    "type": "toolNames",
+                    "required": false
+                },
+                {
+                    "type": "toolPerms",
+                    "required": false
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2957,6 +2957,10 @@
                     "type": "cwsprToolUseId"
                 },
                 {
+                    "type": "cwsprToolPermission",
+                    "required": false
+                },
+                {
                     "type": "enabled",
                     "required": false
                 },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1326,14 +1326,14 @@
             "description": "Client side tool/s name (ex: fsWrite, executeBash)"
         },
         {
-            "name": "cwsprToolUseId",
-            "type": "string",
-            "description": "The id/s when a client side tool/s is used."
-        },
-        {
             "name": "cwsprToolPermission",
             "type": "string",
             "description": "Permission of tool/s set by user"
+        },
+        {
+            "name": "cwsprToolUseId",
+            "type": "string",
+            "description": "The id/s when a client side tool/s is used."
         },
         {
             "name": "databaseCredentials",
@@ -2959,11 +2959,11 @@
                     "type": "cwsprToolName"
                 },
                 {
-                    "type": "cwsprToolUseId"
-                },
-                {
                     "type": "cwsprToolPermission",
                     "required": false
+                },
+                {
+                    "type": "cwsprToolUseId"
                 },
                 {
                     "type": "enabled",
@@ -3120,6 +3120,14 @@
                     "required": false
                 },
                 {
+                    "type": "cwsprToolName",
+                    "required": false
+                },
+                {
+                    "type": "cwsprToolPermission",
+                    "required": false
+                },
+                {
                     "type": "enabled",
                     "required": false
                 },
@@ -3145,14 +3153,6 @@
                 },
                 {
                     "type": "transportType",
-                    "required": false
-                },
-                {
-                    "type": "cwsprToolName",
-                    "required": false
-                },
-                {
-                    "type": "cwsprToolPermission",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1331,6 +1331,11 @@
             "description": "The id/s when a client side tool/s is used."
         },
         {
+            "name": "cwsprToolPermission",
+            "type": "string",
+            "description": "Permission of tool/s set by user"
+        },
+        {
             "name": "databaseCredentials",
             "type": "string",
             "allowedValues": [
@@ -3143,11 +3148,11 @@
                     "required": false
                 },
                 {
-                    "type": "toolNames",
+                    "type": "cwsprToolName",
                     "required": false
                 },
                 {
-                    "type": "toolPerms",
+                    "type": "cwsprToolPermission",
                     "required": false
                 }
             ]

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1956,7 +1956,7 @@
         {
             "name": "permission",
             "type": "string",
-            "description": "Permission of tool/s set by user"
+            "description": "Permission of tool in the operation."
         },
         {
             "name": "platform",
@@ -2228,7 +2228,7 @@
         {
             "name": "toolName",
             "type": "string",
-            "description": "Tool/s name, including MCP (ex: fsWrite,executeBash)"
+            "description": "This field represents a tool name, example: fsWrite, executeBash or any mcp tools"
         },
         {
             "name": "totalResourceCount",


### PR DESCRIPTION
## Problem

Missing metric for feature new launch: built-in tools

## Solution

Add tool permission to invokeLLM to have a data on tool permission set by user 

Add toolNames and ToolPerms to mcpServerInit but only used for buitl-in tools when permission is updated

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
