### PR TITLE
telemetry: Add console login as valid credential source ID

### DIFF
--- a/telemetry/definitions/commonDefinitions.json
+++ b/telemetry/definitions/commonDefinitions.json
@@ -969,6 +969,7 @@
             "type": "string",
             "description": "Where credentials are stored or retrieved from",
             "allowedValues": [
+                "consoleCredentials",
                 "sharedCredentials",
                 "sdkStore",
                 "ec2",


### PR DESCRIPTION
## Problem

When users authenticate using AWS Console credentials in the VS Code toolkit, we want to emit telemetry with `credentialSourceId: 'consoleCredentials'` during the Console Credential Setup flow. 


## Solution

- Added "consoleCredentials" to allowed values for credentialSourceId

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
