### PR TITLE
telemetry: add allowedValue in cwsprChatConversationType

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -1065,6 +1065,7 @@
             "type": "string",
             "allowedValues": [
                 "Chat",
+                "InlineChat",
                 "Assign",
                 "Transform",
                 "AgenticChat",


### PR DESCRIPTION
## Problem
The telemetry in aws-toolkit-vscode uses cwsprChatConversationType but lacks a value for inlineChat situation.

## Solution
add allowedValue in cwsprChatConversationType

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
