### PR TITLE
telemetry: add metrics for iam credentials authentication

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2134,6 +2134,16 @@
             "description": "The state of the setting being changed to. This should not be recorded for free-form settings like file-system paths. Instead, stick to things like flags, numbers, and enums."
         },
         {
+            "name": "signInOption",
+            "type": "string",
+            "allowedValues": [
+                "Company account",
+                "IAM Credentials",
+                "Other"
+            ],
+            "description": "The sign in option for AmazonQ extension."
+        },
+        {
             "name": "source",
             "type": "string",
             "description": "The source of the operation. This answers 'who' caused/triggered the operation. Example: did an Auth signout happen because of some expiration or since the user explicitly clicked the signout button."
@@ -3989,8 +3999,8 @@
             ]
         },
         {
-            "name": "auth_iamLoginFailure",
-            "description": "Emitted when User submit IAM form but receives error",
+            "name": "auth_loginFailure",
+            "description": "Emitted when User submit IAM/SSO form but receive error",
             "metadata": [
                 {
                     "type": "credentialType",
@@ -4003,8 +4013,14 @@
             ]
         },
         {
-            "name": "auth_iamOptionClick",
-            "description": "Emitted when User click IAM login option from login webview"
+            "name": "auth_signInOptionClick",
+            "description": "Emitted when User click a login option from login webview",
+            "metadata": [
+                {
+                    "type": "signInOption",
+                    "required": true
+                }
+            ]
         },
         {
             "name": "auth_signInPageClosed",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2137,7 +2137,8 @@
             "name": "signInOption",
             "type": "string",
             "allowedValues": [
-                "Company account",
+                "BuilderId",
+                "iamIdentityCenter",
                 "IAM Credentials",
                 "Other"
             ],
@@ -3999,6 +4000,15 @@
                 },
                 {
                     "type": "source"
+                }
+            ]
+        },
+        {
+            "name": "auth_signInOptionClick",
+            "description": "Emitted when User click a login option from login webview",
+            "metadata": [
+                {
+                    "type": "signInOption"
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -999,26 +999,6 @@
             ]
         },
         {
-            "name": "iamCredentialType",
-            "type": "string",
-            "description": "The type of IAM credential that was submitted",
-            "allowedValues": [
-                "longTermIam",
-                "assumeRoleIam",
-                "credentialProcessProfile",
-                "assumeMfaRoleIam",
-                "stsCredential",
-                "ecsMetatdata",
-                "ec2Metadata",
-                "other"
-            ]
-        },
-        {
-            "name": "loginErrorIam",
-            "type": "string",
-            "description": "The type of Error received during IAM credential login"
-        },
-        {
             "name": "customRules",
             "type": "int",
             "description": "number of custom rules present in a request"
@@ -3945,14 +3925,6 @@
                     "required": false
                 },
                 {
-                    "type": "credentialAccessKey",
-                    "required": false
-                },
-                {
-                    "type": "credentialRoleArn",
-                    "required": false
-                },
-                {
                     "type": "featureId"
                 },
                 {
@@ -3990,11 +3962,11 @@
             "description": "Emitted when User submit IAM form but receives error",
             "metadata": [
                 {
-                    "type": "iamCredentialType",
+                    "type": "credentialType",
                     "required": true
                 },
                 {
-                    "type": "loginErrorIam",
+                    "type": "reason",
                     "required": true
                 }
             ]
@@ -4079,19 +4051,7 @@
                     "required": false
                 },
                 {
-                    "type": "credentialAccessKey",
-                    "required": false
-                },
-                {
-                    "type": "credentialRoleArn",
-                    "required": false
-                },
-                {
                     "type": "credentialType",
-                    "required": false
-                },
-                {
-                    "type": "iamCredentialType",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3958,24 +3958,6 @@
             ]
         },
         {
-            "name": "auth_iamOptionClick",
-            "description": "Emitted when User click IAM login option from login webview"
-        },
-        {
-            "name": "auth_iamLoginFailure",
-            "description": "Emitted when User submit IAM form but receives error",
-            "metadata": [
-                {
-                    "type": "credentialType",
-                    "required": true
-                },
-                {
-                    "type": "reason",
-                    "required": true
-                }
-            ]
-        },
-        {
             "name": "auth_addedConnections",
             "description": "The diff/change in Auth connections",
             "metadata": [
@@ -4005,6 +3987,24 @@
                     "type": "source"
                 }
             ]
+        },
+        {
+            "name": "auth_iamLoginFailure",
+            "description": "Emitted when User submit IAM form but receives error",
+            "metadata": [
+                {
+                    "type": "credentialType",
+                    "required": true
+                },
+                {
+                    "type": "reason",
+                    "required": true
+                }
+            ]
+        },
+        {
+            "name": "auth_iamOptionClick",
+            "description": "Emitted when User click IAM login option from login webview"
         },
         {
             "name": "auth_signInPageClosed",

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -999,6 +999,26 @@
             ]
         },
         {
+            "name": "iamCredentialType",
+            "type": "string",
+            "description": "The type of IAM credential that was submitted",
+            "allowedValues": [
+                "longTermIam",
+                "assumeRoleIam",
+                "credentialProcessProfile",
+                "assumeMfaRoleIam",
+                "stsCredential",
+                "ecsMetatdata",
+                "ec2Metadata",
+                "other"
+            ]
+        },
+        {
+            "name": "loginErrorIam",
+            "type": "string",
+            "description": "The type of Error received during IAM credential login"
+        },
+        {
             "name": "customRules",
             "type": "int",
             "description": "number of custom rules present in a request"
@@ -3925,6 +3945,14 @@
                     "required": false
                 },
                 {
+                    "type": "credentialAccessKey",
+                    "required": false
+                },
+                {
+                    "type": "credentialRoleArn",
+                    "required": false
+                },
+                {
                     "type": "featureId"
                 },
                 {
@@ -3954,6 +3982,20 @@
                 {
                     "type": "ssoRegistrationExpiresAt",
                     "required": false
+                }
+            ]
+        },
+        {
+            "name": "auth_iamLoginFailure",
+            "description": "Emitted when User submit IAM form but receives error",
+            "metadata": [
+                {
+                    "type": "iamCredentialType",
+                    "required": true
+                },
+                {
+                    "type": "loginErrorIam",
+                    "required": true
                 }
             ]
         },
@@ -4037,7 +4079,19 @@
                     "required": false
                 },
                 {
+                    "type": "credentialAccessKey",
+                    "required": false
+                },
+                {
+                    "type": "credentialRoleArn",
+                    "required": false
+                },
+                {
                     "type": "credentialType",
+                    "required": false
+                },
+                {
+                    "type": "iamCredentialType",
                     "required": false
                 },
                 {

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -3935,6 +3935,10 @@
                     "required": false
                 },
                 {
+                    "type": "credentialType",
+                    "required": false
+                },
+                {
                     "type": "featureId"
                 },
                 {
@@ -3995,27 +3999,6 @@
                 },
                 {
                     "type": "source"
-                }
-            ]
-        },
-        {
-            "name": "auth_loginFailure",
-            "description": "Emitted when User submit IAM/SSO form but receive error",
-            "metadata": [
-                {
-                    "type": "credentialType"
-                },
-                {
-                    "type": "reason"
-                }
-            ]
-        },
-        {
-            "name": "auth_signInOptionClick",
-            "description": "Emitted when User click a login option from login webview",
-            "metadata": [
-                {
-                    "type": "signInOption"
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -4003,12 +4003,10 @@
             "description": "Emitted when User submit IAM/SSO form but receive error",
             "metadata": [
                 {
-                    "type": "credentialType",
-                    "required": true
+                    "type": "credentialType"
                 },
                 {
-                    "type": "reason",
-                    "required": true
+                    "type": "reason"
                 }
             ]
         },
@@ -4017,8 +4015,7 @@
             "description": "Emitted when User click a login option from login webview",
             "metadata": [
                 {
-                    "type": "signInOption",
-                    "required": true
+                    "type": "signInOption"
                 }
             ]
         },

--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -2134,17 +2134,6 @@
             "description": "The state of the setting being changed to. This should not be recorded for free-form settings like file-system paths. Instead, stick to things like flags, numbers, and enums."
         },
         {
-            "name": "signInOption",
-            "type": "string",
-            "allowedValues": [
-                "BuilderId",
-                "iamIdentityCenter",
-                "IAM Credentials",
-                "Other"
-            ],
-            "description": "The sign in option for AmazonQ extension."
-        },
-        {
             "name": "source",
             "type": "string",
             "description": "The source of the operation. This answers 'who' caused/triggered the operation. Example: did an Auth signout happen because of some expiration or since the user explicitly clicked the signout button."
@@ -4000,15 +3989,6 @@
                 },
                 {
                     "type": "source"
-                }
-            ]
-        },
-        {
-            "name": "auth_signInOptionClick",
-            "description": "Emitted when User click a login option from login webview",
-            "metadata": [
-                {
-                    "type": "signInOption"
                 }
             ]
         },


### PR DESCRIPTION
## Metrics Modified:
`auth_addConnection`: add `credentialType` type to record distinguish IAM and other login method.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
