### PR TITLE
fix(telemetry): upgrade log4net 2.0.16 -> 3.3.0 to resolve GHSA-4f7c-pmjv-c25w (NU1902)

### DIFF
--- a/telemetry/csharp/AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj
+++ b/telemetry/csharp/AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj
@@ -21,7 +21,7 @@
 		<AssemblyOriginatorKeyFile>..\toolkit-telemetry.snk</AssemblyOriginatorKeyFile>
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="log4net" Version="2.0.16" />
+	  <PackageReference Include="log4net" Version="3.3.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="System" />


### PR DESCRIPTION
## Problem

The `.NET 8` SDK runs a NuGet security audit during `dotnet restore`, which flags **log4net 2.0.16** for advisory [GHSA-4f7c-pmjv-c25w](https://github.com/advisories/GHSA-4f7c-pmjv-c25w) (moderate severity; vulnerable `< 3.3.0`). Because `telemetry/csharp/AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj` sets `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`, the `NU1902` warning becomes a build error and `dotnet restore` fails:

```
dotnet restore AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj
error NU1902: Warning As Error: Package 'log4net' 2.0.16 has a known moderate severity
vulnerability, https://github.com/advisories/GHSA-4f7c-pmjv-c25w
```

This started failing with **no code change** because the NuGet audit reads the GitHub Advisory Database at restore time, and the advisory was published/updated in mid-June 2026.

## Solution

One-line dependency bump — upgrade `log4net` to **3.3.0**, the first version that resolves the advisory:

```diff
- <PackageReference Include="log4net" Version="2.0.16" />
+ <PackageReference Include="log4net" Version="3.3.0" />
```

- This is the only direct `log4net` reference under `telemetry/csharp`. `AwsToolkit.Telemetry.Events.Tests` depends on this project and inherits `log4net` transitively, so it is fixed by the same change.
- No `Directory.Packages.props` / `packages.lock.json` / `nuget.config` exist, so no other file needs updating.
- **Compatibility:** target framework is `net472`; log4net 3.3.0 supports `net462`/`netstandard2.0`. The only log4net usage is `ILog` and `LogManager.GetLogger(Type)` (in `ITelemetryLogger.cs` and `MetricDatumExtensionMethods.cs`), which are unchanged in log4net 3.x — no source changes required.

### Testing (verified locally, .NET 8 SDK 8.0.422)

Before (reproduces the failure):

```
$ dotnet restore AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj
error NU1902: ... 'log4net' 2.0.16 ... GHSA-4f7c-pmjv-c25w        # exit 1
```

After:

```
$ dotnet restore AwsToolkit.Telemetry.Events/AwsToolkit.Telemetry.Events.csproj        # Restored, exit 0, no NU1902
$ dotnet restore AwsToolkit.Telemetry.Events.Tests/...                                  # Restored, exit 0, no NU1902
$ dotnet build  -c Release AwsToolkit.Telemetry.sln                                     # Build succeeded, 0 Warnings, 0 Errors
$ dotnet test   -c Release AwsToolkit.Telemetry.sln                                     # net8.0 tests: Passed 12/12
$ dotnet list AwsToolkit.Telemetry.Events/...csproj package --include-transitive
   > log4net    3.3.0    3.3.0
```

No `NU1902` in any restore; `log4net` resolves to `3.3.0`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
