### PR TITLE
Fix endpoint override for .NET SDK generator

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.SDK/Custom/AmazonToolkitTelemetryConfig.Partial.cs
+++ b/telemetry/csharp/AwsToolkit.Telemetry.SDK/Custom/AmazonToolkitTelemetryConfig.Partial.cs
@@ -31,15 +31,8 @@ namespace Amazon.ToolkitTelemetry
         /// <returns>The resolved endpoint for the given request.</returns>
         public override Amazon.Runtime.Endpoints.Endpoint DetermineServiceOperationEndpoint(ServiceOperationEndpointParameters parameters)
         {
-            var request = new DefaultRequest(parameters.Request, ServiceId);
-            request.AlternateEndpoint = parameters.AlternateEndpoint;
-            
-            var requestContext = new RequestContext(false);
-            requestContext.ClientConfig = this;
-            requestContext.OriginalRequest = parameters.Request;
-            requestContext.Request = request;
-            var executionContext = new Amazon.Runtime.Internal.ExecutionContext(requestContext, null);
-            return new BaseEndpointResolver().GetEndpoint(executionContext);
+            var endpoint = new Endpoint(this.ServiceURL);
+            return endpoint;
         }
     }
 }


### PR DESCRIPTION
## Description
PR #1082 migrated the C# telemetry generator to AWS SDK V4. Due to changes in contracts with this version, a Custom PartialConfig file was added to meet the interface requirements for configuring endpoints with the ClientConfig. This caused issues during runtime since our client does not rely on endpoitns. As a workaround as per .NET SDK team's guidance,  since our client always sets the ServiceUrl on out client, a fix along those lines has been made to short-circuit the underlying logic and return endpoint based on the service url.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
