### PR TITLE
fix(ci): prevent script injection in trigger-codepipeline workflow

### DIFF
--- a/.github/workflows/trigger-codepipeline.yml
+++ b/.github/workflows/trigger-codepipeline.yml
@@ -21,6 +21,8 @@ jobs:
           aws-region: us-west-2
 
       - name: Trigger CodePipeline for Maven/NuGet
+        env:
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
         run: |
-          echo "Triggering CodePipeline for user commit by ${{ github.event.head_commit.author.name }}"
+          echo "Triggering CodePipeline for user commit by $COMMIT_AUTHOR"
           aws codepipeline start-pipeline-execution --name PackagePipeline


### PR DESCRIPTION
## Summary

Fixes an ACAT/AppSec **script injection** finding in `.github/workflows/trigger-codepipeline.yml` (lines 24-26). The `github.event.head_commit.author.name` context value was interpolated directly via `${{ }}` into the inline `run:` script.

A commit author name is **user-controlled** — an attacker can craft a commit whose author name contains shell metacharacters (e.g. `$(...)` or `"; ...; "`). When that commit lands on `main`, the workflow runs the injected command. This job has `id-token: write` and assumes `GitHubActionsCodePipelineRole`, so injected commands would execute with AWS credentials able to start CodePipeline.

## Fix

Per [GitHub Actions security-hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks), the value is now bound to a step-level `env:` variable and referenced as a quoted shell variable (`$COMMIT_AUTHOR`). Environment values are passed to the shell as data rather than expanded into script text, which removes the injection vector. No behavior change for legitimate commits.

```diff
       - name: Trigger CodePipeline for Maven/NuGet
+        env:
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
         run: |
-          echo "Triggering CodePipeline for user commit by ${{ github.event.head_commit.author.name }}"
+          echo "Triggering CodePipeline for user commit by $COMMIT_AUTHOR"
           aws codepipeline start-pipeline-execution --name PackagePipeline
```

Note: the `if:` condition on the job also references `head_commit.author.name`, but that is a GitHub Actions expression (evaluated by the expression engine, not the shell), so it is not an injection vector and is unchanged.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/trigger-codepipeline.yml'))"` -> parses OK
- Confirmed no `${{ github.* }}` interpolation remains inside the `run:` block.
